### PR TITLE
Make NeighborhoodAccessibles work on potentially unbounded RandomAccessible.

### DIFF
--- a/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/HyperSphereNeighborhoodCursor.java
+++ b/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/HyperSphereNeighborhoodCursor.java
@@ -45,6 +45,10 @@ public final class HyperSphereNeighborhoodCursor< T > extends HypersphereNeighbo
 {
 	private final long[] dimensions;
 
+	private final long[] min;
+
+	private final long[] max;
+
 	private long index;
 
 	private final long maxIndex;
@@ -53,10 +57,14 @@ public final class HyperSphereNeighborhoodCursor< T > extends HypersphereNeighbo
 
 	public HyperSphereNeighborhoodCursor( final RandomAccessibleInterval< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory )
 	{
-		super( source, radius, factory );
+		super( source, radius, factory, source );
 
 		dimensions = new long[ n ];
-		dimensions( dimensions );
+		min = new long[ n ];
+		max = new long[ n ];
+		source.dimensions( dimensions );
+		source.min( min );
+		source.max( max );
 		long size = dimensions[ 0 ];
 		for ( int d = 1; d < n; ++d )
 			size *= dimensions[ d ];
@@ -68,6 +76,8 @@ public final class HyperSphereNeighborhoodCursor< T > extends HypersphereNeighbo
 	{
 		super( c );
 		dimensions = c.dimensions.clone();
+		min = c.min.clone();
+		max = c.max.clone();
 		maxIndex = c.maxIndex;
 		index = c.index;
 		maxIndexOnLine = c.maxIndexOnLine;

--- a/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/HyperSphereNeighborhoodRandomAccess.java
+++ b/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/HyperSphereNeighborhoodRandomAccess.java
@@ -37,47 +37,26 @@
 
 package net.imglib2.algorithm.region.localneighborhood;
 
-import net.imglib2.AbstractInterval;
+import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RandomAccessible;
 
-public class HyperSphereNeighborhoodRandomAccess< T > extends AbstractInterval implements RandomAccess< Neighborhood< T > >
+public class HyperSphereNeighborhoodRandomAccess< T > extends HypersphereNeighborhoodLocalizableSampler< T > implements RandomAccess< Neighborhood< T > >
 {
-	protected final RandomAccessibleInterval< T > source;
-
-	protected final long radius;
-
-	protected final HyperSphereNeighborhoodFactory< T > neighborhoodFactory;
-
-	protected final Neighborhood< T > currentNeighborhood;
-
-	protected final long[] currentPos;
-
-	public HyperSphereNeighborhoodRandomAccess( final RandomAccessibleInterval< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory )
+	public HyperSphereNeighborhoodRandomAccess( final RandomAccessible< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory )
 	{
-		super( source );
-		this.source = source;
-		this.radius = radius;
-		neighborhoodFactory = factory;
-		currentPos = new long[ n ];
-		currentNeighborhood = neighborhoodFactory.create( currentPos, radius, source.randomAccess() );
+		super( source, radius, factory, null );
+	}
+
+	public HyperSphereNeighborhoodRandomAccess( final RandomAccessible< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory, final Interval interval )
+	{
+		super( source, radius, factory, interval );
 	}
 
 	protected HyperSphereNeighborhoodRandomAccess( final HyperSphereNeighborhoodRandomAccess< T > c )
 	{
-		super( c.source );
-		source = c.source;
-		radius = c.radius;
-		neighborhoodFactory = c.neighborhoodFactory;
-		currentPos = c.currentPos.clone();
-		currentNeighborhood = neighborhoodFactory.create( currentPos, radius, source.randomAccess() );
-	}
-
-	@Override
-	public Neighborhood< T > get()
-	{
-		return currentNeighborhood;
+		super( c );
 	}
 
 	@Override
@@ -168,53 +147,5 @@ public class HyperSphereNeighborhoodRandomAccess< T > extends AbstractInterval i
 	public HyperSphereNeighborhoodRandomAccess< T > copyRandomAccess()
 	{
 		return copy();
-	}
-
-	@Override
-	public void localize( final int[] position )
-	{
-		currentNeighborhood.localize( position );
-	}
-
-	@Override
-	public void localize( final long[] position )
-	{
-		currentNeighborhood.localize( position );
-	}
-
-	@Override
-	public int getIntPosition( final int d )
-	{
-		return currentNeighborhood.getIntPosition( d );
-	}
-
-	@Override
-	public long getLongPosition( final int d )
-	{
-		return currentNeighborhood.getLongPosition( d );
-	}
-
-	@Override
-	public void localize( final float[] position )
-	{
-		currentNeighborhood.localize( position );
-	}
-
-	@Override
-	public void localize( final double[] position )
-	{
-		currentNeighborhood.localize( position );
-	}
-
-	@Override
-	public float getFloatPosition( final int d )
-	{
-		return currentNeighborhood.getFloatPosition( d );
-	}
-
-	@Override
-	public double getDoublePosition( final int d )
-	{
-		return currentNeighborhood.getDoublePosition( d );
 	}
 }

--- a/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/HyperSphereShape.java
+++ b/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/HyperSphereShape.java
@@ -39,6 +39,7 @@ package net.imglib2.algorithm.region.localneighborhood;
 
 import java.util.Iterator;
 
+import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.AbstractInterval;
 import net.imglib2.Cursor;
 import net.imglib2.FlatIterationOrder;
@@ -46,8 +47,8 @@ import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.IterableRealInterval;
 import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.view.Views;
 
 /**
  * A factory for Accessibles on hyper-sphere neighboorhoods.
@@ -64,30 +65,30 @@ public class HyperSphereShape implements Shape
 	}
 
 	@Override
-	public < T > IterableInterval< Neighborhood< T >> neighborhoods( final RandomAccessibleInterval< T > source )
+	public < T > NeighborhoodsIterableInterval< T > neighborhoods( final RandomAccessibleInterval< T > source )
 	{
-		return Views.iterable( neighborhoodsRandomAccessible( source ) );
+		return new NeighborhoodsIterableInterval< T >( source, radius, HyperSphereNeighborhoodUnsafe.< T >factory() );
 	}
 
 	@Override
-	public < T > NeighborhoodsAccessible< T > neighborhoodsRandomAccessible( final RandomAccessibleInterval< T > source )
+	public < T > NeighborhoodsAccessible< T > neighborhoodsRandomAccessible( final RandomAccessible< T > source )
 	{
 		return new NeighborhoodsAccessible< T >( source, radius, HyperSphereNeighborhoodUnsafe.< T >factory() );
 	}
 
 	@Override
-	public < T > IterableInterval< Neighborhood< T >> neighborhoodsSafe( final RandomAccessibleInterval< T > source )
+	public < T > NeighborhoodsIterableInterval< T > neighborhoodsSafe( final RandomAccessibleInterval< T > source )
 	{
-		return Views.iterable( neighborhoodsRandomAccessible( source ) );
+		return new NeighborhoodsIterableInterval< T >( source, radius, HyperSphereNeighborhood.< T >factory() );
 	}
 
 	@Override
-	public < T > NeighborhoodsAccessible< T > neighborhoodsRandomAccessibleSafe( final RandomAccessibleInterval< T > source )
+	public < T > NeighborhoodsAccessible< T > neighborhoodsRandomAccessibleSafe( final RandomAccessible< T > source )
 	{
 		return new NeighborhoodsAccessible< T >( source, radius, HyperSphereNeighborhood.< T >factory() );
 	}
 
-	public static final class NeighborhoodsAccessible< T > extends AbstractInterval implements RandomAccessibleInterval< Neighborhood< T > >, IterableInterval< Neighborhood< T > >
+	public static final class NeighborhoodsIterableInterval< T > extends AbstractInterval implements IterableInterval< Neighborhood< T > >
 	{
 		final RandomAccessibleInterval< T > source;
 
@@ -97,7 +98,7 @@ public class HyperSphereShape implements Shape
 
 		final HyperSphereNeighborhoodFactory< T > factory;
 
-		public NeighborhoodsAccessible( final RandomAccessibleInterval< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory )
+		public NeighborhoodsIterableInterval( final RandomAccessibleInterval< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory )
 		{
 			super( source );
 			this.source = source;
@@ -108,18 +109,6 @@ public class HyperSphereShape implements Shape
 			for ( int d = 1; d < n; ++d )
 				s *= source.dimension( d );
 			size = s;
-		}
-
-		@Override
-		public RandomAccess< Neighborhood< T >> randomAccess()
-		{
-			return new HyperSphereNeighborhoodRandomAccess< T >( source, radius, factory );
-		}
-
-		@Override
-		public RandomAccess< Neighborhood< T >> randomAccess( final Interval interval )
-		{
-			return randomAccess();
 		}
 
 		@Override
@@ -162,6 +151,35 @@ public class HyperSphereShape implements Shape
 		public Cursor< Neighborhood< T >> localizingCursor()
 		{
 			return cursor();
+		}
+	}
+
+	public static final class NeighborhoodsAccessible< T > extends AbstractEuclideanSpace implements RandomAccessible< Neighborhood< T > >
+	{
+		final RandomAccessible< T > source;
+
+		final long radius;
+
+		final HyperSphereNeighborhoodFactory< T > factory;
+
+		public NeighborhoodsAccessible( final RandomAccessible< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory )
+		{
+			super( source.numDimensions() );
+			this.source = source;
+			this.radius = radius;
+			this.factory = factory;
+		}
+
+		@Override
+		public RandomAccess< Neighborhood< T >> randomAccess()
+		{
+			return new HyperSphereNeighborhoodRandomAccess< T >( source, radius, factory );
+		}
+
+		@Override
+		public RandomAccess< Neighborhood< T >> randomAccess( final Interval interval )
+		{
+			return new HyperSphereNeighborhoodRandomAccess< T >( source, radius, factory, interval );
 		}
 	}
 }

--- a/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/HypersphereNeighborhoodLocalizableSampler.java
+++ b/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/HypersphereNeighborhoodLocalizableSampler.java
@@ -37,15 +37,20 @@
 
 package net.imglib2.algorithm.region.localneighborhood;
 
-import net.imglib2.AbstractInterval;
+import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
 import net.imglib2.Localizable;
-import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RandomAccessible;
 import net.imglib2.Sampler;
 
-public abstract class HypersphereNeighborhoodLocalizableSampler< T > extends AbstractInterval implements Localizable, Sampler< Neighborhood< T > >
+public abstract class HypersphereNeighborhoodLocalizableSampler< T > extends AbstractEuclideanSpace implements Localizable, Sampler< Neighborhood< T > >
 {
-	protected final RandomAccessibleInterval< T > source;
+	protected final RandomAccessible< T > source;
+
+	protected final long radius;
+
+	protected final Interval sourceInterval;
 
 	protected final HyperSphereNeighborhoodFactory< T > neighborhoodFactory;
 
@@ -53,35 +58,42 @@ public abstract class HypersphereNeighborhoodLocalizableSampler< T > extends Abs
 
 	protected final long[] currentPos;
 
-	protected final long radius;
-
-	public HypersphereNeighborhoodLocalizableSampler( final RandomAccessibleInterval< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory )
+	public HypersphereNeighborhoodLocalizableSampler( final RandomAccessible< T > source, final long radius, final HyperSphereNeighborhoodFactory< T > factory, final Interval accessInterval )
 	{
-		super( source );
+		super( source.numDimensions() );
 		this.source = source;
 		this.radius = radius;
 		neighborhoodFactory = factory;
 		currentPos = new long[ n ];
-		final long[] accessMin = new long[ n ];
-		final long[] accessMax = new long[ n ];
-		source.min( accessMin );
-		source.max( accessMax );
-		for ( int d = 0; d < n; ++d )
+		if ( accessInterval == null )
+			sourceInterval = null;
+		else
 		{
-			accessMin[ d ] -= radius;
-			accessMax[ d ] += radius;
+			final long[] accessMin = new long[ n ];
+			final long[] accessMax = new long[ n ];
+			accessInterval.min( accessMin );
+			accessInterval.max( accessMax );
+			for ( int d = 0; d < n; ++d )
+			{
+				accessMin[ d ] -= radius;
+				accessMax[ d ] += radius;
+			}
+			sourceInterval = new FinalInterval( accessMin, accessMax );
 		}
-		currentNeighborhood = neighborhoodFactory.create( currentPos, radius, source.randomAccess( new FinalInterval( accessMin, accessMax ) ) );
+		currentNeighborhood = neighborhoodFactory.create( currentPos, radius,
+				sourceInterval == null ? source.randomAccess() : source.randomAccess( sourceInterval ) );
 	}
 
 	protected HypersphereNeighborhoodLocalizableSampler( final HypersphereNeighborhoodLocalizableSampler< T > c )
 	{
-		super( c.source );
+		super( c.n );
 		source = c.source;
 		radius = c.radius;
+		sourceInterval = c.sourceInterval;
 		neighborhoodFactory = c.neighborhoodFactory;
 		currentPos = c.currentPos.clone();
-		currentNeighborhood = neighborhoodFactory.create( currentPos, radius, source.randomAccess() );
+		currentNeighborhood = neighborhoodFactory.create( currentPos, radius,
+				sourceInterval == null ? source.randomAccess() : source.randomAccess( sourceInterval ) );
 	}
 
 	@Override

--- a/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/RectangleNeighborhoodCursor.java
+++ b/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/RectangleNeighborhoodCursor.java
@@ -46,6 +46,10 @@ public final class RectangleNeighborhoodCursor< T > extends RectangleNeighborhoo
 {
 	private final long[] dimensions;
 
+	private final long[] min;
+
+	private final long[] max;
+
 	private long index;
 
 	private final long maxIndex;
@@ -54,10 +58,14 @@ public final class RectangleNeighborhoodCursor< T > extends RectangleNeighborhoo
 
 	public RectangleNeighborhoodCursor( final RandomAccessibleInterval< T > source, final Interval span, final RectangleNeighborhoodFactory< T > factory )
 	{
-		super( source, span, factory );
+		super( source, span, factory, source );
 
 		dimensions = new long[ n ];
-		dimensions( dimensions );
+		min = new long[ n ];
+		max = new long[ n ];
+		source.dimensions( dimensions );
+		source.min( min );
+		source.max( max );
 		long size = dimensions[ 0 ];
 		for ( int d = 1; d < n; ++d )
 			size *= dimensions[ d ];
@@ -69,6 +77,8 @@ public final class RectangleNeighborhoodCursor< T > extends RectangleNeighborhoo
 	{
 		super( c );
 		dimensions = c.dimensions.clone();
+		min = c.min.clone();
+		max = c.max.clone();
 		maxIndex = c.maxIndex;
 		index = c.index;
 		maxIndexOnLine = c.maxIndexOnLine;
@@ -162,5 +172,4 @@ public final class RectangleNeighborhoodCursor< T > extends RectangleNeighborhoo
 	{
 		return copy();
 	}
-
 }

--- a/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/RectangleNeighborhoodLocalizableSampler.java
+++ b/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/RectangleNeighborhoodLocalizableSampler.java
@@ -37,18 +37,20 @@
 
 package net.imglib2.algorithm.region.localneighborhood;
 
-import net.imglib2.AbstractInterval;
+import net.imglib2.AbstractEuclideanSpace;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.Localizable;
-import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RandomAccessible;
 import net.imglib2.Sampler;
 
-public abstract class RectangleNeighborhoodLocalizableSampler< T > extends AbstractInterval implements Localizable, Sampler< Neighborhood< T > >
+public abstract class RectangleNeighborhoodLocalizableSampler< T > extends AbstractEuclideanSpace implements Localizable, Sampler< Neighborhood< T > >
 {
-	protected final RandomAccessibleInterval< T > source;
+	protected final RandomAccessible< T > source;
 
 	protected final Interval span;
+
+	protected final Interval sourceInterval;
 
 	protected final RectangleNeighborhoodFactory< T > neighborhoodFactory;
 
@@ -60,37 +62,46 @@ public abstract class RectangleNeighborhoodLocalizableSampler< T > extends Abstr
 
 	protected final long[] currentMax;
 
-	public RectangleNeighborhoodLocalizableSampler( final RandomAccessibleInterval< T > source, final Interval span, final RectangleNeighborhoodFactory< T > factory )
+	public RectangleNeighborhoodLocalizableSampler( final RandomAccessible< T > source, final Interval span, final RectangleNeighborhoodFactory< T > factory, final Interval accessInterval )
 	{
-		super( source );
+		super( source.numDimensions() );
 		this.source = source;
 		this.span = span;
 		neighborhoodFactory = factory;
 		currentPos = new long[ n ];
 		currentMin = new long[ n ];
 		currentMax = new long[ n ];
-		final long[] accessMin = new long[ n ];
-		final long[] accessMax = new long[ n ];
-		source.min( accessMin );
-		source.max( accessMax );
-		for ( int d = 0; d < n; ++d )
+		if ( accessInterval == null )
+			sourceInterval = null;
+		else
 		{
-			accessMin[ d ] += span.min( d );
-			accessMax[ d ] += span.max( d );
+			final long[] accessMin = new long[ n ];
+			final long[] accessMax = new long[ n ];
+			accessInterval.min( accessMin );
+			accessInterval.max( accessMax );
+			for ( int d = 0; d < n; ++d )
+			{
+				accessMin[ d ] += span.min( d );
+				accessMax[ d ] += span.max( d );
+			}
+			sourceInterval = new FinalInterval( accessMin, accessMax );
 		}
-		currentNeighborhood = neighborhoodFactory.create( currentPos, currentMin, currentMax, span, source.randomAccess( new FinalInterval( accessMin, accessMax ) ) );
+		currentNeighborhood = neighborhoodFactory.create( currentPos, currentMin, currentMax, span,
+				sourceInterval == null ? source.randomAccess() : source.randomAccess( sourceInterval ) );
 	}
 
 	protected RectangleNeighborhoodLocalizableSampler( final RectangleNeighborhoodLocalizableSampler< T > c )
 	{
-		super( c.source );
+		super( c.n );
 		source = c.source;
 		span = c.span;
+		sourceInterval = c.sourceInterval;
 		neighborhoodFactory = c.neighborhoodFactory;
 		currentPos = c.currentPos.clone();
 		currentMin = c.currentMin.clone();
 		currentMax = c.currentMax.clone();
-		currentNeighborhood = neighborhoodFactory.create( currentPos, currentMin, currentMax, span, source.randomAccess() );
+		currentNeighborhood = neighborhoodFactory.create( currentPos, currentMin, currentMax, span,
+				sourceInterval == null ? source.randomAccess() : source.randomAccess( sourceInterval ) );
 	}
 
 	@Override

--- a/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/RectangleNeighborhoodRandomAccess.java
+++ b/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/RectangleNeighborhoodRandomAccess.java
@@ -40,13 +40,18 @@ package net.imglib2.algorithm.region.localneighborhood;
 import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RandomAccessible;
 
 public final class RectangleNeighborhoodRandomAccess< T > extends RectangleNeighborhoodLocalizableSampler< T > implements RandomAccess< Neighborhood< T > >
 {
-	public RectangleNeighborhoodRandomAccess( final RandomAccessibleInterval< T > source, final Interval span, final RectangleNeighborhoodFactory< T > factory )
+	public RectangleNeighborhoodRandomAccess( final RandomAccessible< T > source, final Interval span, final RectangleNeighborhoodFactory< T > factory )
 	{
-		super( source, span, factory );
+		super( source, span, factory, null );
+	}
+
+	public RectangleNeighborhoodRandomAccess( final RandomAccessible< T > source, final Interval span, final RectangleNeighborhoodFactory< T > factory, final Interval interval )
+	{
+		super( source, span, factory, interval );
 	}
 
 	private RectangleNeighborhoodRandomAccess( final RectangleNeighborhoodRandomAccess< T > c )

--- a/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/Shape.java
+++ b/algorithms/core/src/main/java/net/imglib2/algorithm/region/localneighborhood/Shape.java
@@ -40,12 +40,13 @@ package net.imglib2.algorithm.region.localneighborhood;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Sampler;
 
 /**
  * A factory for Accessibles on {@link Neighborhood Neighborhoods}.
- * 
+ *
  * @author Tobias Pietzsch <tobias.pietzsch@gmail.com>
  */
 public interface Shape
@@ -53,14 +54,14 @@ public interface Shape
 	/**
 	 * Get an {@link IterableInterval} that contains all {@link Neighborhood
 	 * Neighborhoods} of the source image.
-	 * 
+	 *
 	 * <p>
 	 * A {@link Cursor} on the resulting accessible can be used to access the
 	 * {@link Neighborhood neighborhoods}. As usual, when the cursor is moved, a
 	 * neighborhood {@link Sampler#get() obtained} previously from the cursor
 	 * should be considered invalid.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * <em>The {@link Neighborhood neighborhoods} that are obtained from the
 	 * resulting accessible are unsafe in the following sense:</em> Every time,
@@ -78,7 +79,7 @@ public interface Shape
 	 * not recommended if you want to use enhanced for loops).
 	 * </ol>
 	 * </p>
-	 * 
+	 *
 	 * @param source
 	 *            source image.
 	 * @return an {@link IterableInterval} that contains all
@@ -89,14 +90,14 @@ public interface Shape
 	/**
 	 * Get an {@link RandomAccessibleInterval} that contains all
 	 * {@link Neighborhood Neighborhoods} of the source image.
-	 * 
+	 *
 	 * <p>
 	 * A {@link RandomAccess} on the resulting accessible can be used to access
 	 * the {@link Neighborhood neighborhoods}. As usual, when the access is
 	 * moved, a neighborhood {@link Sampler#get() obtained} previously from the
 	 * access should be considered invalid.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * <em>The {@link Neighborhood neighborhoods} that are obtained from the
 	 * resulting accessible are unsafe in the following sense:</em> Every time,
@@ -115,25 +116,25 @@ public interface Shape
 	 * therefore is not recommended if you want to use enhanced for loops).
 	 * </ol>
 	 * </p>
-	 * 
+	 *
 	 * @param source
 	 *            source image.
 	 * @return an {@link RandomAccessibleInterval} that contains all
 	 *         {@link Neighborhood Neighborhoods} of the source image.
 	 */
-	public < T > RandomAccessibleInterval< Neighborhood< T > > neighborhoodsRandomAccessible( final RandomAccessibleInterval< T > source );
+	public < T > RandomAccessible< Neighborhood< T > > neighborhoodsRandomAccessible( final RandomAccessible< T > source );
 
 	/**
 	 * Get an {@link IterableInterval} that contains all {@link Neighborhood
 	 * Neighborhoods} of the source image.
-	 * 
+	 *
 	 * <p>
 	 * A {@link Cursor} on the resulting accessible can be used to access the
 	 * {@link Neighborhood neighborhoods}. As usual, when the cursor is moved, a
 	 * neighborhood {@link Sampler#get() obtained} previously from the cursor
 	 * should be considered invalid.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * Every time, a {@link Cursor} is requested from a {@link Neighborhood}
 	 * (where the neighborhood in turn is obtained from a cursor on the
@@ -143,7 +144,7 @@ public interface Shape
 	 * {@link #neighborhoods(RandomAccessibleInterval)} which re-uses the same
 	 * instance every time (but therefore has to be used carefully).
 	 * </p>
-	 * 
+	 *
 	 * @param source
 	 *            source image.
 	 * @return an {@link IterableInterval} that contains all
@@ -154,14 +155,14 @@ public interface Shape
 	/**
 	 * Get an {@link RandomAccessibleInterval} that contains all
 	 * {@link Neighborhood Neighborhoods} of the source image.
-	 * 
+	 *
 	 * <p>
 	 * A {@link RandomAccess} on the resulting accessible can be used to access
 	 * the {@link Neighborhood neighborhoods}. As usual, when the access is
 	 * moved, a neighborhood {@link Sampler#get() obtained} previously from the
 	 * access should be considered invalid.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * Every time, a {@link Cursor} is requested from a {@link Neighborhood}
 	 * (where the neighborhood in turn is obtained from a cursor on the
@@ -171,11 +172,11 @@ public interface Shape
 	 * {@link #neighborhoods(RandomAccessibleInterval)} which re-uses the same
 	 * instance every time (but therefore has to be used carefully).
 	 * </p>
-	 * 
+	 *
 	 * @param source
 	 *            source image.
 	 * @return an {@link RandomAccessibleInterval} that contains all
 	 *         {@link Neighborhood Neighborhoods} of the source image.
 	 */
-	public < T > RandomAccessibleInterval< Neighborhood< T > > neighborhoodsRandomAccessibleSafe( final RandomAccessibleInterval< T > source );
+	public < T > RandomAccessible< Neighborhood< T > > neighborhoodsRandomAccessibleSafe( final RandomAccessible< T > source );
 }


### PR DESCRIPTION
Shape.neighborhoodsRandomAccessible(source) doesn't require bounded source anymore. It works on any RandomAccessible source now, instead of requiring RandomAccessibleInterval as before.

The randomAccess(interval) on these neighborhoodsRandomAccessibles work as
expected now. That is, they extend interval by the required span and
operate on source accesses optimized for that extended interval.

Also, now HyperSphereNeighborhoodRandomAccess extends
HypersphereNeighborhoodLocalizableSampler, as it should, instead of reimplementing that functionality.
