### PR TITLE
Added permuteCoordinates,

### DIFF
--- a/src/main/java/net/imglib2/transform/integer/permutation/AbstractPermutationTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/permutation/AbstractPermutationTransform.java
@@ -1,0 +1,103 @@
+/**
+ *
+ */
+package net.imglib2.transform.integer.permutation;
+
+import net.imglib2.transform.InvertibleTransform;
+
+/**
+ * Bijective integer transform mapping between integer coordinates in [0,n-1].
+ * Currently, this transform handles only coordinates in the integer range
+ * because it is implemented using primitive arrays with integer indices for
+ * efficiency reasons.  Expect this permutation to be transferred to long
+ * coordinates some time in more distant future.
+ *
+ * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>
+ * @author Stephan Saalfeld <saalfelds@janelia.hhmi.org>
+ */
+public abstract class AbstractPermutationTransform implements InvertibleTransform
+{
+
+	final protected int[] lut;
+
+	final protected int[] inverseLut;
+
+	/**
+	 * @param lut
+	 *            must be a bijective permutation over its index set, i.e. for a
+	 *            lut of length n, the sorted content of the array must be
+	 *            [0,...,n-1] which is the index set of the lut.
+	 * @param numSourceDimensions
+	 * @param numTargetDimensions
+	 */
+	public AbstractPermutationTransform( final int[] lut )
+	{
+		super();
+		this.lut = lut.clone();
+
+		this.inverseLut = new int[ lut.length ];
+		for ( int i = 0; i < lut.length; ++i )
+			this.inverseLut[ lut[ i ] ] = i;
+	}
+
+	public int apply( final int x )
+	{
+		return this.lut[ x ];
+	}
+
+	public long applyChecked( final int x )
+	{
+		if ( x < 0 )
+			return -Long.MAX_VALUE;
+		else if ( x >= this.lut.length )
+			return Long.MAX_VALUE;
+		else
+			return this.apply( x );
+	}
+
+	public int applyInverse( final int y )
+	{
+		return this.inverseLut[ y ];
+	}
+
+	public long applyInverseChecked( final int y )
+	{
+		if ( y < 0 )
+			return -Long.MAX_VALUE;
+		else if ( y >= this.lut.length )
+			return Long.MAX_VALUE;
+		else
+			return this.applyInverse( y );
+	}
+
+	public int[] getLutCopy()
+	{
+		return this.lut.clone();
+	}
+
+	public int[] getInverseLutCopy()
+	{
+		return this.inverseLut.clone();
+	}
+
+	final static public boolean checkBijectivity( final int[] lut )
+	{
+		final int[] inverseLut = new int[ lut.length ];
+		try
+		{
+			for ( int i = 0; i < lut.length; ++i )
+				inverseLut[ i ] = -1;
+			for ( int i = 0; i < lut.length; ++i )
+				inverseLut[ lut[ i ] ] = i;
+			for ( int i = 0; i < lut.length; ++i )
+				if ( inverseLut[ i ] == -1 )
+					return false;
+			return true;
+		}
+		catch ( final ArrayIndexOutOfBoundsException e )
+		{
+			return false;
+		}
+	}
+
+}

--- a/src/main/java/net/imglib2/transform/integer/permutation/PermutationTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/permutation/PermutationTransform.java
@@ -1,0 +1,130 @@
+/**
+ *
+ */
+package net.imglib2.transform.integer.permutation;
+
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+
+/**
+ * Bijective integer transform mapping between integer coordinates in [0,n-1].
+ *
+ * @author Stephan Saalfeld <saalfelds@janelia.hhmi.org>
+ * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>
+ */
+public class PermutationTransform extends AbstractPermutationTransform
+{
+	final protected int numSourceDimensions;
+
+	final protected int numTargetDimensions;
+
+	/**
+	 *
+	 * @param lut
+	 *            must be a bijective permutation over its index set, i.e. for a
+	 *            lut of length <em>n</em>, the sorted content the array must be
+	 *            [0,...,n-1] which is the index set of the lut.
+	 * @param numSourceDimensions
+	 * @param numTargetDimensions
+	 */
+	public PermutationTransform( final int[] lut, final int numSourceDimensions, final int numTargetDimensions )
+	{
+		super( lut );
+		this.numSourceDimensions = numSourceDimensions;
+		this.numTargetDimensions = numTargetDimensions;
+
+	}
+
+	@Override
+	public int numSourceDimensions()
+	{
+		return this.numSourceDimensions;
+	}
+
+	@Override
+	public int numTargetDimensions()
+	{
+		return this.numTargetDimensions;
+	}
+
+	@Override
+	public void apply( final long[] source, final long[] target )
+	{
+		assert source.length >= this.numTargetDimensions && target.length >= this.numTargetDimensions: "Dimensions do not match.";
+
+		for ( int d = 0; d < this.numTargetDimensions; ++d )
+			target[ d ] = this.apply( ( int ) source[ d ] );
+	}
+
+	@Override
+	public void apply( final int[] source, final int[] target )
+	{
+		assert source.length >= this.numTargetDimensions && target.length >= this.numTargetDimensions: "Dimensions do not match.";
+
+		for ( int d = 0; d < this.numTargetDimensions; ++d )
+			target[ d ] = this.apply( this.lut[ source[ d ] ] );
+	}
+
+	@Override
+	public void apply( final Localizable source, final Positionable target )
+	{
+		assert source.numDimensions() >= this.numTargetDimensions && target.numDimensions() >= this.numTargetDimensions: "Dimensions do not match.";
+
+		for ( int d = 0; d < this.numTargetDimensions; ++d )
+			target.setPosition( this.apply( source.getIntPosition( d ) ), d );
+	}
+
+	@Override
+	public void applyInverse( final long[] source, final long[] target )
+	{
+		assert source.length >= this.numSourceDimensions && target.length >= this.numSourceDimensions: "Dimensions do not match.";
+
+		for ( int d = 0; d < this.numSourceDimensions; ++d )
+			source[ d ] = this.applyInverse( ( int ) target[ d ] );
+	}
+
+	@Override
+	public void applyInverse( final int[] source, final int[] target )
+	{
+		assert source.length >= this.numSourceDimensions && target.length >= this.numSourceDimensions: "Dimensions do not match.";
+
+		for ( int d = 0; d < this.numSourceDimensions; ++d )
+			source[ d ] = this.applyInverse( target[ d ] );
+	}
+
+	@Override
+	public void applyInverse( final Positionable source, final Localizable target )
+	{
+		assert source.numDimensions() >= this.numSourceDimensions && target.numDimensions() >= this.numSourceDimensions: "Dimensions do not match.";
+
+		for ( int d = 0; d < this.numSourceDimensions; ++d )
+			source.setPosition( this.applyInverse( target.getIntPosition( d ) ), d );
+	}
+
+	@Override
+	public PermutationTransform inverse()
+	{
+		return new PermutationTransform( this.inverseLut, this.numTargetDimensions, this.numSourceDimensions );
+	}
+
+	/**
+	 * Test whether a given lut can be applied to an interval. This means that
+	 * the interval is a hypercube at min = 0<sup><em>n</em></sup> with size =
+	 * lut.length.
+	 *
+	 * @param interval
+	 * @param lut
+	 * @return
+	 */
+	static public boolean checkInterval( final Interval interval, final int[] lut )
+	{
+		for ( int d = 0; d < interval.numDimensions(); ++d )
+		{
+			if ( !( interval.min( d ) == 0 && interval.dimension( d ) == lut.length ) )
+				return false;
+		}
+		return true;
+	}
+
+}

--- a/src/main/java/net/imglib2/transform/integer/permutation/SingleDimensionPermutationTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/permutation/SingleDimensionPermutationTransform.java
@@ -1,0 +1,107 @@
+/**
+ *
+ */
+package net.imglib2.transform.integer.permutation;
+
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+
+/**
+ * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>
+ *
+ *         Apply bijective permutation to one coordinate axis only.
+ *
+ */
+public class SingleDimensionPermutationTransform extends AbstractPermutationTransform
+{
+
+	final protected int numSourceDimensions;
+
+	final protected int numTargetDimensions;
+
+	final protected int d;
+
+	/**
+	 * @param lut
+	 * @param numSourceDimensions
+	 *            dimensionality of source
+	 * @param numTargetDimensions
+	 *            dimensionality of target
+	 * @param d
+	 *            dimension which shall be transformed. Must be smaller than
+	 *            {@link #numSourceDimensions} and {@link #numTargetDimensions}
+	 */
+	public SingleDimensionPermutationTransform(
+			final int[] lut,
+			final int numSourceDimensions,
+			final int numTargetDimensions,
+			final int d )
+	{
+		super( lut );
+		assert d > 0 && d < numTargetDimensions && d < numSourceDimensions;
+		this.numSourceDimensions = numSourceDimensions;
+		this.numTargetDimensions = numTargetDimensions;
+		this.d = d;
+	}
+
+	@Override
+	public void applyInverse( final long[] source, final long[] target )
+	{
+		System.arraycopy( target, 0, source, 0, this.numSourceDimensions );
+		source[ this.d ] = this.applyInverse( ( int ) target[ this.d ] );
+	}
+
+	@Override
+	public void applyInverse( final int[] source, final int[] target )
+	{
+		System.arraycopy( target, 0, source, 0, this.numSourceDimensions );
+		source[ this.d ] = this.applyInverse( target[ this.d ] );
+	}
+
+	@Override
+	public void applyInverse( final Positionable source, final Localizable target )
+	{
+		source.setPosition( target );
+		source.setPosition( this.applyInverse( target.getIntPosition( this.d ) ), this.d );
+	}
+
+	@Override
+	public SingleDimensionPermutationTransform inverse()
+	{
+		return new SingleDimensionPermutationTransform( this.inverseLut, this.numSourceDimensions, this.numTargetDimensions, this.d );
+	}
+
+	@Override
+	public int numSourceDimensions()
+	{
+		return this.numSourceDimensions;
+	}
+
+	@Override
+	public int numTargetDimensions()
+	{
+		return this.numTargetDimensions;
+	}
+
+	@Override
+	public void apply( final long[] source, final long[] target )
+	{
+		System.arraycopy( source, 0, target, 0, this.numTargetDimensions );
+		target[ this.d ] = this.apply( ( int ) source[ this.d ] );
+	}
+
+	@Override
+	public void apply( final int[] source, final int[] target )
+	{
+		System.arraycopy( source, 0, target, 0, this.numTargetDimensions );
+		target[ this.d ] = this.apply( source[ this.d ] );
+	}
+
+	@Override
+	public void apply( final Localizable source, final Positionable target )
+	{
+		target.setPosition( source );
+		target.setPosition( this.apply( source.getIntPosition( this.d ) ), this.d );
+	}
+
+}

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -57,6 +57,9 @@ import net.imglib2.outofbounds.OutOfBoundsPeriodicFactory;
 import net.imglib2.outofbounds.OutOfBoundsRandomValueFactory;
 import net.imglib2.transform.integer.BoundingBox;
 import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.transform.integer.permutation.AbstractPermutationTransform;
+import net.imglib2.transform.integer.permutation.PermutationTransform;
+import net.imglib2.transform.integer.permutation.SingleDimensionPermutationTransform;
 import net.imglib2.transform.integer.shear.InverseShearTransform;
 import net.imglib2.transform.integer.shear.ShearTransform;
 import net.imglib2.type.Type;
@@ -72,23 +75,23 @@ import net.imglib2.view.composite.RealComposite;
 
 /**
  * Create light-weight views into {@link RandomAccessible RandomAccessibles}.
- * 
+ *
  * A view is itself a {@link RandomAccessible} or
  * {@link RandomAccessibleInterval} that provides {@link RandomAccess accessors}
  * that transform coordinates on-the-fly without copying the underlying data.
  * Consecutive transformations are concatenated and simplified to provide
  * optimally efficient accessors. Note, that accessors provided by a view are
  * read/write. Changing pixels in a view changes the underlying image data.
- * 
+ *
  * @author Tobias Pietzsch <tobias.pietzsch@gmail.com>
- * @author Stephan Saalfeld
+ * @author Stephan Saalfeld <saalfelds@janelia.hhmi.org>
  * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>
  */
 public class Views
 {
 	/**
 	 * Returns a {@link RealRandomAccessible} using interpolation
-	 * 
+	 *
 	 * @param source
 	 *            the {@link EuclideanSpace} to be interpolated
 	 * @param factory
@@ -104,10 +107,10 @@ public class Views
 	/**
 	 * Turns a {@link RealRandomAccessible} into a {@link RandomAccessible},
 	 * providing {@link RandomAccess} at integer coordinates.
-	 * 
+	 *
 	 * @see #interpolate(net.imglib2.EuclideanSpace,
 	 *      net.imglib2.interpolation.InterpolatorFactory)
-	 * 
+	 *
 	 * @param source
 	 *            the {@link RealRandomAccessible} to be rasterized.
 	 * @return a {@link RandomAccessibleOnRealRandomAccessible} wrapping source.
@@ -119,7 +122,7 @@ public class Views
 
 	/**
 	 * Extend a RandomAccessibleInterval with an out-of-bounds strategy.
-	 * 
+	 *
 	 * @param source
 	 *            the interval to extend.
 	 * @param factory
@@ -134,9 +137,9 @@ public class Views
 
 	/**
 	 * Extend a RandomAccessibleInterval with a mirroring out-of-bounds
-	 * strategy. Boundary pixels are not repeated.  Note that this requires
-	 * that all dimensions of the source (F source) must be &gt; 1.
-	 * 
+	 * strategy. Boundary pixels are not repeated. Note that this requires that
+	 * all dimensions of the source (F source) must be &gt; 1.
+	 *
 	 * @param source
 	 *            the interval to extend.
 	 * @return (unbounded) RandomAccessible which extends the input interval to
@@ -151,7 +154,7 @@ public class Views
 	/**
 	 * Extend a RandomAccessibleInterval with a mirroring out-of-bounds
 	 * strategy. Boundary pixels are repeated.
-	 * 
+	 *
 	 * @param source
 	 *            the interval to extend.
 	 * @return (unbounded) RandomAccessible which extends the input interval to
@@ -166,7 +169,7 @@ public class Views
 	/**
 	 * Extend a RandomAccessibleInterval with a constant-value out-of-bounds
 	 * strategy.
-	 * 
+	 *
 	 * @param source
 	 *            the interval to extend.
 	 * @return (unbounded) RandomAccessible which extends the input interval to
@@ -181,7 +184,7 @@ public class Views
 	/**
 	 * Extend a RandomAccessibleInterval with a constant-value out-of-bounds
 	 * strategy where the constant value is the zero-element of the data type.
-	 * 
+	 *
 	 * @param source
 	 *            the interval to extend.
 	 * @return (unbounded) RandomAccessible which extends the input interval to
@@ -198,7 +201,7 @@ public class Views
 	/**
 	 * Extend a RandomAccessibleInterval with a random-value out-of-bounds
 	 * strategy.
-	 * 
+	 *
 	 * @param source
 	 *            the interval to extend.
 	 * @param min
@@ -216,7 +219,7 @@ public class Views
 
 	/**
 	 * Extend a RandomAccessibleInterval with a periodic out-of-bounds strategy.
-	 * 
+	 *
 	 * @param source
 	 *            the interval to extend.
 	 * @return (unbounded) RandomAccessible which extends the input interval to
@@ -231,7 +234,7 @@ public class Views
 	/**
 	 * Extend a RandomAccessibleInterval with an out-of-bounds strategy to
 	 * repeat border pixels.
-	 * 
+	 *
 	 * @param source
 	 *            the interval to extend.
 	 * @return (unbounded) RandomAccessible which extends the input interval to
@@ -247,7 +250,7 @@ public class Views
 	 * Define an interval on a RandomAccessible. It is the callers
 	 * responsibility to ensure that the source RandomAccessible is defined in
 	 * the specified interval.
-	 * 
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 * @param min
@@ -265,7 +268,7 @@ public class Views
 	 * Define an interval on a RandomAccessible. It is the callers
 	 * responsibility to ensure that the source RandomAccessible is defined in
 	 * the specified interval.
-	 * 
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 * @param interval
@@ -280,11 +283,11 @@ public class Views
 	/**
 	 * Create view that is rotated by 90 degrees. The rotation is specified by
 	 * the fromAxis and toAxis arguments.
-	 * 
+	 *
 	 * If fromAxis=0 and toAxis=1, this means that the X-axis of the source view
 	 * is mapped to the Y-Axis of the rotated view. That is, it corresponds to a
 	 * 90 degree clock-wise rotation of the source view in the XY plane.
-	 * 
+	 *
 	 * fromAxis=1 and toAxis=0 corresponds to a counter-clock-wise rotation in
 	 * the XY plane.
 	 */
@@ -321,11 +324,11 @@ public class Views
 	/**
 	 * Create view that is rotated by 90 degrees. The rotation is specified by
 	 * the fromAxis and toAxis arguments.
-	 * 
+	 *
 	 * If fromAxis=0 and toAxis=1, this means that the X-axis of the source view
 	 * is mapped to the Y-Axis of the rotated view. That is, it corresponds to a
 	 * 90 degree clock-wise rotation of the source view in the XY plane.
-	 * 
+	 *
 	 * fromAxis=1 and toAxis=0 corresponds to a counter-clock-wise rotation in
 	 * the XY plane.
 	 */
@@ -345,12 +348,12 @@ public class Views
 			min[ fromAxis ] = fromMinNew;
 			max[ fromAxis ] = fromMaxNew;
 		}
-		return interval( rotate( ( RandomAccessible< T > ) interval, fromAxis, toAxis ), min, max );
+		return Views.interval( Views.rotate( ( RandomAccessible< T > ) interval, fromAxis, toAxis ), min, max );
 	}
 
 	/**
 	 * Create view with permuted axes. fromAxis and toAxis are swapped.
-	 * 
+	 *
 	 * If fromAxis=0 and toAxis=2, this means that the X-axis of the source view
 	 * is mapped to the Z-Axis of the permuted view and vice versa. For a XYZ
 	 * source, a ZYX view would be created.
@@ -370,7 +373,7 @@ public class Views
 
 	/**
 	 * Create view with permuted axes. fromAxis and toAxis are swapped.
-	 * 
+	 *
 	 * If fromAxis=0 and toAxis=2, this means that the X-axis of the source view
 	 * is mapped to the Z-Axis of the permuted view and vice versa. For a XYZ
 	 * source, a ZYX view would be created.
@@ -388,14 +391,14 @@ public class Views
 		max[ toAxis ] = max[ fromAxis ];
 		min[ fromAxis ] = fromMinNew;
 		max[ fromAxis ] = fromMaxNew;
-		return interval( permute( ( RandomAccessible< T > ) interval, fromAxis, toAxis ), min, max );
+		return Views.interval( Views.permute( ( RandomAccessible< T > ) interval, fromAxis, toAxis ), min, max );
 	}
 
 	/**
 	 * Translate the source view by the given translation vector. Pixel
 	 * <em>x</em> in the source view has coordinates <em>(x + translation)</em>
 	 * in the resulting view.
-	 * 
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 * @param translation
@@ -415,7 +418,7 @@ public class Views
 	 * Translate the source view by the given translation vector. Pixel
 	 * <em>x</em> in the source view has coordinates <em>(x + translation)</em>
 	 * in the resulting view.
-	 * 
+	 *
 	 * @param interval
 	 *            the source
 	 * @param translation
@@ -435,13 +438,13 @@ public class Views
 			min[ d ] += translation[ d ];
 			max[ d ] += translation[ d ];
 		}
-		return interval( translate( ( RandomAccessible< T > ) interval, translation ), min, max );
+		return Views.interval( Views.translate( ( RandomAccessible< T > ) interval, translation ), min, max );
 	}
 
 	/**
 	 * Translate such that pixel at offset in randomAccessible is at the origin
 	 * in the resulting view. This is equivalent to translating by -offset.
-	 * 
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 * @param offset
@@ -459,7 +462,7 @@ public class Views
 	/**
 	 * Translate such that pixel at offset in interval is at the origin in the
 	 * resulting view. This is equivalent to translating by -offset.
-	 * 
+	 *
 	 * @param interval
 	 *            the source
 	 * @param offset
@@ -478,12 +481,12 @@ public class Views
 			min[ d ] -= offset[ d ];
 			max[ d ] -= offset[ d ];
 		}
-		return interval( offset( ( RandomAccessible< T > ) interval, offset ), min, max );
+		return Views.interval( Views.offset( ( RandomAccessible< T > ) interval, offset ), min, max );
 	}
 
 	/**
 	 * Translate the source such that the upper left corner is at the origin
-	 * 
+	 *
 	 * @param interval
 	 *            the source.
 	 * @return view of the source translated to the origin
@@ -500,7 +503,7 @@ public class Views
 			max[ d ] -= offset[ d ];
 		final MixedTransform t = new MixedTransform( n, n );
 		t.setTranslation( offset );
-		return interval( new MixedTransformView< T >( interval, t ), min, max );
+		return Views.interval( new MixedTransformView< T >( interval, t ), min, max );
 	}
 
 	/**
@@ -563,17 +566,17 @@ public class Views
 				max[ e - 1 ] = view.max( e );
 			}
 		}
-		return interval( hyperSlice( ( RandomAccessible< T > ) view, d, pos ), min, max );
+		return Views.interval( Views.hyperSlice( ( RandomAccessible< T > ) view, d, pos ), min, max );
 	}
 
 	/**
 	 * Create view which adds a dimension to the source {@link RandomAccessible}
 	 * .
-	 * 
+	 *
 	 * The additional dimension is the last dimension. For example, an XYZ view
 	 * is created for an XY source. When accessing an XYZ sample in the view,
 	 * the final coordinate is discarded and the source XY sample is accessed.
-	 * 
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 */
@@ -589,11 +592,11 @@ public class Views
 	 * Create view which adds a dimension to the source
 	 * {@link RandomAccessibleInterval}. The {@link Interval} boundaries in the
 	 * additional dimension are set to the specified values.
-	 * 
+	 *
 	 * The additional dimension is the last dimension. For example, an XYZ view
 	 * is created for an XY source. When accessing an XYZ sample in the view,
 	 * the final coordinate is discarded and the source XY sample is accessed.
-	 * 
+	 *
 	 * @param interval
 	 *            the source
 	 * @param minOfNewDim
@@ -613,12 +616,12 @@ public class Views
 		}
 		min[ m ] = minOfNewDim;
 		max[ m ] = maxOfNewDim;
-		return interval( addDimension( interval ), min, max );
+		return Views.interval( Views.addDimension( interval ), min, max );
 	}
 
 	/**
 	 * Invert the d-axis.
-	 * 
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 * @param d
@@ -636,7 +639,7 @@ public class Views
 
 	/**
 	 * Invert the d-axis.
-	 * 
+	 *
 	 * @param interval
 	 *            the source
 	 * @param d
@@ -652,14 +655,14 @@ public class Views
 		final long tmp = min[ d ];
 		min[ d ] = -max[ d ];
 		max[ d ] = -tmp;
-		return interval( invertAxis( ( RandomAccessible< T > ) interval, d ), min, max );
+		return Views.interval( Views.invertAxis( ( RandomAccessible< T > ) interval, d ), min, max );
 	}
 
 	/**
 	 * Define an interval on a RandomAccessible and translate it such that the
 	 * min corner is at the origin. It is the callers responsibility to ensure
 	 * that the source RandomAccessible is defined in the specified interval.
-	 * 
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 * @param offset
@@ -675,14 +678,14 @@ public class Views
 		final long[] max = new long[ n ];
 		for ( int d = 0; d < n; ++d )
 			max[ d ] = dimension[ d ] - 1;
-		return interval( offset( randomAccessible, offset ), min, max );
+		return Views.interval( Views.offset( randomAccessible, offset ), min, max );
 	}
 
 	/**
 	 * Define an interval on a RandomAccessible and translate it such that the
 	 * min corner is at the origin. It is the callers responsibility to ensure
 	 * that the source RandomAccessible is defined in the specified interval.
-	 * 
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 * @param interval
@@ -700,12 +703,12 @@ public class Views
 		interval.max( max );
 		for ( int d = 0; d < n; ++d )
 			max[ d ] -= offset[ d ];
-		return interval( offset( randomAccessible, offset ), min, max );
+		return Views.interval( Views.offset( randomAccessible, offset ), min, max );
 	}
 
 	/**
 	 * test whether the source interval starts at (0,0,...,0)
-	 * 
+	 *
 	 * @param interval
 	 *            - the {@link Interval} to test
 	 * @return true if zero-bounded, false otherwise
@@ -724,7 +727,7 @@ public class Views
 	 * {@link RandomAccessibleInterval} is already an {@link IterableInterval}
 	 * then it is returned directly (this is the case for {@link Img}). If not,
 	 * then an {@link IterableRandomAccessibleInterval} is created.
-	 * 
+	 *
 	 * @param randomAccessibleInterval
 	 *            the source
 	 * @return an {@link IterableInterval}
@@ -743,7 +746,7 @@ public class Views
 	 * {@link IterableInterval} with {@link FlatIterationOrder} then it is
 	 * returned directly (this is the case for {@link ArrayImg}). If not, then
 	 * an {@link IterableRandomAccessibleInterval} is created.
-	 * 
+	 *
 	 * @param randomAccessibleInterval
 	 *            the source
 	 * @return an {@link IterableInterval} with {@link FlatIterationOrder}
@@ -761,7 +764,7 @@ public class Views
 	 * -dimensional {@link RandomAccessibleInterval}&lt;T&gt; into an (
 	 * <em>n</em>-1)-dimensional {@link RandomAccessibleInterval}&lt;
 	 * {@link GenericComposite}&lt;T&gt;&gt;
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @return an (<em>n</em>-1)-dimensional {@link CompositeIntervalView} of
@@ -777,7 +780,7 @@ public class Views
 	 * -dimensional {@link RandomAccessibleInterval}&lt;T extends
 	 * {@link RealType}&lt;T&gt;&gt; into an (<em>n</em>-1)-dimensional
 	 * {@link RandomAccessibleInterval}&lt;{@link RealComposite}&lt;T&gt;&gt;
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @return an (<em>n</em>-1)-dimensional {@link CompositeIntervalView} of
@@ -793,7 +796,7 @@ public class Views
 	 * -dimensional {@link RandomAccessibleInterval}&lt;T extends
 	 * {@link NumericType}&lt;T&gt;&gt; into an (<em>n</em>-1)-dimensional
 	 * {@link RandomAccessibleInterval}&lt;{@link NumericComposite}&lt;T&gt;&gt;
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @return an (<em>n</em>-1)-dimensional {@link CompositeIntervalView} of
@@ -809,7 +812,7 @@ public class Views
 	 * -dimensional {@link RandomAccessible}&lt;T&gt; into an (<em>n</em>
 	 * -1)-dimensional {@link RandomAccessible}&lt;{@link GenericComposite}
 	 * &lt;T&gt;&gt;
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @return an (<em>n</em>-1)-dimensional {@link CompositeView} of
@@ -825,7 +828,7 @@ public class Views
 	 * -dimensional {@link RandomAccessible}&lt;T extends {@link RealType}
 	 * &lt;T&gt;&gt; into an (<em>n</em>-1)-dimensional {@link RandomAccessible}
 	 * &lt;{@link RealComposite}&lt;T&gt;&gt;
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @param numChannels
@@ -844,7 +847,7 @@ public class Views
 	 * -dimensional {@link RandomAccessible}&lt;T extends {@link NumericType}
 	 * &lt;T&gt;&gt; into an (<em>n</em>-1)-dimensional {@link RandomAccessible}
 	 * &lt;{@link NumericComposite}&lt;T&gt;&gt;
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @param numChannels
@@ -862,7 +865,7 @@ public class Views
 	 * Sample only every <em>step</em><sup>th</sup> value of a source
 	 * {@link RandomAccessibleInterval}. This is effectively an integer scaling
 	 * and zero offset transformation.
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @param step
@@ -879,7 +882,7 @@ public class Views
 	 * Sample only every <em>step<sub>d</sub></em><sup>th</sup> value of a
 	 * source {@link RandomAccessibleInterval}. This is effectively an integer
 	 * scaling and zero offset transformation.
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @param steps
@@ -898,13 +901,13 @@ public class Views
 	 * Sample only every <em>step</em><sup>th</sup> value of a source
 	 * {@link RandomAccessible}. This is effectively an integer scaling
 	 * transformation.
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @param step
 	 *            the subsampling step size
 	 * @return a subsampled {@link RandomAccessible}
-	 * 
+	 *
 	 */
 	public static < T > SubsampleView< T > subsample( final RandomAccessible< T > source, final long step )
 	{
@@ -915,13 +918,13 @@ public class Views
 	 * Sample only every <em>step<sub>d</sub></em><sup>th</sup> value of a
 	 * source {@link RandomAccessible}. This is effectively an integer scaling
 	 * transformation.
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @param steps
 	 *            the subsampling step sizes
 	 * @return a subsampled {@link RandomAccessible}
-	 * 
+	 *
 	 */
 	public static < T > SubsampleView< T > subsample( final RandomAccessible< T > source, final long... steps )
 	{
@@ -929,11 +932,11 @@ public class Views
 
 		return new SubsampleView< T >( source, steps );
 	}
-	
+
 	/**
 	 * Removes all unit dimensions (dimensions with size one) from the
 	 * RandomAccessibleInterval
-	 * 
+	 *
 	 * @param source
 	 *            the source
 	 * @return a RandomAccessibleInterval without dimensions of size one
@@ -952,7 +955,7 @@ public class Views
 	/**
 	 * Form a <em>(n+1)</em>-dimensional {@link RandomAccessibleInterval} by
 	 * stacking <em>n</em>-dimensional {@link RandomAccessibleInterval}s.
-	 * 
+	 *
 	 * @param hyperslices
 	 *            a list of <em>n</em>-dimensional
 	 *            {@link RandomAccessibleInterval} of identical sizes.
@@ -967,7 +970,7 @@ public class Views
 	/**
 	 * Form a <em>(n+1)</em>-dimensional {@link RandomAccessibleInterval} by
 	 * stacking <em>n</em>-dimensional {@link RandomAccessibleInterval}s.
-	 * 
+	 *
 	 * @param hyperslices
 	 *            a list of <em>n</em>-dimensional
 	 *            {@link RandomAccessibleInterval} of identical sizes.
@@ -982,7 +985,7 @@ public class Views
 	/**
 	 * Form a <em>(n+1)</em>-dimensional {@link RandomAccessibleInterval} by
 	 * stacking <em>n</em>-dimensional {@link RandomAccessibleInterval}s.
-	 * 
+	 *
 	 * @param stackAccessMode
 	 *            describes how a {@link RandomAccess} on the <em>(n+1)</em>
 	 *            -dimensional {@link StackView} maps position changes into
@@ -1002,7 +1005,7 @@ public class Views
 	/**
 	 * Form a <em>(n+1)</em>-dimensional {@link RandomAccessibleInterval} by
 	 * stacking <em>n</em>-dimensional {@link RandomAccessibleInterval}s.
-	 * 
+	 *
 	 * @param stackAccessMode
 	 *            describes how a {@link RandomAccess} on the <em>(n+1)</em>
 	 *            -dimensional {@link StackView} maps position changes into
@@ -1018,87 +1021,217 @@ public class Views
 	{
 		return new StackView< T >( Arrays.asList( hyperslices ), stackAccessMode );
 	}
-	
+
 	/**
-	 * Positive shear transform of a RandomAccessible using {@link ShearTransform}, i.e.
-	 * c[ shearDimension ] = c[ shearDimension ] + c[ referenceDimension ]
-	 * 
-	 * @param source				input, e.g. extended {@link RandomAccessibleInterval}
-	 * @param shearDimension		dimension to be sheared
-	 * @param referenceDimension	reference dimension for shear
-	 * 
+	 * Positive shear transform of a RandomAccessible using
+	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[ shearDimension ] +
+	 * c[ referenceDimension ]
+	 *
+	 * @param source
+	 *            input, e.g. extended {@link RandomAccessibleInterval}
+	 * @param shearDimension
+	 *            dimension to be sheared
+	 * @param referenceDimension
+	 *            reference dimension for shear
+	 *
 	 * @return {@link TransformView} containing the result.
 	 */
-	public static < T > TransformView< T > shear( 
+	public static < T > TransformView< T > shear(
 			final RandomAccessible< T > source,
 			final int shearDimension,
 			final int referenceDimension )
 	{
-		ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
+		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
 		return new TransformView< T >( source, transform.inverse() );
 	}
-	
+
 	/**
-	 * Negative shear transform of a RandomAccessible using {@link InverseShearTransform}, i.e.
-	 * c[ shearDimension ] = c[ shearDimension ] - c[ referenceDimension ]
-	 * 
-	 * @param source				input, e.g. extended {@link RandomAccessibleInterval}
-	 * @param shearDimension		dimension to be sheared
-	 * @param referenceDimension	reference dimension for shear
-	 * 
+	 * Negative shear transform of a RandomAccessible using
+	 * {@link InverseShearTransform}, i.e. c[ shearDimension ] = c[
+	 * shearDimension ] - c[ referenceDimension ]
+	 *
+	 * @param source
+	 *            input, e.g. extended {@link RandomAccessibleInterval}
+	 * @param shearDimension
+	 *            dimension to be sheared
+	 * @param referenceDimension
+	 *            reference dimension for shear
+	 *
 	 * @return {@link TransformView} containing the result.
 	 */
-	public static < T > TransformView< T > unshear( 
+	public static < T > TransformView< T > unshear(
 			final RandomAccessible< T > source,
 			final int shearDimension,
 			final int referenceDimension )
 	{
-		InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
+		final InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
 		return new TransformView< T >( source, transform.inverse() );
 	}
-	
+
 	/**
-	 * Positive shear transform of a RandomAccessible using {@link ShearTransform}, i.e.
-	 * c[ shearDimension ] = c[ shearDimension ] + c[ referenceDimension ]
-	 * 
-	 * @param source				input, e.g. extended {@link RandomAccessibleInterval}
-	 * @param interval				original interval
-	 * @param shearDimension		dimension to be sheared
-	 * @param referenceDimension	reference dimension for shear
-	 * 
-	 * @return {@link IntervalView} containing the result. The returned interval's dimension are determined by
-	 * applying the {@link ShearTransform#transform} method on the input interval.
+	 * Positive shear transform of a RandomAccessible using
+	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[ shearDimension ] +
+	 * c[ referenceDimension ]
+	 *
+	 * @param source
+	 *            input, e.g. extended {@link RandomAccessibleInterval}
+	 * @param interval
+	 *            original interval
+	 * @param shearDimension
+	 *            dimension to be sheared
+	 * @param referenceDimension
+	 *            reference dimension for shear
+	 *
+	 * @return {@link IntervalView} containing the result. The returned
+	 *         interval's dimension are determined by applying the
+	 *         {@link ShearTransform#transform} method on the input interval.
 	 */
-	public static < T > IntervalView< T > shear( 
+	public static < T > IntervalView< T > shear(
 			final RandomAccessible< T > source,
 			final Interval interval,
 			final int shearDimension,
 			final int referenceDimension )
 	{
-		ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
-		return Views.interval( Views.shear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval) ).getInterval() );
+		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
+		return Views.interval( Views.shear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval ) ).getInterval() );
 	}
-	
+
 	/**
-	 * Negative shear transform of a RandomAccessible using {@link InverseShearTransform}, i.e.
-	 * c[ shearDimension ] = c[ shearDimension ] - c[ referenceDimension ]
-	 * 
-	 * @param source				input, e.g. extended {@link RandomAccessibleInterval}
-	 * @param interval				original interval
-	 * @param shearDimension		dimension to be sheared
-	 * @param referenceDimension	reference dimension for shear
-	 * 
-	 * @return {@link IntervalView} containing the result. The returned interval's dimension are determined by
-	 * applying the {@link ShearTransform#transform} method on the input interval.
+	 * Negative shear transform of a RandomAccessible using
+	 * {@link InverseShearTransform}, i.e. c[ shearDimension ] = c[
+	 * shearDimension ] - c[ referenceDimension ]
+	 *
+	 * @param source
+	 *            input, e.g. extended {@link RandomAccessibleInterval}
+	 * @param interval
+	 *            original interval
+	 * @param shearDimension
+	 *            dimension to be sheared
+	 * @param referenceDimension
+	 *            reference dimension for shear
+	 *
+	 * @return {@link IntervalView} containing the result. The returned
+	 *         interval's dimension are determined by applying the
+	 *         {@link ShearTransform#transform} method on the input interval.
 	 */
-	public static < T > IntervalView< T > unshear( 
+	public static < T > IntervalView< T > unshear(
 			final RandomAccessible< T > source,
 			final Interval interval,
 			final int shearDimension,
 			final int referenceDimension )
 	{
-		InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
-		return Views.interval( Views.unshear( source, shearDimension, referenceDimension ),transform.transform( new BoundingBox( interval) ).getInterval() );
+		final InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
+		return Views.interval( Views.unshear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval ) ).getInterval() );
 	}
-	
+
+	/**
+	 * Bijective permutation of the integer coordinates in each dimension of a
+	 * {@link RandomAccessibleInterval}.
+	 *
+	 * @param source
+	 *            must be an <em>n</em>-dimensional hypercube with each
+	 *            dimension being of the same size as the permutation array
+	 * @param permutation
+	 *            must be a bijective permutation over its index set, i.e. for a
+	 *            LUT of length n, the sorted content the array must be
+	 *            [0,...,n-1] which is the index set of the LUT.
+	 *
+	 * @return {@link IntervalView} of permuted source.
+	 */
+	public static < T > IntervalView< T > permuteCoordinates(
+			final RandomAccessibleInterval< T > source,
+			final int[] permutation )
+	{
+		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
+		assert PermutationTransform.checkInterval( source, permutation ): "Source interval boundaries do not match permutation.";
+
+		final int nDim = source.numDimensions();
+		final PermutationTransform transform = new PermutationTransform( permutation, nDim, nDim );
+		return Views.interval( new TransformView< T >( source, transform.inverse() ), source );
+	}
+
+	/**
+	 * Bijective permutation of the integer coordinates of one dimension of a
+	 * {@link RandomAccessibleInterval}.
+	 *
+	 * @param source
+	 *            must have dimension(dimension) == permutation.length
+	 * @param permutation
+	 *            must be a bijective permutation over its index set, i.e. for a
+	 *            lut of length n, the sorted content the array must be
+	 *            [0,...,n-1] which is the index set of the lut.
+	 * @param d
+	 *            dimension index to be permuted
+	 *
+	 * @return {@link IntervalView} of permuted source.
+	 */
+	public static < T > IntervalView< T > permuteCoordinates(
+			final RandomAccessibleInterval< T > source,
+			final int[] permutation,
+			final int d )
+	{
+		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
+		assert source.min( d ) == 0: "Source with min[d] coordinate != 0 passed to coordinate permutation.";
+		assert source.dimension( d ) == permutation.length: "Source with dimension[d] != LUT.length passed to coordinate permutation.";
+
+		final int nDim = source.numDimensions();
+		final SingleDimensionPermutationTransform transform = new SingleDimensionPermutationTransform( permutation, nDim, nDim, d );
+		return Views.interval( new TransformView< T >( source, transform.inverse() ), source );
+	}
+
+	/**
+	 * Inverse Bijective permutation of the integer coordinates in each
+	 * dimension of a {@link RandomAccessibleInterval}.
+	 *
+	 * @param source
+	 *            must be an <em>n</em>-dimensional hypercube with each
+	 *            dimension being of the same size as the permutation array
+	 * @param permutation
+	 *            must be a bijective permutation over its index set, i.e. for a
+	 *            LUT of length n, the sorted content the array must be
+	 *            [0,...,n-1] which is the index set of the LUT.
+	 *
+	 * @return {@link IntervalView} of permuted source.
+	 */
+	public static < T > IntervalView< T > permuteCoordinatesInverse(
+			final RandomAccessibleInterval< T > source,
+			final int[] permutation )
+	{
+		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
+		assert PermutationTransform.checkInterval( source, permutation ): "Source interval boundaries do not match permutation.";
+
+		final int nDim = source.numDimensions();
+		final PermutationTransform transform = new PermutationTransform( permutation, nDim, nDim ).inverse();
+		return Views.interval( new TransformView< T >( source, transform.inverse() ), source );
+	}
+
+	/**
+	 * Inverse bijective permutation of the integer coordinates of one dimension
+	 * of a {@link RandomAccessibleInterval}.
+	 *
+	 * @param source
+	 *            must have dimension(dimension) == permutation.length
+	 * @param permutation
+	 *            must be a bijective permutation over its index set, i.e. for a
+	 *            lut of length n, the sorted content the array must be
+	 *            [0,...,n-1] which is the index set of the lut.
+	 * @param d
+	 *            dimension index to be permuted
+	 *
+	 * @return {@link IntervalView} of permuted source.
+	 */
+	public static < T > IntervalView< T > permuteCoordinateInverse(
+			final RandomAccessibleInterval< T > source,
+			final int[] permutation,
+			final int d )
+	{
+		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
+		assert source.min( d ) == 0: "Source with min[d] coordinate != 0 passed to coordinate permutation.";
+		assert source.dimension( d ) == permutation.length: "Source with dimension[d] != LUT.length passed to coordinate permutation.";
+
+		final int nDim = source.numDimensions();
+		final SingleDimensionPermutationTransform transform = new SingleDimensionPermutationTransform( permutation, nDim, nDim, d ).inverse();
+		return Views.interval( new TransformView< T >( source, transform.inverse() ), source );
+	}
+
 }

--- a/src/test/java/net/imglib2/transform/integer/permutation/AbstractPerumtationTransformTest.java
+++ b/src/test/java/net/imglib2/transform/integer/permutation/AbstractPerumtationTransformTest.java
@@ -1,0 +1,174 @@
+/**
+ *
+ */
+package net.imglib2.transform.integer.permutation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import net.imglib2.Localizable;
+import net.imglib2.Positionable;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>
+ *
+ */
+public class AbstractPerumtationTransformTest
+{
+
+	/**
+	 * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org> Wrapper class
+	 *         for AbstractPermutatioTransform to test protected methods.
+	 */
+	public static class MockPermutation extends AbstractPermutationTransform
+	{
+
+		// test protected methods
+		@Override
+		public int apply( final int x )
+		{
+			return super.apply( x );
+		}
+
+		@Override
+		public long applyChecked( final int x )
+		{
+			return super.applyChecked( x );
+		}
+
+		@Override
+		public int applyInverse( final int y )
+		{
+			return super.applyInverse( y );
+		}
+
+		@Override
+		public long applyInverseChecked( final int y )
+		{
+			return super.applyInverseChecked( y );
+		}
+
+		public MockPermutation( final int[] lut )
+		{
+			super( lut );
+		}
+
+		// ignore unimplemented methods
+		@Override
+		public void applyInverse( final long[] source, final long[] target )
+		{
+
+		}
+
+		@Override
+		public void applyInverse( final int[] source, final int[] target )
+		{
+
+		}
+
+		@Override
+		public void applyInverse( final Positionable source, final Localizable target )
+		{
+
+		}
+
+		@Override
+		public MockPermutation inverse()
+		{
+			return new MockPermutation( this.inverseLut );
+		}
+
+		@Override
+		public int numSourceDimensions()
+		{
+			return 0;
+		}
+
+		@Override
+		public int numTargetDimensions()
+		{
+			return 0;
+		}
+
+		@Override
+		public void apply( final long[] source, final long[] target )
+		{
+
+		}
+
+		@Override
+		public void apply( final int[] source, final int[] target )
+		{
+
+		}
+
+		@Override
+		public void apply( final Localizable source, final Positionable target )
+		{
+
+		}
+
+	}
+
+	private final int size = 200;
+
+	private final int[] lut = new int[ this.size ];
+
+	private final int[] inv = new int[ this.size ];
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception
+	{
+
+		final ArrayList< Integer > al = new ArrayList< Integer >();
+		for ( int i = 0; i < this.size; ++i )
+			al.add( i );
+
+		Collections.shuffle( al );
+
+		for ( int i = 0; i < this.size; ++i )
+		{
+			this.lut[ i ] = al.get( i );
+			this.inv[ this.lut[ i ] ] = i;
+		}
+
+	}
+
+	@Test
+	public void test()
+	{
+		final MockPermutation transform = new MockPermutation( this.lut );
+		final MockPermutation inverse = transform.inverse();
+		int resInt;
+		long resLong;
+		for ( int i = 0; i < this.size; ++i )
+		{
+			resInt = transform.apply( i );
+			resLong = transform.applyChecked( i );
+			Assert.assertEquals( this.lut[ i ], resInt );
+			Assert.assertEquals( this.lut[ i ], resLong );
+
+			resInt = inverse.apply( transform.apply( i ) );
+			resLong = transform.apply( inverse.apply( i ) );
+			Assert.assertEquals( i, resInt );
+			Assert.assertEquals( i, resLong );
+
+			resInt = inverse.apply( i );
+			resLong = inverse.applyChecked( i );
+			Assert.assertEquals( this.inv[ i ], resInt );
+			Assert.assertEquals( this.inv[ i ], resLong );
+		}
+
+		Assert.assertEquals( -Long.MAX_VALUE, transform.applyChecked( -1 ) );
+		Assert.assertEquals( Long.MAX_VALUE, transform.applyChecked( this.size + 1 ) );
+
+	}
+
+}

--- a/src/test/java/net/imglib2/transform/integer/permutation/PermutationTransformTest.java
+++ b/src/test/java/net/imglib2/transform/integer/permutation/PermutationTransformTest.java
@@ -1,0 +1,118 @@
+/**
+ *
+ */
+package net.imglib2.transform.integer.permutation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
+
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.array.ArrayRandomAccess;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.TransformView;
+import net.imglib2.view.Views;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ *
+ * @author Stephan Saalfeld <saalfelds@janelia.hhmi.org>
+ * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>
+ */
+public class PermutationTransformTest
+{
+	final static Random rnd = new Random();
+
+	static long[] values;
+
+	static int[] lut;
+
+	static final int width = 5;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception
+	{
+		PermutationTransformTest.values = new long[ PermutationTransformTest.width * PermutationTransformTest.width ];
+		for ( int i = 0; i < PermutationTransformTest.values.length; ++i )
+			PermutationTransformTest.values[ i ] = PermutationTransformTest.rnd.nextLong();
+
+		PermutationTransformTest.lut = new int[ PermutationTransformTest.width ];
+
+		final ArrayList< Integer > indices = new ArrayList< Integer >();
+		for ( int i = 0; i < PermutationTransformTest.width; ++i )
+			indices.add( i );
+
+		Collections.shuffle( indices );
+
+		for ( int i = 0; i < PermutationTransformTest.width; ++i )
+			PermutationTransformTest.lut[ i ] = indices.get( i );
+	}
+
+	@Test
+	public void test()
+	{
+		final ArrayImg< LongType, LongArray > img = ArrayImgs.longs( PermutationTransformTest.values, PermutationTransformTest.width, PermutationTransformTest.width );
+		final PermutationTransform t = new PermutationTransform( PermutationTransformTest.lut, 2, 2 );
+		final TransformView< LongType > bijectivePermutation = new TransformView< LongType >( img, t );
+		final TransformView< LongType > inverseBijectivePermutation = new TransformView< LongType >( bijectivePermutation, t.inverse() );
+		final IntervalView< LongType > viewTransformed = Views.permuteCoordinatesInverse( img, PermutationTransformTest.lut );
+		final IntervalView< LongType > identity = Views.permuteCoordinates( viewTransformed, PermutationTransformTest.lut );
+
+		final RandomAccess< LongType > reference = img.randomAccess();
+		final RandomAccess< LongType > result = Views.interval( inverseBijectivePermutation, img ).randomAccess();
+
+		for ( int i = 0; i < 1000; ++i )
+		{
+			final long[] x = new long[] { PermutationTransformTest.rnd.nextInt( PermutationTransformTest.width ), PermutationTransformTest.rnd.nextInt( PermutationTransformTest.width ) };
+			reference.setPosition( x );
+			result.setPosition( x );
+			Assert.assertEquals( reference.get().get(), result.get().get() );
+		}
+
+		{
+			final Cursor< LongType > v = Views.flatIterable( viewTransformed ).cursor();
+			final Cursor< LongType > b = Views.flatIterable( Views.interval( bijectivePermutation, img ) ).cursor();
+			final Cursor< LongType > i = Views.flatIterable( identity ).cursor();
+			final ArrayRandomAccess< LongType > r = img.randomAccess();
+
+			while ( v.hasNext() )
+			{
+				b.fwd();
+				v.fwd();
+				for ( int d = 0; d < r.numDimensions(); ++d )
+					r.setPosition( PermutationTransformTest.lut[ b.getIntPosition( d ) ], d ); // manually
+				// permute
+				// source
+				// image
+				// coordinate
+
+				Assert.assertEquals( r.get().get(), b.get().get() );
+				Assert.assertEquals( b.get().get(), v.get().get() );
+
+				i.fwd();
+				r.setPosition( i );
+
+				Assert.assertEquals( r.get().get(), i.get().get() );
+
+			}
+		}
+
+		{
+			int i = 0;
+			for ( final LongType l : Views.flatIterable( Views.interval( inverseBijectivePermutation, img ) ) )
+				Assert.assertEquals( PermutationTransformTest.values[ i++ ], l.get() );
+		}
+	}
+}

--- a/src/test/java/net/imglib2/transform/integer/permutation/SingleDimensionPermutationTransformTest.java
+++ b/src/test/java/net/imglib2/transform/integer/permutation/SingleDimensionPermutationTransformTest.java
@@ -1,0 +1,172 @@
+/**
+ *
+ */
+package net.imglib2.transform.integer.permutation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
+
+import net.imglib2.Cursor;
+import net.imglib2.img.array.ArrayCursor;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.array.ArrayRandomAccess;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.TransformView;
+import net.imglib2.view.Views;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>
+ *
+ */
+public class SingleDimensionPermutationTransformTest
+{
+
+	private final Random rng = new Random();
+
+	private final int width = 100;
+
+	private final int height = 200;
+
+	private final long[] dim = new long[] { this.width, this.height };
+
+	private final int d = 1;
+
+	private final int size = ( int ) this.dim[ this.d ];
+
+	private final int nDim = this.dim.length;
+
+	private final int[] lut = new int[ this.size ];
+
+	private final int[] inv = new int[ this.size ];
+
+	private final int nRandomReps = 1000;
+
+	private final ArrayImg< IntType, IntArray > img = ArrayImgs.ints( this.dim );
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception
+	{
+		final ArrayList< Integer > al = new ArrayList< Integer >();
+		for ( int i = 0; i < this.size; ++i )
+			al.add( i );
+
+		Collections.shuffle( al );
+
+		for ( int i = 0; i < this.lut.length; ++i )
+		{
+			this.lut[ i ] = al.get( i );
+			this.inv[ this.lut[ i ] ] = i;
+		}
+
+		for ( final IntType l : this.img )
+			l.set( this.rng.nextInt() );
+	}
+
+	@Test
+	public void test()
+	{
+		final SingleDimensionPermutationTransform transform = new SingleDimensionPermutationTransform( this.lut, this.nDim, this.nDim, this.d );
+		final SingleDimensionPermutationTransform inverse = transform.inverse();
+
+		final TransformView< IntType > transformed = new TransformView< IntType >( this.img, transform );
+		final TransformView< IntType > inversed = new TransformView< IntType >( transformed, inverse );
+
+		final IntervalView< IntType > viewTransformed = Views.permuteCoordinateInverse( this.img, this.lut, this.d );
+		final IntervalView< IntType > identity = Views.permuteCoordinates( viewTransformed, this.lut, this.d );
+
+		final ArrayCursor< IntType > ref = this.img.cursor();
+		final Cursor< IntType > res = Views.flatIterable( Views.interval( inversed, this.img ) ).cursor();
+		while ( ref.hasNext() )
+			Assert.assertEquals( ref.next().get(), res.next().get() );
+
+		final ArrayRandomAccess< IntType > raFwd = this.img.randomAccess();
+		final ArrayRandomAccess< IntType > raBck = this.img.randomAccess();
+		final ArrayRandomAccess< IntType > ra = this.img.randomAccess();
+
+		final long[] fwdLong = new long[ this.nDim ];
+		final long[] bckLong = new long[ this.nDim ];
+
+		final int[] fwdInt = new int[ this.nDim ];
+		final int[] bckInt = new int[ this.nDim ];
+
+		for ( int i = 0; i < this.nRandomReps; ++i )
+		{
+			final int x = this.rng.nextInt( this.width );
+			final int y = this.rng.nextInt( this.width );
+			final int[] xyInt = new int[] { x, y };
+			final long[] xyLong = new long[] { x, y };
+			ra.setPosition( xyInt );
+
+			transform.apply( xyInt, fwdInt );
+			transform.apply( xyLong, fwdLong );
+			transform.apply( ra, raFwd );
+
+			transform.applyInverse( bckInt, xyInt );
+			transform.applyInverse( bckLong, xyLong );
+			transform.applyInverse( raBck, ra );
+
+			for ( int d = 0; d < this.nDim; ++d )
+			{
+				final int fwdVal;
+				final int bckVal;
+				if ( d == this.d )
+				{
+					fwdVal = this.lut[ xyInt[ d ] ];
+					bckVal = this.inv[ xyInt[ d ] ];
+				}
+				else
+				{
+					fwdVal = xyInt[ d ];
+					bckVal = xyInt[ d ];
+				}
+
+				Assert.assertEquals( fwdVal, fwdInt[ d ] );
+				Assert.assertEquals( bckVal, bckInt[ d ] );
+
+				Assert.assertEquals( fwdVal, fwdLong[ d ] );
+				Assert.assertEquals( bckVal, bckLong[ d ] );
+
+				Assert.assertEquals( fwdVal, raFwd.getIntPosition( d ) );
+				Assert.assertEquals( bckVal, raBck.getIntPosition( d ) );
+
+			}
+
+		}
+
+		{
+			final Cursor< IntType > v = Views.flatIterable( viewTransformed ).cursor();
+			final Cursor< IntType > i = Views.flatIterable( identity ).cursor();
+			final ArrayRandomAccess< IntType > r = this.img.randomAccess();
+			final Cursor< IntType > t = Views.flatIterable( Views.interval( transformed, this.img ) ).cursor();
+			while ( t.hasNext() )
+			{
+				t.fwd();
+				v.fwd();
+				r.setPosition( t );
+				r.setPosition( this.lut[ t.getIntPosition( this.d ) ], this.d );
+
+				Assert.assertEquals( r.get().get(), t.get().get() );
+				Assert.assertEquals( t.get().get(), v.get().get() );
+
+				i.fwd();
+				r.setPosition( i );
+
+				Assert.assertEquals( r.get().get(), i.get().get() );
+
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
which transforms either a single or all coordinates of a
RandomAccessibleInterval according to a bijective permutation over the index
set of that coordinate.

Implemented the following classes/methods:

class AbstractPermutationTransform // with test
class PermutationTransform  // with test
class SingleDimensionPermutationTransform // with test
IntervalView Views.permuteCoordinates(RandomAccessibleInterval, int[])
IntervalView Views.permuteCoordinates(RandomAccessibleInterval, int[], int)
IntervalView Views.permuteCoordinatesInverse(RandomAccessibleInterval, int[])
IntervalView Views.permuteCoordinatesInverse(RandomAccessibleInterval, int[], int)

Signed-off-by: Stephan Saalfeld <saalfelds@janelia.hhmi.org>, Philipp Hanslovsky <hanslovskyp@janelia.hhmi.org>