### PR TITLE
Loosen the type bounds on Converters.

### DIFF
--- a/core/src/main/java/net/imglib2/converter/Converters.java
+++ b/core/src/main/java/net/imglib2/converter/Converters.java
@@ -73,7 +73,7 @@ public class Converters
 	@SuppressWarnings( "unchecked" )
 	final static public < A, B extends Type< B > > RandomAccessible< B > convert(
 			final RandomAccessible< A > source,
-			final Converter< A, B > converter,
+			final Converter< ? super A, ? super B > converter,
 			final B b )
 	{
 		if ( TypeIdentity.class.isInstance( converter ) )
@@ -94,7 +94,7 @@ public class Converters
 	 */
 	final static public < A, B extends Type< B > > WriteConvertedRandomAccessible< A, B > convert(
 			final RandomAccessible< A > source,
-			final SamplerConverter< A, B > converter )
+			final SamplerConverter< ? super A, B > converter )
 	{
 		return new WriteConvertedRandomAccessible< A, B >( source, converter );
 	}
@@ -115,7 +115,7 @@ public class Converters
 	@SuppressWarnings( "unchecked" )
 	final static public < A, B extends Type< B > > RandomAccessibleInterval< B > convert(
 			final RandomAccessibleInterval< A > source,
-			final Converter< A, B > converter,
+			final Converter< ? super A, ? super B > converter,
 			final B b )
 	{
 		if ( TypeIdentity.class.isInstance( converter ) )
@@ -136,7 +136,7 @@ public class Converters
 	 */
 	final static public < A, B extends Type< B > > WriteConvertedRandomAccessibleInterval< A, B > convert(
 			final RandomAccessibleInterval< A > source,
-			final SamplerConverter< A, B > converter )
+			final SamplerConverter< ? super A, B > converter )
 	{
 		return new WriteConvertedRandomAccessibleInterval< A, B >( source, converter );
 	}
@@ -156,7 +156,7 @@ public class Converters
 	@SuppressWarnings( "unchecked" )
 	final static public < A, B extends Type< B > > IterableInterval< B > convert(
 			final IterableInterval< A > source,
-			final Converter< A, B > converter,
+			final Converter< ? super A, ? super B > converter,
 			final B b )
 	{
 		if ( TypeIdentity.class.isInstance( converter ) )
@@ -176,7 +176,7 @@ public class Converters
 	 */
 	final static public < A, B extends Type< B > > WriteConvertedIterableInterval< A, B > convert(
 			final IterableInterval< A > source,
-			final SamplerConverter< A, B > converter )
+			final SamplerConverter< ? super A, B > converter )
 	{
 		return new WriteConvertedIterableInterval< A, B >( source, converter );
 	}
@@ -196,7 +196,7 @@ public class Converters
 	final static public < A, B extends Type< B >, S extends RandomAccessible< A > & IterableInterval< A > >
 			WriteConvertedIterableRandomAccessibleInterval< A, B, S > convertRandomAccessibleIterableInterval(
 					final S source,
-					final SamplerConverter< A, B > converter )
+					final SamplerConverter< ? super A, B > converter )
 	{
 		return new WriteConvertedIterableRandomAccessibleInterval< A, B, S >( source, converter );
 	}

--- a/core/src/main/java/net/imglib2/converter/read/ConvertedCursor.java
+++ b/core/src/main/java/net/imglib2/converter/read/ConvertedCursor.java
@@ -44,7 +44,7 @@ import net.imglib2.type.Type;
  */
 public class ConvertedCursor< A, B extends Type< B > > extends AbstractConvertedCursor< A, B >
 {
-	final protected Converter< A, B > converter;
+	final protected Converter< ? super A, ? super B > converter;
 
 	final protected B converted;
 
@@ -56,7 +56,7 @@ public class ConvertedCursor< A, B extends Type< B > > extends AbstractConverted
 	 * @param converter
 	 * @param b
 	 */
-	public ConvertedCursor( final Cursor< A > source, final Converter< A, B > converter, final B b )
+	public ConvertedCursor( final Cursor< A > source, final Converter< ? super A, ? super B > converter, final B b )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
+++ b/core/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
@@ -44,7 +44,7 @@ import net.imglib2.type.Type;
  */
 public class ConvertedIterableInterval< A, B extends Type< B > > extends AbstractConvertedIterableInterval< A, B >
 {
-	final protected Converter< A, B > converter;
+	final protected Converter< ? super A, ? super B > converter;
 
 	final protected B converted;
 
@@ -56,7 +56,7 @@ public class ConvertedIterableInterval< A, B extends Type< B > > extends Abstrac
 	 * @param converter
 	 * @param b
 	 */
-	public ConvertedIterableInterval( final IterableInterval< A > source, final Converter< A, B > converter, final B b )
+	public ConvertedIterableInterval( final IterableInterval< A > source, final Converter< ? super A, ? super B > converter, final B b )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/read/ConvertedRandomAccess.java
+++ b/core/src/main/java/net/imglib2/converter/read/ConvertedRandomAccess.java
@@ -44,11 +44,11 @@ import net.imglib2.type.Type;
  */
 final public class ConvertedRandomAccess< A, B extends Type< B > > extends AbstractConvertedRandomAccess< A, B >
 {
-	final protected Converter< A, B > converter;
+	final protected Converter< ? super A, ? super B > converter;
 
 	final protected B converted;
 
-	public ConvertedRandomAccess( final RandomAccess< A > source, final Converter< A, B > converter, final B b )
+	public ConvertedRandomAccess( final RandomAccess< A > source, final Converter< ? super A, ? super B > converter, final B b )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
+++ b/core/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
@@ -45,11 +45,11 @@ import net.imglib2.type.Type;
  */
 public class ConvertedRandomAccessible< A, B extends Type< B > > extends AbstractConvertedRandomAccessible< A, B >
 {
-	final protected Converter< A, B > converter;
+	final protected Converter< ? super A, ? super B > converter;
 
 	final protected B converted;
 
-	public ConvertedRandomAccessible( final RandomAccessible< A > source, final Converter< A, B > converter, final B b )
+	public ConvertedRandomAccessible( final RandomAccessible< A > source, final Converter< ? super A, ? super B > converter, final B b )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
+++ b/core/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
@@ -45,11 +45,11 @@ import net.imglib2.type.Type;
  */
 public class ConvertedRandomAccessibleInterval< A, B extends Type< B > > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >
 {
-	final protected Converter< A, B > converter;
+	final protected Converter< ? super A, ? super B > converter;
 
 	final protected B converted;
 
-	public ConvertedRandomAccessibleInterval( final RandomAccessibleInterval< A > source, final Converter< A, B > converter, final B b )
+	public ConvertedRandomAccessibleInterval( final RandomAccessibleInterval< A > source, final Converter< ? super A, ? super B > converter, final B b )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/readwrite/RealDoubleSamplerConverter.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/RealDoubleSamplerConverter.java
@@ -45,16 +45,16 @@ import net.imglib2.type.numeric.real.DoubleType;
 public final class RealDoubleSamplerConverter< R extends RealType< R > > implements SamplerConverter< R, DoubleType >
 {
 	@Override
-	public DoubleType convert( final Sampler< R > sampler )
+	public DoubleType convert( final Sampler< ? extends R > sampler )
 	{
 		return new DoubleType( new RealConvertingDoubleAccess< R >( sampler ) );
 	}
 
 	private static final class RealConvertingDoubleAccess< R extends RealType< R > > implements DoubleAccess
 	{
-		private final Sampler< R > sampler;
+		private final Sampler< ? extends R > sampler;
 
-		private RealConvertingDoubleAccess( final Sampler< R > sampler )
+		private RealConvertingDoubleAccess( final Sampler< ? extends R > sampler )
 		{
 			this.sampler = sampler;
 		}

--- a/core/src/main/java/net/imglib2/converter/readwrite/RealFloatSamplerConverter.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/RealFloatSamplerConverter.java
@@ -45,16 +45,16 @@ import net.imglib2.type.numeric.real.FloatType;
 public final class RealFloatSamplerConverter< R extends RealType< R > > implements SamplerConverter< R, FloatType >
 {
 	@Override
-	public FloatType convert( final Sampler< R > sampler )
+	public FloatType convert( final Sampler< ? extends R > sampler )
 	{
 		return new FloatType( new RealConvertingFloatAccess< R >( sampler ) );
 	}
 
 	private static final class RealConvertingFloatAccess< R extends RealType< R > > implements FloatAccess
 	{
-		private final Sampler< R > sampler;
+		private final Sampler< ? extends R > sampler;
 
-		private RealConvertingFloatAccess( final Sampler< R > sampler )
+		private RealConvertingFloatAccess( final Sampler< ? extends R > sampler )
 		{
 			this.sampler = sampler;
 		}

--- a/core/src/main/java/net/imglib2/converter/readwrite/SamplerConverter.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/SamplerConverter.java
@@ -41,5 +41,5 @@ import net.imglib2.Sampler;
  */
 public interface SamplerConverter< A, B >
 {
-	public B convert( Sampler< A > sampler );
+	public B convert( Sampler< ? extends A > sampler );
 }

--- a/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedCursor.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedCursor.java
@@ -42,11 +42,11 @@ import net.imglib2.converter.AbstractConvertedCursor;
  */
 public class WriteConvertedCursor< A, B > extends AbstractConvertedCursor< A, B >
 {
-	private final SamplerConverter< A, B > converter;
+	private final SamplerConverter< ? super A, B > converter;
 
 	private final B converted;
 
-	public WriteConvertedCursor( final Cursor< A > source, final SamplerConverter< A, B > converter )
+	public WriteConvertedCursor( final Cursor< A > source, final SamplerConverter< ? super A, B > converter )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableInterval.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableInterval.java
@@ -42,9 +42,9 @@ import net.imglib2.converter.AbstractConvertedIterableInterval;
  */
 public class WriteConvertedIterableInterval< A, B > extends AbstractConvertedIterableInterval< A, B >
 {
-	private final SamplerConverter< A, B > converter;
+	private final SamplerConverter< ? super A, B > converter;
 
-	public WriteConvertedIterableInterval( final IterableInterval< A > source, final SamplerConverter< A, B > converter )
+	public WriteConvertedIterableInterval( final IterableInterval< A > source, final SamplerConverter< ? super A, B > converter )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableRandomAccessibleInterval.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableRandomAccessibleInterval.java
@@ -44,9 +44,9 @@ import net.imglib2.converter.AbstractConvertedIterableRandomAccessibleInterval;
  */
 public class WriteConvertedIterableRandomAccessibleInterval< A, B, S extends RandomAccessible< A > & IterableInterval< A > > extends AbstractConvertedIterableRandomAccessibleInterval< A, B, S >
 {
-	private final SamplerConverter< A, B > converter;
+	private final SamplerConverter< ? super A, B > converter;
 
-	public WriteConvertedIterableRandomAccessibleInterval( final S source, final SamplerConverter< A, B > converter )
+	public WriteConvertedIterableRandomAccessibleInterval( final S source, final SamplerConverter< ? super A, B > converter )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccess.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccess.java
@@ -42,11 +42,11 @@ import net.imglib2.converter.AbstractConvertedRandomAccess;
  */
 public final class WriteConvertedRandomAccess< A, B > extends AbstractConvertedRandomAccess< A, B >
 {
-	private final SamplerConverter< A, B > converter;
+	private final SamplerConverter< ? super A, B > converter;
 
 	private final B converted;
 
-	public WriteConvertedRandomAccess( final RandomAccess< A > source, final SamplerConverter< A, B > converter )
+	public WriteConvertedRandomAccess( final RandomAccess< A > source, final SamplerConverter< ? super A, B > converter )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessible.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessible.java
@@ -43,9 +43,9 @@ import net.imglib2.converter.AbstractConvertedRandomAccessible;
  */
 public class WriteConvertedRandomAccessible< A, B > extends AbstractConvertedRandomAccessible< A, B >
 {
-	private final SamplerConverter< A, B > converter;
+	private final SamplerConverter< ? super A, B > converter;
 
-	public WriteConvertedRandomAccessible( final RandomAccessible< A > source, final SamplerConverter< A, B > converter )
+	public WriteConvertedRandomAccessible( final RandomAccessible< A > source, final SamplerConverter< ? super A, B > converter )
 	{
 		super( source );
 		this.converter = converter;

--- a/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessibleInterval.java
+++ b/core/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessibleInterval.java
@@ -43,9 +43,9 @@ import net.imglib2.RandomAccessibleInterval;
  */
 public class WriteConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >
 {
-	private final SamplerConverter< A, B > converter;
+	private final SamplerConverter< ? super A, B > converter;
 
-	public WriteConvertedRandomAccessibleInterval( final RandomAccessibleInterval< A > source, final SamplerConverter< A, B > converter )
+	public WriteConvertedRandomAccessibleInterval( final RandomAccessibleInterval< A > source, final SamplerConverter< ? super A, B > converter )
 	{
 		super( source );
 		this.converter = converter;


### PR DESCRIPTION
To convert from type A to type B, a Converter< ? super A, ? super B > is sufficient, and now the Converters API allows to do that. Type bounds in Converters convenience methods and related classes have been loosened accordingly.
