### PR TITLE
Follow the SNAPSHOT version of mpicbg.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
 		<module>imglib2</module>
 	</modules>
 
+	<properties>
+		<mpicbg.version>0.6.0-SNAPSHOT</mpicbg.version>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
This also helps MiniMaven in the Fiji project which would otherwise
confuse 20111128 (the version inferred from the Scijava POM) to be a
higher version number than 0.6.0-SNAPSHOT and prefer the older version.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
