### PR TITLE
Type bug fixes

### DIFF
--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
@@ -142,34 +142,22 @@ public class Unsigned128BitType extends AbstractIntegerType<Unsigned128BitType> 
 		bytes[15] = (byte)((lower >>>  8) & 0xffL);
 		bytes[16] = (byte) (lower         & 0xffL);
 	}
-	
+
 	/** The first byte is the most significant byte, like in {@link BigInteger#toByteArray()}.
 	 * Only the last 16 bytes are read, if there are more. */
 	public void set( final byte[] bytes ) {
 		final int k = i * 2;
-		int b = bytes.length -1;
-		int cut = b - 8;
-		long u = 0;
-
-		// Set lower
-		if ( b > cut ) {
-			for (int p = 0; b > cut; --b, ++p) {
-				u |= ( bytes[ b ] & 0xffL ) << ( p * 8 );
+		int b = bytes.length - 1;
+		for ( int offset = 0; offset < 2; ++offset ) {
+			final int cut = Math.max( -1, b - 8 );
+			long u = 0;
+			for ( int p = 0; b > cut; --b, p += 8 ) {
+				u |= ( bytes[ b ] & 0xffL ) << p;
 			}
+			dataAccess.setValue( k + offset, u );
 		}
-		dataAccess.setValue( k, u );
-
-		// Set upper
-		u = 0;
-		cut = Math.max( -1, cut - 8 );
-		if ( b > cut ) {
-			for (int p = 0; b > cut; --b, ++p) {
-				u |= ( bytes[ b ] & 0xffL ) << ( p * 8 );
-			}
-		}
-		dataAccess.setValue( k + 1, u );
 	}
-	
+
 	public BigInteger get() {
 		final int k = i * 2;
 		intoBytes( dataAccess.getValue( k ), dataAccess.getValue( k + 1 ) );

--- a/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
@@ -132,7 +132,7 @@ public abstract class AbstractRealType< T extends AbstractRealType< T >> extends
 	@Override
 	public boolean equals( final Object o )
 	{
-		if ( ! (o instanceof RealType) )
+		if ( !getClass().isInstance(o) )
 			return false;
 		@SuppressWarnings("unchecked")
 		final T t = (T) o;

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
@@ -59,7 +59,7 @@ public class Unsigned128BitTypeTest
 	}
 
 	/**
-	 * Test method for {@link net.imglib2.type.numeric.integer.Unsigned128BitType}.
+	 * Tests {@link Unsigned128BitType#set(BigInteger)} with random values.
 	 */
 	@Test
 	public void testSetRandom()

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
@@ -78,4 +78,30 @@ public class Unsigned128BitTypeTest
 			assertTrue( t.get().compareTo( b ) == 0 );
 		}
 	}
+
+	/**
+	 * Regression test that verifies small {@link BigInteger} values work as
+	 * expected when passed to
+	 * {@link Unsigned128BitType#Unsigned128BitType(BigInteger)}.
+	 */
+	@Test
+	public void testSmallBigIntegerValues()
+	{
+		final BigInteger b = BigInteger.valueOf( 329l );
+		final Unsigned128BitType u = new Unsigned128BitType( b );
+
+		assertEquals( b, u.get() );
+	}
+
+	/**
+	 * Tests {@link Unsigned128BitType#equals(Object)}.
+	 */
+	@Test
+	public void testEquals()
+	{
+		final UnsignedIntType i = new UnsignedIntType( 127l );
+		final Unsigned128BitType b = new Unsigned128BitType( BigInteger.valueOf( 908742l ) );
+
+		assertFalse( i.equals( b ) );
+	}
 }


### PR DESCRIPTION
Hello! The first commit is to prevent ArrayIndexOutOfBounds exceptions when creating an Unsigned128BitType with less than 7 bytes. And the second commit is to prevent ClassCastException. 

Please let me know if there are any issues with either of these commits! 