### PR TITLE
ImgView: add static wrap method to represent a RAI as an Img

### DIFF
--- a/src/main/java/net/imglib2/img/ImgView.java
+++ b/src/main/java/net/imglib2/img/ImgView.java
@@ -65,11 +65,15 @@ public class ImgView< T extends Type< T > > extends
 	 * View on {@link Img} which is defined by a given Interval, but still is an
 	 * {@link Img}.
 	 * 
+	 * Deprecation: Use {@link ImgView#wrap(RandomAccessibleInterval, ImgFactory)} 
+	 * to represent a RandomAccessibleInterval as an Img
+	 * 
 	 * @param in
 	 *            Source interval for the view
 	 * @param fac
 	 *            <T> Factory to create img
 	 */
+	@Deprecated
 	public ImgView( final RandomAccessibleInterval< T > in, final ImgFactory< T > fac )
 	{
 		super( in );
@@ -153,5 +157,23 @@ public class ImgView< T extends Type< T > > extends
 		else
 			return Views.interval( this.sourceInterval, interval )
 					.localizingCursor();
+	}
+	
+	/**
+	 * Represent an arbitrary RandomAccessibleInterval as an Img
+	 * 
+	 * @param accessible 
+	 * 			RandomAccessibleInterval which will be wrapped with an ImgView
+	 * @param factory
+	 * 			ImgFactory returned by {@link ImgView#factory()}
+	 * @return
+	 * 			RandomAccessibleInterval represented as an Img
+	 */
+	public static < T extends Type< T >> Img< T > wrap(RandomAccessibleInterval< T > accessible, final ImgFactory< T > factory){
+		if(accessible instanceof Img){
+			return (Img<T>) accessible;
+		}else{
+			return new ImgView< T >(accessible, factory);
+		}
 	}
 }


### PR DESCRIPTION
The methods makes sure, that we only wrap a RandomAccessibleInterval if
its not already an Img