### PR TITLE
Unsigned types behavior

### DIFF
--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteType.java
@@ -57,7 +57,7 @@ public class UnsignedByteType extends GenericByteType< UnsignedByteType >
 	// this is the constructor if you want it to be a variable
 	public UnsignedByteType( final int value )
 	{
-		super( getCodedSignedByteChecked( value ) );
+		super( getCodedSignedByte( value ) );
 	}
 
 	// this is the constructor if you want to specify the dataAccess

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntType.java
@@ -57,7 +57,7 @@ public class UnsignedIntType extends GenericIntType< UnsignedIntType >
 	// this is the constructor if you want it to be a variable
 	public UnsignedIntType( final long value )
 	{
-		super( getCodedSignedIntChecked( value ) );
+		super( getCodedSignedInt( value ) );
 	}
 
 	// this is the constructor if you want to specify the dataAccess

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
@@ -57,7 +57,7 @@ public class UnsignedShortType extends GenericShortType< UnsignedShortType >
 	// this is the constructor if you want it to be a variable
 	public UnsignedShortType( final int value )
 	{
-		super( getCodedSignedShortChecked( value ) );
+		super( getCodedSignedShort( value ) );
 	}
 
 	// this is the constructor if you want to specify the dataAccess

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedByteTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedByteTypeTest.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2015 Tobias Pietzsch, Stephan Preibisch, Barry DeZonia,
+ * Stephan Saalfeld, Curtis Rueden, Albert Cardona, Christian Dietz, Jean-Yves
+ * Tinevez, Johannes Schindelin, Jonathan Hale, Lee Kamentsky, Larry Lindsey, Mark
+ * Hiner, Michael Zinsmaier, Martin Horn, Grant Harris, Aivar Grislis, John
+ * Bogovic, Steffen Jaensch, Stefan Helfrich, Jan Funke, Nick Perry, Mark Longair,
+ * Melissa Linkert and Dimiter Prodanov.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class UnsignedByteTypeTest
+{
+	/**
+	 * Regression test that verifies in range int values work as expected when
+	 * passed to {@link UnsignedByteType#UnsignedByteType(int)}.
+	 */
+	@Test
+	public void testInRangeValues()
+	{
+		final int i = 126;
+		final UnsignedByteType u = new UnsignedByteType( i );
+
+		assertEquals( i, u.get() );
+
+		u.set( 0 );
+		assertEquals( 0, u.get() );
+
+		u.set( 5 );
+		assertEquals( 5, u.get() );
+	}
+
+	/**
+	 * Regression test that verifies that an int which is greater than 256 works
+	 * as expected when passed to {@link UnsignedByteType#UnsignedByteType(int)}.
+	 */
+	@Test
+	public void testPositiveOutOfRangeValue()
+	{
+		final int i = 1027;
+		final UnsignedByteType u = new UnsignedByteType( i );
+
+		assertEquals( 3, u.get() );
+	}
+
+	/**
+	 * Regression test that verifies that a negative value works as
+	 * expected when passed to {@link UnsignedByteType#UnsignedByteType(int)}.
+	 */
+	@Test
+	public void testNegativeOutOfRangeValue()
+	{
+		final int i = -212;
+		final UnsignedByteType u = new UnsignedByteType( i );
+
+		assertEquals( 44, u.get() );
+	}
+}

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedIntTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedIntTypeTest.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2015 Tobias Pietzsch, Stephan Preibisch, Barry DeZonia,
+ * Stephan Saalfeld, Curtis Rueden, Albert Cardona, Christian Dietz, Jean-Yves
+ * Tinevez, Johannes Schindelin, Jonathan Hale, Lee Kamentsky, Larry Lindsey, Mark
+ * Hiner, Michael Zinsmaier, Martin Horn, Grant Harris, Aivar Grislis, John
+ * Bogovic, Steffen Jaensch, Stefan Helfrich, Jan Funke, Nick Perry, Mark Longair,
+ * Melissa Linkert and Dimiter Prodanov.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class UnsignedIntTypeTest
+{
+	/**
+	 * Regression test that verifies in range long values work as expected when
+	 * passed to {@link UnsignedIntType#UnsignedIntType(long)}.
+	 */
+	@Test
+	public void testInRangeValues()
+	{
+		final long l = 9823409L;
+		final UnsignedIntType u = new UnsignedIntType( l );
+
+		assertEquals( l, u.get() );
+
+		u.set( 0L );
+		assertEquals( 0L, u.get() );
+
+		u.set( 120L );
+		assertEquals( 120L, u.get() );
+	}
+
+	/**
+	 * Regression test that verifies that an long which is greater than 
+	 * 0xffffffffL works as expected when passed to
+	 * {@link UnsignedIntType#UnsignedIntType(long)}.
+	 */
+	@Test
+	public void testPositiveOutOfRangeValue()
+	{
+		final long l = 4294967299L;
+		final UnsignedIntType u = new UnsignedIntType( l );
+
+		assertEquals( 3L, u.get() );
+	}
+
+	/**
+	 * Regression test that verifies that a negative value works as
+	 * expected when passed to {@link UnsignedIntType#UnsignedIntType(long)}.
+	 */
+	@Test
+	public void testNegativeOutOfRangeValue()
+	{
+		final long l = -2038L;
+		final UnsignedIntType u = new UnsignedIntType( l );
+
+		assertEquals( 4294965258L, u.get() );
+	}
+}

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedShortTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedShortTypeTest.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2015 Tobias Pietzsch, Stephan Preibisch, Barry DeZonia,
+ * Stephan Saalfeld, Curtis Rueden, Albert Cardona, Christian Dietz, Jean-Yves
+ * Tinevez, Johannes Schindelin, Jonathan Hale, Lee Kamentsky, Larry Lindsey, Mark
+ * Hiner, Michael Zinsmaier, Martin Horn, Grant Harris, Aivar Grislis, John
+ * Bogovic, Steffen Jaensch, Stefan Helfrich, Jan Funke, Nick Perry, Mark Longair,
+ * Melissa Linkert and Dimiter Prodanov.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class UnsignedShortTypeTest
+{
+	/**
+	 * Regression test that verifies in range int values work as expected when
+	 * passed to {@link UnsignedShortType#UnsignedShortType(int)}.
+	 */
+	@Test
+	public void testInRangeValues()
+	{
+		final int i = 6004;
+		final UnsignedShortType u = new UnsignedShortType( i );
+
+		assertEquals( i, u.get() );
+
+		u.set( 0 );
+		assertEquals( 0, u.get() );
+
+		u.set( 34 );
+		assertEquals( 34, u.get() );
+	}
+
+	/**
+	 * Regression test that verifies that an int which is greater than 65535 works
+	 * as expected when passed to {@link UnsignedShortType#UnsignedShortType(int)}.
+	 */
+	@Test
+	public void testPositiveOutOfRangeValue()
+	{
+		final int i = 78098;
+		final UnsignedShortType u = new UnsignedShortType( i );
+
+		assertEquals( 12562, u.get() );
+	}
+
+	/**
+	 * Regression test that verifies that a negative value works as
+	 * expected when passed to {@link UnsignedShortType#UnsignedShortType(int)}.
+	 */
+	@Test
+	public void testNegativeOutOfRangeValue()
+	{
+		final int i = -597;
+		final UnsignedShortType u = new UnsignedShortType( i );
+
+		assertEquals( 64939, u.get() );
+	}
+}


### PR DESCRIPTION
Hello! These changes implement the masking behavior for the variable constructors in UnsignedByteType, UnsignedIntType, and UnsignedShortType as discussed in issue #95. The changes also include the corresponding regression tests for the masking behavior. 

Please let me know your thoughts on these changes, and thank you in advance for any feedback!