### PR TITLE
Synchronized  UnsignedXYTypes

### DIFF
--- a/src/main/java/net/imglib2/type/AbstractBit64Type.java
+++ b/src/main/java/net/imglib2/type/AbstractBit64Type.java
@@ -108,20 +108,22 @@ public abstract class AbstractBit64Type<T extends AbstractBit64Type<T>> extends 
 		final long k = i * nBits;
 		final int i1 = (int)(k >>> 6); // k / 64;
 		final long shift = k & 63; // Same as k % 64;
-		final long v = dataAccess.getValue(i1);
-		if (0 == shift) {
-			// Number contained in a single long, ending exactly at the first bit
-			return v & mask;
-		} else {
-			final long antiShift = 64 - shift;
-			if (antiShift < nBits) {
-				// Number split between two adjacent long
-				final long v1 = (v >>> shift) & (mask >>> (nBits - antiShift)); // lower part, stored at the upper end
-				final long v2 = (dataAccess.getValue(i1 + 1) & (mask >>> antiShift)) << antiShift; // upper part, stored at the lower end
-				return v1 | v2;
+		synchronized ( dataAccess ) {
+			final long v = dataAccess.getValue(i1);
+			if (0 == shift) {
+				// Number contained in a single long, ending exactly at the first bit
+				return v & mask;
 			} else {
-				// Number contained inside a single long
-				return (v >>> shift) & mask;
+				final long antiShift = 64 - shift;
+				if (antiShift < nBits) {
+					// Number split between two adjacent long
+					final long v1 = (v >>> shift) & (mask >>> (nBits - antiShift)); // lower part, stored at the upper end
+					final long v2 = (dataAccess.getValue(i1 + 1) & (mask >>> antiShift)) << antiShift; // upper part, stored at the lower end
+					return v1 | v2;
+				} else {
+					// Number contained inside a single long
+					return (v >>> shift) & mask;
+				}
 			}
 		}
 	}
@@ -139,30 +141,32 @@ public abstract class AbstractBit64Type<T extends AbstractBit64Type<T>> extends 
 		final int i1 = (int)(k >>> 6); // k / 64;
 		final long shift = k & 63; // Same as k % 64;
 		final long safeValue = value & mask;
-		if (0 == shift) {
-			// Number contained in a single long, ending exactly at the first bit
-			dataAccess.setValue(i1, (dataAccess.getValue(i1) & invMask) | safeValue);
-		} else {
-			final long antiShift = 64 - shift;
-			final long v = dataAccess.getValue(i1);
-			if (antiShift < nBits) {
-				// Number split between two adjacent longs
-				// 1. Store the lower bits of safeValue at the upper bits of v1
-				final long v1 = (v & (0xffffffffffffffffL >>> antiShift)) // clear upper bits, keep other values
-						| ((safeValue & (mask >>> (nBits - antiShift))) << shift); // the lower part of safeValue, stored at the upper end
-				dataAccess.setValue(i1, v1);
-				// 2. Store the upper bits of safeValue at the lower bits of v2
-				final long v2 = (dataAccess.getValue(i1 + 1) & (0xffffffffffffffffL << (nBits - antiShift))) // other
-						| (safeValue >>> antiShift); // upper part of safeValue, stored at the lower end
-				dataAccess.setValue(i1 + 1, v2);
+		synchronized ( dataAccess ) {
+			if (0 == shift) {
+				// Number contained in a single long, ending exactly at the first bit
+				dataAccess.setValue(i1, (dataAccess.getValue(i1) & invMask) | safeValue);
 			} else {
-				// Number contained inside a single long
-				if (0 == v) {
-					// Trivial case
-					dataAccess.setValue(i1, safeValue << shift);
+				final long antiShift = 64 - shift;
+				final long v = dataAccess.getValue(i1);
+				if (antiShift < nBits) {
+					// Number split between two adjacent longs
+					// 1. Store the lower bits of safeValue at the upper bits of v1
+					final long v1 = (v & (0xffffffffffffffffL >>> antiShift)) // clear upper bits, keep other values
+							| ((safeValue & (mask >>> (nBits - antiShift))) << shift); // the lower part of safeValue, stored at the upper end
+					dataAccess.setValue(i1, v1);
+					// 2. Store the upper bits of safeValue at the lower bits of v2
+					final long v2 = (dataAccess.getValue(i1 + 1) & (0xffffffffffffffffL << (nBits - antiShift))) // other
+							| (safeValue >>> antiShift); // upper part of safeValue, stored at the lower end
+					dataAccess.setValue(i1 + 1, v2);
 				} else {
-					// Clear the bits first
-					dataAccess.setValue(i1, (v & ~(mask << shift)) | (safeValue << shift));
+					// Number contained inside a single long
+					if (0 == v) {
+						// Trivial case
+						dataAccess.setValue(i1, safeValue << shift);
+					} else {
+						// Clear the bits first
+						dataAccess.setValue(i1, (v & ~(mask << shift)) | (safeValue << shift));
+					}
 				}
 			}
 		}

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned12BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned12BitType.java
@@ -128,8 +128,8 @@ public class Unsigned12BitType extends AbstractIntegerBitType<Unsigned12BitType>
 		final long antiShift = 64 - shift;
 		
 		synchronized ( dataAccess ) {
-		final long v = dataAccess.getValue(i1);
-		if (antiShift < 12) {
+			final long v = dataAccess.getValue(i1);
+			if (antiShift < 12) {
 				// Number split between two adjacent longs
 				// 1. Store the lower bits of safeValue at the upper bits of v1
 				final long v1 = (v & (0xffffffffffffffffL >>> antiShift)) // clear upper bits, keep other values

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned12BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned12BitType.java
@@ -100,20 +100,18 @@ public class Unsigned12BitType extends AbstractIntegerBitType<Unsigned12BitType>
 	public long get() {
 		final long k = i * 12;
 		final int i1 = (int)(k >>> 6); // k / 64;
-		final long shift = k & 63; // k % 64;		
+		final long shift = k & 63; // k % 64;
+		final long v = dataAccess.getValue(i1);
 		final long antiShift = 64 - shift;
-		synchronized ( dataAccess ) {
-			final long v = dataAccess.getValue(i1);
-		
-			if (antiShift < 12) {
+
+		if (antiShift < 12) {
 			// Number split between two adjacent long
-				final long v1 = (v >>> shift) & (mask >>> (12 - antiShift)); // lower part, stored at the upper end
-				final long v2 = (dataAccess.getValue(i1 + 1) & (mask >>> antiShift)) << antiShift; // upper part, stored at the lower end
-				return v1 | v2;
-			} else {
+			final long v1 = (v >>> shift) & (mask >>> (12 - antiShift)); // lower part, stored at the upper end
+			final long v2 = (dataAccess.getValue(i1 + 1) & (mask >>> antiShift)) << antiShift; // upper part, stored at the lower end
+			return v1 | v2;
+		} else {
 			// Number contained inside a single long
-				return (v >>> shift) & mask;
-			}
+			return (v >>> shift) & mask;
 		}
 	}
 

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned12BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned12BitType.java
@@ -101,17 +101,19 @@ public class Unsigned12BitType extends AbstractIntegerBitType<Unsigned12BitType>
 		final long k = i * 12;
 		final int i1 = (int)(k >>> 6); // k / 64;
 		final long shift = k & 63; // k % 64;		
-		final long v = dataAccess.getValue(i1);
 		final long antiShift = 64 - shift;
+		synchronized ( dataAccess ) {
+			final long v = dataAccess.getValue(i1);
 		
-		if (antiShift < 12) {
+			if (antiShift < 12) {
 			// Number split between two adjacent long
-			final long v1 = (v >>> shift) & (mask >>> (12 - antiShift)); // lower part, stored at the upper end
-			final long v2 = (dataAccess.getValue(i1 + 1) & (mask >>> antiShift)) << antiShift; // upper part, stored at the lower end
-			return v1 | v2;
-		} else {
+				final long v1 = (v >>> shift) & (mask >>> (12 - antiShift)); // lower part, stored at the upper end
+				final long v2 = (dataAccess.getValue(i1 + 1) & (mask >>> antiShift)) << antiShift; // upper part, stored at the lower end
+				return v1 | v2;
+			} else {
 			// Number contained inside a single long
-			return (v >>> shift) & mask;
+				return (v >>> shift) & mask;
+			}
 		}
 	}
 
@@ -124,25 +126,28 @@ public class Unsigned12BitType extends AbstractIntegerBitType<Unsigned12BitType>
 		final long safeValue = value & mask;
 
 		final long antiShift = 64 - shift;
+		
+		synchronized ( dataAccess ) {
 		final long v = dataAccess.getValue(i1);
 		if (antiShift < 12) {
-			// Number split between two adjacent longs
-			// 1. Store the lower bits of safeValue at the upper bits of v1
-			final long v1 = (v & (0xffffffffffffffffL >>> antiShift)) // clear upper bits, keep other values
-					| ((safeValue & (mask >>> (12 - antiShift))) << shift); // the lower part of safeValue, stored at the upper end
-			dataAccess.setValue(i1, v1);
-			// 2. Store the upper bits of safeValue at the lower bits of v2
-			final long v2 = (dataAccess.getValue(i1 + 1) & (0xffffffffffffffffL << (12 - antiShift))) // other
-					| (safeValue >>> antiShift); // upper part of safeValue, stored at the lower end
-			dataAccess.setValue(i1 + 1, v2);
-		} else {
-			// Number contained inside a single long
-			if (0 == v) {
-				// Trivial case
-				dataAccess.setValue(i1, safeValue << shift);
+				// Number split between two adjacent longs
+				// 1. Store the lower bits of safeValue at the upper bits of v1
+				final long v1 = (v & (0xffffffffffffffffL >>> antiShift)) // clear upper bits, keep other values
+						| ((safeValue & (mask >>> (12 - antiShift))) << shift); // the lower part of safeValue, stored at the upper end
+				dataAccess.setValue(i1, v1);
+				// 2. Store the upper bits of safeValue at the lower bits of v2
+				final long v2 = (dataAccess.getValue(i1 + 1) & (0xffffffffffffffffL << (12 - antiShift))) // other
+						| (safeValue >>> antiShift); // upper part of safeValue, stored at the lower end
+				dataAccess.setValue(i1 + 1, v2);
 			} else {
-				// Clear the bits first
-				dataAccess.setValue(i1, (v & ~(mask << shift)) | (safeValue << shift));
+				// Number contained inside a single long
+				if (0 == v) {
+					// Trivial case
+					dataAccess.setValue(i1, safeValue << shift);
+				} else {
+					// Clear the bits first
+					dataAccess.setValue(i1, (v & ~(mask << shift)) | (safeValue << shift));
+				}
 			}
 		}
 	}

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned2BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned2BitType.java
@@ -110,9 +110,7 @@ public class Unsigned2BitType extends AbstractIntegerBitType<Unsigned2BitType>
 		//return (dataAccess.getValue((int)(i >>> 5)) >>> ((i % 32) << 1)) & mask;
 		// Even less operations
 		// div 32 == shr 5
-		synchronized ( dataAccess ) {
-			return (dataAccess.getValue((int)(i >>> 5)) >>> ((i & 31) << 1)) & mask;
-		}
+		return (dataAccess.getValue((int)(i >>> 5)) >>> ((i & 31) << 1)) & mask;
 	}
 
 	// Crops value to within mask

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned2BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned2BitType.java
@@ -110,7 +110,9 @@ public class Unsigned2BitType extends AbstractIntegerBitType<Unsigned2BitType>
 		//return (dataAccess.getValue((int)(i >>> 5)) >>> ((i % 32) << 1)) & mask;
 		// Even less operations
 		// div 32 == shr 5
-		return (dataAccess.getValue((int)(i >>> 5)) >>> ((i & 31) << 1)) & mask;
+		synchronized ( dataAccess ) {
+			return (dataAccess.getValue((int)(i >>> 5)) >>> ((i & 31) << 1)) & mask;
+		}
 	}
 
 	// Crops value to within mask
@@ -125,7 +127,10 @@ public class Unsigned2BitType extends AbstractIntegerBitType<Unsigned2BitType>
 		final int i1 = (int)(i >>> 5); // Same as (i * 2) / 64 = (i << 1) >>> 6
 		final long shift = (i << 1) & 63; // Same as (i * 2) % 64
 		// Clear the bits first, then or the masked value
-		dataAccess.setValue(i1, (dataAccess.getValue(i1) & ~(mask << shift)) | ((value & mask) << shift));
+		
+		synchronized ( dataAccess ) {
+			dataAccess.setValue(i1, (dataAccess.getValue(i1) & ~(mask << shift)) | ((value & mask) << shift));
+		}
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned2BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned2BitType.java
@@ -127,9 +127,11 @@ public class Unsigned2BitType extends AbstractIntegerBitType<Unsigned2BitType>
 		final int i1 = (int)(i >>> 5); // Same as (i * 2) / 64 = (i << 1) >>> 6
 		final long shift = (i << 1) & 63; // Same as (i * 2) % 64
 		// Clear the bits first, then or the masked value
-		
+
+		final long bitsToRetain = ~(mask << shift);
+		final long bitsToSet = (value & mask) << shift;
 		synchronized ( dataAccess ) {
-			dataAccess.setValue(i1, (dataAccess.getValue(i1) & ~(mask << shift)) | ((value & mask) << shift));
+			dataAccess.setValue(i1, (dataAccess.getValue(i1) & bitsToRetain) | bitsToSet);
 		}
 	}
 

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
@@ -45,7 +45,7 @@ import net.imglib2.type.Type;
 import net.imglib2.util.Fraction;
 
 /**
- * A {@link Type} with a bit depth of 2.
+ * A {@link Type} with a bit depth of 4.
  * 
  * The performance of this type is traded off for the gain in memory storage.
  * 

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
@@ -102,9 +102,7 @@ public class Unsigned4BitType extends AbstractIntegerBitType<Unsigned4BitType>
 
 	@Override
 	public long get() {
-		synchronized ( dataAccess ) {
-			return (dataAccess.getValue((int)(i >>> 4)) >>> ((i & 15) << 2)) & mask;
-		}
+		return (dataAccess.getValue((int)(i >>> 4)) >>> ((i & 15) << 2)) & mask;
 	}
 
 	// Crops value to within mask

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
@@ -102,7 +102,9 @@ public class Unsigned4BitType extends AbstractIntegerBitType<Unsigned4BitType>
 
 	@Override
 	public long get() {
-		return (dataAccess.getValue((int)(i >>> 4)) >>> ((i & 15) << 2)) & mask;
+		synchronized ( dataAccess ) {
+			return (dataAccess.getValue((int)(i >>> 4)) >>> ((i & 15) << 2)) & mask;
+		}
 	}
 
 	// Crops value to within mask
@@ -117,7 +119,10 @@ public class Unsigned4BitType extends AbstractIntegerBitType<Unsigned4BitType>
 		final int i1 = (int)(i >>> 4); //  Same as (i * 4) / 64 = ((i << 2) >>> 6)
 		final long shift = (i << 2) & 63; // Same as (i * 4) % 64
 		// Clear the bits first, then or the masked value
-		dataAccess.setValue(i1, (dataAccess.getValue(i1) & ~(mask << shift)) | ((value & mask) << shift));
+		
+		synchronized ( dataAccess ) {
+			dataAccess.setValue(i1, (dataAccess.getValue(i1) & ~(mask << shift)) | ((value & mask) << shift));
+		}
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
@@ -119,9 +119,11 @@ public class Unsigned4BitType extends AbstractIntegerBitType<Unsigned4BitType>
 		final int i1 = (int)(i >>> 4); //  Same as (i * 4) / 64 = ((i << 2) >>> 6)
 		final long shift = (i << 2) & 63; // Same as (i * 4) % 64
 		// Clear the bits first, then or the masked value
-		
+
+		final long bitsToRetain = ~(mask << shift);
+		final long bitsToSet = (value & mask) << shift;
 		synchronized ( dataAccess ) {
-			dataAccess.setValue(i1, (dataAccess.getValue(i1) & ~(mask << shift)) | ((value & mask) << shift));
+			dataAccess.setValue(i1, (dataAccess.getValue(i1) & bitsToRetain) | bitsToSet);
 		}
 	}
 


### PR DESCRIPTION
parallel access on these types caused problems. it was fixed for BitType, but not for the remaining types.

See https://github.com/imglib/imglib2/tree/synchronized-bit-access for details.