### PR TITLE
Make equals consistent with compareTo

### DIFF
--- a/core/src/main/java/net/imglib2/type/logic/BitType.java
+++ b/core/src/main/java/net/imglib2/type/logic/BitType.java
@@ -190,6 +190,13 @@ public class BitType extends AbstractIntegerType<BitType> implements BooleanType
 	public void dec() { inc(); }
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Boolean#hashCode().
+		return get() ? 1231 : 1237;
+	}
+
+	@Override
 	public int compareTo( final BitType c )
 	{
 		final boolean b1 = dataAccess.getValue(i);

--- a/core/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerType.java
@@ -67,6 +67,14 @@ public abstract class AbstractIntegerType<T extends AbstractIntegerType<T>> exte
 	public void setOne() { setInteger( 1 ); }	
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Long#hashCode().
+		final long value = getIntegerLong();
+		return (int) (value ^ (value >>> 32));
+	}
+
+	@Override
 	public int compareTo( final T c ) 
 	{ 
 		final long a = getIntegerLong();

--- a/core/src/main/java/net/imglib2/type/numeric/integer/GenericByteType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/integer/GenericByteType.java
@@ -133,6 +133,13 @@ public abstract class GenericByteType<T extends GenericByteType<T>> extends Abst
 	}
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Byte#hashCode().
+		return getValue();
+	}
+
+	@Override
 	public int compareTo( final T c )
 	{
 		final byte a = getValue();

--- a/core/src/main/java/net/imglib2/type/numeric/integer/GenericIntType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/integer/GenericIntType.java
@@ -130,6 +130,13 @@ public abstract class GenericIntType<T extends GenericIntType<T>> extends Abstra
 	}
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Integer#hashCode().
+		return getValue();
+	}
+
+	@Override
 	public int compareTo( final T c )
 	{
 		final int a = getValue();

--- a/core/src/main/java/net/imglib2/type/numeric/integer/GenericShortType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/integer/GenericShortType.java
@@ -130,6 +130,13 @@ public abstract class GenericShortType<T extends GenericShortType<T>> extends Ab
 	}
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Short#hashCode().
+		return getValue();
+	}
+
+	@Override
 	public int compareTo( final T c )
 	{
 		final short a = getValue();

--- a/core/src/main/java/net/imglib2/type/numeric/integer/LongType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/integer/LongType.java
@@ -154,6 +154,14 @@ final public class LongType extends AbstractIntegerType<LongType> implements Nat
 	}
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Long#hashCode().
+		final long value = get();
+		return (int) (value ^ (value >>> 32));
+	}
+
+	@Override
 	public int compareTo( final LongType c )
 	{
 		final long a = get();

--- a/core/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteType.java
@@ -145,6 +145,13 @@ public class UnsignedByteType extends GenericByteType<UnsignedByteType>
 	public double getMinValue()  { return 0; }
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Integer#hashCode().
+		return get();
+	}
+
+	@Override
 	public int compareTo( final UnsignedByteType c )
 	{
 		final int a = get();

--- a/core/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntType.java
@@ -164,6 +164,14 @@ public class UnsignedIntType extends GenericIntType<UnsignedIntType>
 	public double getMinValue()  { return 0; }
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Long#hashCode().
+		final long value = get();
+		return (int) (value ^ (value >>> 32));
+	}
+
+	@Override
 	public int compareTo( final UnsignedIntType c )
 	{
 		final long a = get();

--- a/core/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
@@ -154,6 +154,13 @@ public class UnsignedShortType extends GenericShortType<UnsignedShortType>
 	public double getMinValue()  { return 0; }
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Integer#hashCode().
+		return get();
+	}
+
+	@Override
 	public int compareTo( final UnsignedShortType c )
 	{
 		final int a = get();

--- a/core/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
@@ -84,6 +84,24 @@ public abstract class AbstractRealType<T extends AbstractRealType<T>> extends Ab
 	public void setOne() { setReal( 1 ); }
 	
 	@Override
+	public boolean equals( final Object o )
+	{
+		if ( ! (o instanceof RealType) )
+			return false;
+		@SuppressWarnings("unchecked")
+		final T t = (T) o;
+		return compareTo(t) == 0;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Double#hashCode().
+		final long bits = Double.doubleToLongBits(getRealDouble());
+		return (int) (bits ^ (bits >>> 32));
+	}
+
+	@Override
 	public int compareTo( final T c ) 
 	{ 
 		final double a = getRealDouble();
@@ -95,6 +113,7 @@ public abstract class AbstractRealType<T extends AbstractRealType<T>> extends Ab
 		else 
 			return 0;
 	}
+
 	@Override
 	public float getPowerFloat() { return getRealFloat(); }
 

--- a/core/src/main/java/net/imglib2/type/numeric/real/FloatType.java
+++ b/core/src/main/java/net/imglib2/type/numeric/real/FloatType.java
@@ -159,6 +159,13 @@ public class FloatType extends AbstractRealType<FloatType> implements NativeType
 	}
 
 	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Float#hashCode().
+		return Float.floatToIntBits(get());
+	}
+
+	@Override
 	public int compareTo( final FloatType c ) 
 	{ 
 		final float a = get();


### PR DESCRIPTION
From the javadoc of Comparable#compareTo:

> It is strongly recommended, but _not_ strictly required that `(x.compareTo(y)==0) == (x.equals(y))`. Generally speaking, any class that implements the `Comparable` interface and violates this condition should clearly indicate this fact. The recommended language is "Note: this class has a natural ordering that is inconsistent with equals."

The `RealType` interface extends `Comparable`, and `AbstractRealType` overrides `compareTo`, but it did not override `equals` or `hashCode`. This commit updates the `AbstractRealType` class hierarchy to override `equals` and `hashCode` in the appropriate places, so that type equality is consistent with the results of the `compareTo` method.

Thanks to @MichaelZinsmaier for noticing this issue.
