### PR TITLE
Fix for bug 434 + tests - added nextRaster(long[],long[],Interval) which...

### DIFF
--- a/imglib2/core/src/main/java/net/imglib2/roi/AbstractIterableRegionOfInterest.java
+++ b/imglib2/core/src/main/java/net/imglib2/roi/AbstractIterableRegionOfInterest.java
@@ -40,11 +40,13 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 import net.imglib2.Cursor;
+import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.IterableRealInterval;
 import net.imglib2.Positionable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealPositionable;
 import net.imglib2.type.Type;
 
@@ -94,6 +96,48 @@ public abstract class AbstractIterableRegionOfInterest extends AbstractRegionOfI
 	 * @return true if there is a raster after this one.
 	 */
 	protected abstract boolean nextRaster( long[] position, long[] end );
+	
+	/**
+	 * Advance the position to the next raster, taking care that the
+	 * raster is wholly within the given interval.
+	 * 
+	 * Consider overriding if knowing the interval can be used to skip
+	 * rasters outside of the interval.
+	 * 
+	 * @param position
+	 *            on entry, the position of the raster after advancement to its
+	 *            end (or initial or final position)
+	 * @param end
+	 *            on exit, the coordinates of the end of the raster. Index 0 is
+	 *            generally the only pertinent variable, subsequent indices
+	 *            should be duplicates of the start raster. Nevertheless, using
+	 *            an array lets the caller pass the results as a modification of
+	 *            the array.
+	 * @param interval
+	 *            the raster must be within this interval.
+	 * @return true if there is a raster after this one.
+	 */
+	protected boolean nextRaster( long [] position, long [] end, Interval interval) {
+		loop:
+		while(nextRaster(position, end)) {
+			
+			for ( int i = 0; i < position.length; i++ )
+			{
+				if (position[i] > interval.max(i))
+					continue loop;
+			}
+			for (int i = 1; i < position.length; i++ ) {
+				if (position[i] < interval.min( i ))
+					continue loop;
+			}
+			if (end[0] <= interval.min(0))
+				continue;
+			position[0] = Math.max( position[0], interval.min(0) );
+			end[0] = Math.min( end[0], interval.max( 0 ) + 1 );
+			return true;
+		}
+		return false;
+	}
 
 	/**
 	 * Jump forward a certain number of steps from the given position.
@@ -111,9 +155,13 @@ public abstract class AbstractIterableRegionOfInterest extends AbstractRegionOfI
 	 *            of steps
 	 * @param end
 	 *            - the end position of the current raster on entry and on exit.
+	 * @param interval
+	 *            - constraining interval. Pixels will only be counted while jumping
+	 *              for the region within the interval. If interval is null,
+	 *              there is no constraining interval.
 	 * @return true if taking that number of steps still lands within the ROI.
 	 */
-	protected boolean jumpFwd( long totalSteps, long[] position, long[] end )
+	protected boolean jumpFwd( long totalSteps, long[] position, long[] end, Interval interval )
 	{
 		long steps = totalSteps;
 		while ( true )
@@ -125,7 +173,10 @@ public abstract class AbstractIterableRegionOfInterest extends AbstractRegionOfI
 			}
 			steps -= end[ 0 ] - position[ 0 ];
 			position[ 0 ] = end[ 0 ];
-			if ( !nextRaster( position, end ) )
+			if (interval != null) {
+				if ( !nextRaster( position, end, interval))
+					return false;
+			} else if ( !nextRaster( position, end ) )
 				return false;
 		}
 	}
@@ -148,7 +199,8 @@ public abstract class AbstractIterableRegionOfInterest extends AbstractRegionOfI
 		}
 	}
 
-	protected class AROIIterableInterval< T extends Type< T >> implements IterableInterval< T >
+	protected class AROIIterableInterval< T extends Type< T >> 
+	implements IterableInterval< T >
 	{
 		protected RandomAccessible< T > src;
 
@@ -275,7 +327,10 @@ public abstract class AbstractIterableRegionOfInterest extends AbstractRegionOfI
 			@Override
 			public void jumpFwd( long steps )
 			{
-				if ( !AbstractIterableRegionOfInterest.this.jumpFwd( steps, position, raster_end ) ) { throw new IllegalAccessError( "Jumped past end of sequence" ); }
+				final Interval interval = (src instanceof Interval)?(Interval)src:null;
+				if ( !AbstractIterableRegionOfInterest.this.jumpFwd( steps, position, raster_end, interval ) ) { 
+					throw new IllegalAccessError( "Jumped past end of sequence" ); 
+				}
 				mark_dirty();
 			}
 
@@ -307,7 +362,8 @@ public abstract class AbstractIterableRegionOfInterest extends AbstractRegionOfI
 			{
 				if ( !next_is_valid )
 				{
-					has_next = AbstractIterableRegionOfInterest.this.jumpFwd( 1, next_position, next_raster_end );
+					final Interval interval = (src instanceof Interval)?(Interval)src:null;
+					has_next = AbstractIterableRegionOfInterest.this.jumpFwd( 1, next_position, next_raster_end, interval );
 				}
 				next_is_valid = true;
 				return has_next;
@@ -356,7 +412,15 @@ public abstract class AbstractIterableRegionOfInterest extends AbstractRegionOfI
 				long[] raster_end = new long[ numDimensions() ];
 				Arrays.fill( position, Long.MIN_VALUE );
 				Arrays.fill( raster_end, Long.MIN_VALUE );
-				if ( !nextRaster( position, raster_end ) ) { throw new IllegalAccessError( "Tried to get first element, but ROI has no elements" ); }
+				boolean hasNext;
+				if (src instanceof Interval) {
+					hasNext = nextRaster( position, raster_end, (Interval) src );
+				} else {
+					hasNext = nextRaster( position, raster_end );
+				}
+				if (! hasNext) { 
+					throw new IllegalAccessError( "Tried to get first element, but ROI has no elements" ); 
+				}
 				r.setPosition( position );
 				cached_first_element = r.get();
 			}
@@ -484,10 +548,144 @@ public abstract class AbstractIterableRegionOfInterest extends AbstractRegionOfI
 		}
 
 	}
+	
+	protected class AROIClippedIterableInterval< T extends Type< T >> extends AROIIterableInterval<T> {
+
+		public AROIClippedIterableInterval(RandomAccessibleInterval< T > src)
+		{
+			super( src );
+		}
+		
+		protected Interval getSrcInterval() {
+			return (Interval) src;
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#realMin(int)
+		 */
+		@Override
+		public double realMin( int d )
+		{
+			return Math.max( super.realMin( d ), getSrcInterval().realMin( d ));
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#realMin(double[])
+		 */
+		@Override
+		public void realMin( double[] min )
+		{
+			for ( int i = 0; i < min.length; i++ )
+			{
+				min[i] = realMin(i);
+			}
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#realMin(net.imglib2.RealPositionable)
+		 */
+		@Override
+		public void realMin( RealPositionable min )
+		{
+			for ( int i = 0; i < min.numDimensions(); i++ )
+			{
+				min.setPosition( realMin(i), i);
+			}
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#realMax(int)
+		 */
+		@Override
+		public double realMax( int d )
+		{
+			return Math.min( super.realMax( d ), getSrcInterval().realMax( d ));
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#realMax(double[])
+		 */
+		@Override
+		public void realMax( double[] max )
+		{
+			for ( int i = 0; i < max.length; i++ )
+			{
+				max[i] = realMax(i);
+			}
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#realMax(net.imglib2.RealPositionable)
+		 */
+		@Override
+		public void realMax( RealPositionable max )
+		{
+			for ( int i = 0; i < max.numDimensions(); i++ )
+			{
+				max.setPosition( realMax(i) , i);
+			}
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#min(int)
+		 */
+		@Override
+		public long min( int d )
+		{
+			return Math.max( super.min( d ), getSrcInterval().min( d ) );
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#min(long[])
+		 */
+		@Override
+		public void min( long[] min )
+		{
+			for ( int i = 0; i < min.length; i++ )
+			{
+				min[i] = min(i);
+			}
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#min(net.imglib2.Positionable)
+		 */
+		@Override
+		public void min( Positionable min )
+		{
+			for ( int i = 0; i < min.numDimensions(); i++ )
+			{
+				min.setPosition( min(i), i );
+			}
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#max(int)
+		 */
+		@Override
+		public long max( int d )
+		{
+			return Math.min(super.max( d ), getSrcInterval().max( d ));
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#max(long[])
+		 */
+		@Override
+		public void max( long[] max )
+		{
+			for ( int i = 0; i<max.length; i++) 
+			{
+				max[i] = max(i);
+			}
+		}
+		/* (non-Javadoc)
+		 * @see net.imglib2.roi.AbstractIterableRegionOfInterest.AROIIterableInterval#max(net.imglib2.Positionable)
+		 */
+		@Override
+		public void max( Positionable max )
+		{
+			for ( int i = 0; i < max.numDimensions(); i++ )
+			{
+				max.setPosition( max(i), i );
+			}
+		}
+	}
 
 	@Override
 	public < T extends Type< T >> IterableInterval< T > getIterableIntervalOverROI( RandomAccessible< T > src )
 	{
+		if (src instanceof RandomAccessibleInterval)
+			return new AROIClippedIterableInterval< T >( (RandomAccessibleInterval< T >) src );
 		return new AROIIterableInterval< T >( src );
 	}
 

--- a/imglib2/core/src/test/java/net/imglib2/roi/AbstractIterableRegionOfInterestTest.java
+++ b/imglib2/core/src/test/java/net/imglib2/roi/AbstractIterableRegionOfInterestTest.java
@@ -1,0 +1,143 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2012 Stephan Preibisch, Stephan Saalfeld, Tobias
+ * Pietzsch, Albert Cardona, Barry DeZonia, Curtis Rueden, Lee Kamentsky, Larry
+ * Lindsey, Johannes Schindelin, Christian Dietz, Grant Harris, Jean-Yves
+ * Tinevez, Steffen Jaensch, Mark Longair, Nick Perry, and Jan Funke.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+package net.imglib2.roi;
+
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.integer.IntType;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+/**
+ * @author Lee Kamentsky
+ * 
+ * Test cases exercising functionality provided
+ * by AbstractIterableRegionOfInterest
+ *
+ */
+public class AbstractIterableRegionOfInterestTest
+{
+	/**
+	 * Regression test of bug 434 - make sure that the interval
+	 * returned by getIterableIntervalOverROI does not extend
+	 * past the ROI.
+	 */
+	@Test
+	public void testIntervalOfIteratorOverRandomAccessibleInterval() {
+		int width = 27;
+		int height = 16;
+		int depth = 17;
+		Img<IntType> img = new ArrayImgFactory<IntType>().create(new long [] {width, height, depth} , new IntType());
+		double dimensions [][][] = {
+				{ { 1.0, 2.0, 3.0 }, {28.5, 6.0, 7.0 } },
+				{ { 1.0, 2.0, 3.0 }, {5.0, 17.5, 7.0 } },
+				{ { 1.0, 2.0, 3.0 }, {5.0,  6.0, 18.5 } },
+				{ { -1.0, 2.0, 3.0 }, {5.0, 6.0, 7.0 } },
+				{ { 1.0, -2.0, 3.0 }, {5.0, 6.0, 7.0 } },
+				{ { 1.0, 2.0, -3.0 }, {5.0, 6.0, 7.0 } }};
+
+		for (double [][] dd: dimensions) {
+			RectangleRegionOfInterest r = new RectangleRegionOfInterest(dd[0], dd[1]);
+			IterableInterval<IntType> ii = r.getIterableIntervalOverROI(img);
+			for ( int i = 0; i < ii.numDimensions(); i++ ) {
+				assertEquals(Math.max( r.min( i ), img.min(i) ), ii.min( i ));
+				assertEquals(Math.min( r.max( i ), img.max(i) ), ii.max( i ));
+				assertEquals(Math.max( r.realMin( i ), img.realMin(i) ), ii.realMin( i ), 0);
+				assertEquals(Math.min( r.realMax( i ), img.realMax(i) ), ii.realMax( i ), 0);
+			}
+		}
+	}
+	/**
+	 * Regression test of bug 434 - make sure that the cursor from
+	 * getIterableIntervalOverROI().cursor() iterates over the pixels
+	 * within a RandomAccessibleInterval that is not entirely within the ROI.
+	 * 
+	 * Prior to fix, the cursor threw an ArrayIndexOutOfBoundsException.
+	 */
+	@Test
+	public void testCursorOverRandomAccessibleInterval() {
+		int width = 27;
+		int height = 16;
+		int depth = 17;
+		Img<IntType> img = new ArrayImgFactory<IntType>().create(new long [] {width, height, depth} , new IntType());
+		double dimensions [][][] = {
+				{ { 1.0, 2.0, 3.0 }, {28.5, 6.0, 7.0 } },
+				{ { 1.0, 2.0, 3.0 }, {5.0, 17.5, 7.0 } },
+				{ { 1.0, 2.0, 3.0 }, {5.0,  6.0, 18.5 } },
+				{ { -1.0, 2.0, 3.0 }, {5.0, 6.0, 7.0 } },
+				{ { 1.0, -2.0, 3.0 }, {5.0, 6.0, 7.0 } },
+				{ { 1.0, 2.0, -3.0 }, {5.0, 6.0, 7.0 } }};
+
+		int [] position = new int[img.numDimensions()];
+		for (double [][] dd: dimensions) {
+			RectangleRegionOfInterest r = new RectangleRegionOfInterest(dd[0], dd[1]);
+			IterableInterval<IntType> ii = r.getIterableIntervalOverROI(img);
+			boolean mask [][][] = new boolean[width][height][depth];
+			RealRandomAccess<BitType> ra = r.realRandomAccess();
+			for (int i=0; i<width; i++) {
+				ra.setPosition( i, 0);
+				for (int j=0; j<height; j++) {
+					ra.setPosition(j, 1);
+					for (int k=0; k<depth; k++) {
+						ra.setPosition(k, 2);
+						if (ra.get().get()) mask[i][j][k] = true;
+					}
+				}
+			}
+			
+			Cursor<IntType> c = r.getIterableIntervalOverROI(img).localizingCursor();
+			while(c.hasNext()) {
+				c.next();
+				c.localize( position );
+				assertTrue(mask[position[0]][position[1]][position[2]]);
+				mask[position[0]][position[1]][position[2]] = false;
+			}
+			for (int i=0; i<width; i++) {
+				for (int j=0; j<height; j++) {
+					for (int k=0; k<depth; k++) {
+						assertFalse(mask[i][j][k]);
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hi all, here's my fix for fiji bug 434. There's a new test file which demonstrates the problems:
If a region of interest is used to iterate over a RandomAccessibleInterval and the region is not wholly within the interval:
1) The minima and the maxima of the ROI's IterableInterval will be outside of the RandomAccessibleInterval.
2) When iterating, the IterableInterval will access an out-of-bounds value on the RandomAccessibleInterval and will likely improperly throw an exception.

And of course, the problem itself is fixed.
