### PR TITLE
Deprecate (faulty, according to Stephan Preibisch) legacy FFT

### DIFF
--- a/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/Bandpass.java
+++ b/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/Bandpass.java
@@ -41,6 +41,7 @@ import net.imglib2.view.Views;
 /**
  * TODO
  * 
+ * @deprecated use {@link net.imglib2.algorithm.fft2.FFT} instead
  */
 public class Bandpass< T extends NumericType< T >> implements OutputAlgorithm< RandomAccessibleInterval< T >>, Benchmark
 {

--- a/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/FFTFunctions.java
+++ b/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/FFTFunctions.java
@@ -51,6 +51,7 @@ import net.imglib2.view.Views;
  * Unfortunately only supports a maximal size of INT in each dimension as the one-dimensional FFT is based on arrays.
  * 
  * @author Stephan Preibisch (stephan.preibisch@gmx.de)
+ * @deprecated use {@link net.imglib2.algorithm.fft2.FFTMethods} instead
  */
 final public class FFTFunctions 
 {

--- a/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/FourierConvolution.java
+++ b/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/FourierConvolution.java
@@ -62,6 +62,7 @@ import net.imglib2.view.Views;
  * @param <S>
  *            - {@link RealType} of the kernel
  * @author Stephan Preibisch (stephan.preibisch@gmx.de)
+ * @deprecated use {@link net.imglib2.algorithm.fft2.FFTConvolution} instead
  */
 public class FourierConvolution< T extends RealType< T >, S extends RealType< S >> implements MultiThreaded, OutputAlgorithm< Img< T >>, Benchmark
 {

--- a/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/FourierTransform.java
+++ b/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/FourierTransform.java
@@ -51,6 +51,7 @@ import net.imglib2.util.Util;
  * @param <T> - the intput, {@link RealType}
  * @param <S> - the ouput, {@link ComplexType}
  * @author Stephan Preibisch (stephan.preibisch@gmx.de)
+ * @deprecated use {@link net.imglib2.algorithm.fft2.FFT} instead
  */
 public class FourierTransform<T extends RealType<T>, S extends ComplexType<S>> implements MultiThreaded, OutputAlgorithm<Img<S>>, Benchmark
 {

--- a/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/InverseFourierConvolution.java
+++ b/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/InverseFourierConvolution.java
@@ -42,6 +42,7 @@ import net.imglib2.view.Views;
  * 
  * 
  * @author Stephan Saalfeld <saalfeld@mpi-cbg.de>
+ * @deprecated use {@link net.imglib2.algorithm.fft2.FFT} instead
  */
 public class InverseFourierConvolution< T extends RealType< T >, S extends RealType< S > > extends FourierConvolution< T, S >
 {

--- a/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/InverseFourierTransform.java
+++ b/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/InverseFourierTransform.java
@@ -46,6 +46,7 @@ import net.imglib2.type.numeric.RealType;
  * @param <T> - the output, {@link RealType}
  * @param <S> - the input, {@link ComplexType}
  * @author Stephan Preibisch (stephan.preibisch@gmx.de)
+ * @deprecated use {@link net.imglib2.algorithm.fft2.FFT} instead
  */
 public class InverseFourierTransform<T extends RealType<T>, S extends ComplexType<S>> implements MultiThreaded, OutputAlgorithm<Img<T>>, Benchmark
 {

--- a/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/LocalNeighborhoodCursor.java
+++ b/algorithms/gpl/src/main/java/net/imglib2/algorithm/fft/LocalNeighborhoodCursor.java
@@ -32,6 +32,7 @@ import net.imglib2.RandomAccess;
 /**
  * TODO
  *
+ * @deprecated
  */
 public class LocalNeighborhoodCursor<T> extends AbstractCursor<T>
 {


### PR DESCRIPTION
The phase correlation is still missing, but the better way to do FFT
with ImgLib2 is in imglib2.algorithm.fft2.\* and should be used instead.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
