### PR TITLE
Switch 'knip' branch to a KNIP-specific version

### DIFF
--- a/algorithms/core/pom.xml
+++ b/algorithms/core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2-algorithms</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>imglib2-algorithms</artifactId>

--- a/algorithms/gpl/pom.xml
+++ b/algorithms/gpl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2-algorithms</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>imglib2-algorithms-gpl</artifactId>

--- a/algorithms/legacy/pom.xml
+++ b/algorithms/legacy/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2-algorithms</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>imglib2-algorithms-legacy</artifactId>

--- a/algorithms/pom.xml
+++ b/algorithms/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>pom-imglib2-algorithms</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>imglib2</artifactId>

--- a/meta/pom.xml
+++ b/meta/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>imglib2-meta</artifactId>

--- a/ops/pom.xml
+++ b/ops/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>imglib2-ops</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.imglib2</groupId>
 	<artifactId>pom-imglib2</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.0-knip-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>ImgLib2 Projects</name>

--- a/realtransform/pom.xml
+++ b/realtransform/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>imglib2-realtransform</artifactId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imglib2</groupId>
 		<artifactId>pom-imglib2</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0-knip-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>imglib2-ui</artifactId>


### PR DESCRIPTION
... in preparation for the Maven-based OSGi bundle generation.
