### PR TITLE
Lee ellipse roi bug

### DIFF
--- a/imglib2/core/src/main/java/net/imglib2/roi/EllipseRegionOfInterest.java
+++ b/imglib2/core/src/main/java/net/imglib2/roi/EllipseRegionOfInterest.java
@@ -263,18 +263,36 @@ public class EllipseRegionOfInterest extends AbstractIterableRegionOfInterest {
 				d0 = getRasterDisplacement(position, i);
 				position[i] = (long)Math.ceil(origin.getDoublePosition(i)-d0);
 			}
-			System.arraycopy(position,1,end,1,numDimensions()-1);
-			end[0] = (long)Math.floor(origin.getDoublePosition(0)+d0) + 1;
-			return true;
+			if (isMember(position)) {
+				System.arraycopy(position,1,end,1,numDimensions()-1);
+				end[0] = (long)Math.floor(origin.getDoublePosition(0)+d0) + 1;
+				return true;
+			}
 		}
-		dimensionloop: for (int i=1; i < numDimensions(); i++) {
+		for (int i=1; i < numDimensions(); i++) {
 			/*
 			 * Advance the position until we get a position
 			 * within the ellipse.
 			 */
 			position[i]++;
 			final double partialDisplacement = getPartialDisplacement(position, i);
-			if (partialDisplacement < 1) {
+			if (partialDisplacement <= 1) {
+				/*
+				 * Check that we can find a point within the ellipse. It may be the case
+				 * that, for dimension # 0,  both the pixel at the floor of the origin 
+				 * and at the ceiling of the origin are outside of the ellipse even 
+				 * though the origin itself is within the ellipse.
+				 */
+				double d = 0;
+				for (int j = i; j < numDimensions(); j++) {
+					double diff = (position[j] - origin.getDoublePosition(j)) / radii[j]; 
+					d += diff * diff;
+				}
+				for (int j = 0; j < i; j++) {
+					double diff = (origin.getDoublePosition(j) - Math.round(origin.getDoublePosition(j))) / radii[j];
+					d += diff * diff;
+				}
+				if (d > 1) continue;
 				/*
 				 * Adjust the lesser positions to the start of
 				 * the ellipse.
@@ -287,19 +305,6 @@ public class EllipseRegionOfInterest extends AbstractIterableRegionOfInterest {
 					} else {
 						end[j] = position[j];
 					}
-				}
-				return true;
-			} else if (partialDisplacement == 1) {
-				/*
-				 * All remaining must be at the origin position
-				 */
-				for (int j=i-1; j >= 0; j--) {
-					double originPosition = origin.getDoublePosition(j);
-					if (Math.floor(originPosition) != originPosition) continue dimensionloop;
-				}
-				for (int j=i-1; j >= 0; j--) {
-					position[j] = (long) origin.getDoublePosition(j);
-					end[j] = (j > 0)? position[j] : (position[j] + 1);
 				}
 				return true;
 			}
@@ -342,6 +347,21 @@ public class EllipseRegionOfInterest extends AbstractIterableRegionOfInterest {
 	 */
 	@Override
 	protected boolean isMember(double[] position) {
+		double accumulator = 0;
+		for (int i=0; i<numDimensions(); i++) {
+			double diff = ((position[i] - origin.getDoublePosition(i)) / radii[i]);
+			accumulator += diff * diff;
+		}
+		return accumulator <= 1;
+	}
+	
+	/**
+	 * Test to see if an integer position is inside the ellipse.
+	 * 
+	 * @param position
+	 * @return
+	 */
+	public boolean isMember(long [] position) {
 		double accumulator = 0;
 		for (int i=0; i<numDimensions(); i++) {
 			double diff = ((position[i] - origin.getDoublePosition(i)) / radii[i]);


### PR DESCRIPTION
This should be a more comprehensive fix:
- Fix Christian's original bug which left off the last pixel of a radius-1 circle centered at (1,1)
- Fix cases where the code finds the integer coordinates of the start of a raster for dimensions 1 to n-1 that are within the ellipse, but the floor and ceiling of the origin for dimension 0 is outside of the ellipse because the origin is not an integer.
