### PR TITLE
Bugs in watershed

### DIFF
--- a/imglib2/algorithms/core/src/main/java/net/imglib2/algorithm/labeling/Watershed.java
+++ b/imglib2/algorithms/core/src/main/java/net/imglib2/algorithm/labeling/Watershed.java
@@ -208,6 +208,7 @@ public class Watershed< T extends RealType< T >, L extends Comparable< L >> impl
 		if ( output == null )
 		{
 			long[] dimensions = new long[ seeds.numDimensions() ];
+			seeds.dimensions( dimensions );
 			NativeImgLabeling< L, IntType > o = new NativeImgLabeling< L, IntType >( new ArrayImgFactory< IntType >().create( dimensions, new IntType() ) );
 			output = o;
 		}
@@ -300,6 +301,7 @@ public class Watershed< T extends RealType< T >, L extends Comparable< L >> impl
 					continue;
 				outputLabelingType.setLabeling( l );
 				double intensity = imageAccess.get().getRealDouble();
+				outputAccess.localize( destPosition );
 				pq.add( new PixelIntensity< L >( destPosition, dimensions, intensity, age++, l ) );
 			}
 		}

--- a/imglib2/algorithms/core/src/test/java/tests/labeling/WatershedTest.java
+++ b/imglib2/algorithms/core/src/test/java/tests/labeling/WatershedTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 import net.imglib2.Cursor;
 import net.imglib2.algorithm.labeling.AllConnectedComponents;
@@ -144,5 +145,26 @@ public class WatershedTest
 	public final void testTwo()
 	{
 		testSeededCase2D( new int[][] { { 0, 0, 0 }, { 0, 0, 0 }, { 1, 1, 1 }, { 0, 0, 0 } }, new int[][] { { 0, 1, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 2, 0 } }, new int[][] { { 1, 1, 1 }, { 1, 1, 1 }, { 2, 2, 2 }, { 2, 2, 2 } }, null, 0 );
+	}
+	@Test
+	public final void testBig()
+	{
+		// Make an image that's composed of two rectangles that require propagation.
+		int [][] image = new int[9][11];
+		for (int i = 0; i<image.length; i++) {
+			image[i][image[0].length / 2] = 1;
+		}
+		// The seeds are placed asymetrically so that the closer to the middle
+		// (= # 2) will propagate first to the ridge.
+		int [][] seeds = new int [9][11];
+		seeds[4][0] = 1;
+		seeds[4][6] = 2;
+		int [][] expected = new int[9][11];
+		for (int i = 0; i < image.length; i++) {
+			for (int j = 0; j < image[0].length; j++) {
+				expected[i][j] = (j < image[0].length / 2) ? 1:2;
+			}
+		}
+		testSeededCase2D( image, seeds, expected, null, 0 );
 	}
 }


### PR DESCRIPTION
Martin Horn reported two fairly serious bugs in my implementation of the watershed. I'm wondering if Christian can accept this patch and merge into the labeling branch.

I've updated the test code to add a simple case that fails on the current code base.

Thanks, Lee

Here's Martin's Email:
Hi Lee,

I found two bugs in you watershed implementation, which prevent it to return correct results:

first a minor bug in line 210:
 long[] dimensions = new long[ seeds.numDimensions() ];
 NativeImgLabeling< L, IntType > o = new NativeImgLabeling< L, IntType>( new ArrayImgFactory< IntType >().create( dimensions, new IntType() ) );

should be replaced by

NativeImgLabeling< L, IntType > o = new NativeImgLabeling< L, IntType>( new ArrayImgFactory< IntType >().create( seeds, new IntType() ) );

because its creating an image of size 0x0x... otherwise

and, second, in line 303, before adding the new pixel to the priority queue, the destPosition has to be updated:

> > imageAccess.localize(destPosition);
> > pq.add( new PixelIntensity< L >( destPosition, dimensions, intensity,age++, l ) );

Thanks for fixing it ...

Best,

Martin 
