### PR TITLE
IterableIntervalProjector2D: Target should use X,Y not dimX, dimY

### DIFF
--- a/src/main/java/net/imglib2/display/projector/IterableIntervalProjector2D.java
+++ b/src/main/java/net/imglib2/display/projector/IterableIntervalProjector2D.java
@@ -140,10 +140,10 @@ public class IterableIntervalProjector2D< A, B > extends AbstractProjector2D
 			final RandomAccess< A > sourceRandomAccess = source.randomAccess( sourceInterval );
 			sourceRandomAccess.setPosition( position );
 
-			final long cr = -target.dimension( dimX );
+			final long cr = -target.dimension( X );
 
-			final long width = target.dimension( dimX );
-			final long height = target.dimension( dimY );
+			final long width = target.dimension( X );
+			final long height = target.dimension( Y );
 
 			sourceRandomAccess.setPosition( min );
 			for ( long y = 0; y < height; ++y )

--- a/src/main/java/net/imglib2/display/projector/IterableIntervalProjector2D.java
+++ b/src/main/java/net/imglib2/display/projector/IterableIntervalProjector2D.java
@@ -73,10 +73,6 @@ public class IterableIntervalProjector2D< A, B > extends AbstractProjector2D
 
 	private final int dimY;
 
-	protected final int X = 0;
-
-	protected final int Y = 1;
-
 	/**
 	 * creates a new 2D projector that samples a plain in the dimensions dimX,
 	 * dimY.
@@ -111,10 +107,10 @@ public class IterableIntervalProjector2D< A, B > extends AbstractProjector2D
 		for ( int d = 0; d < position.length; ++d )
 			min[ d ] = max[ d ] = position[ d ];
 
-		min[ dimX ] = target.min( X );
-		min[ dimY ] = target.min( Y );
-		max[ dimX ] = target.max( X );
-		max[ dimY ] = target.max( Y );
+		min[ dimX ] = target.min( 0 );
+		min[ dimY ] = target.min( 1 );
+		max[ dimX ] = target.max( 0 );
+		max[ dimY ] = target.max( 1 );
 
 		// TODO: this is ugly, but the only way to make sure, that iteration
 		// order fits in the case of one sized dims. Tobi?
@@ -140,10 +136,10 @@ public class IterableIntervalProjector2D< A, B > extends AbstractProjector2D
 			final RandomAccess< A > sourceRandomAccess = source.randomAccess( sourceInterval );
 			sourceRandomAccess.setPosition( position );
 
-			final long cr = -target.dimension( X );
+			final long cr = -target.dimension( 0 );
 
-			final long width = target.dimension( X );
-			final long height = target.dimension( Y );
+			final long width = target.dimension( 0 );
+			final long height = target.dimension( 1 );
 
 			sourceRandomAccess.setPosition( min );
 			for ( long y = 0; y < height; ++y )
@@ -169,8 +165,8 @@ public class IterableIntervalProjector2D< A, B > extends AbstractProjector2D
 			while ( targetCursor.hasNext() )
 			{
 				final B b = targetCursor.next();
-				sourceRandomAccess.setPosition( targetCursor.getLongPosition( X ), dimX );
-				sourceRandomAccess.setPosition( targetCursor.getLongPosition( Y ), dimY );
+				sourceRandomAccess.setPosition( targetCursor.getLongPosition( 0 ), dimX );
+				sourceRandomAccess.setPosition( targetCursor.getLongPosition( 1 ), dimY );
 
 				converter.convert( sourceRandomAccess.get(), b );
 			}

--- a/src/main/java/net/imglib2/display/projector/volatiles/Volatile2DRandomAccessibleProjector.java
+++ b/src/main/java/net/imglib2/display/projector/volatiles/Volatile2DRandomAccessibleProjector.java
@@ -79,10 +79,10 @@ public class Volatile2DRandomAccessibleProjector< T, A extends Volatile< T >, B 
 		for ( int d = 0; d < position.length; ++d )
 			min[ d ] = max[ d ] = position[ d ];
 
-		min[ X ] = target.min( X );
-		min[ Y ] = target.min( Y );
-		max[ X ] = target.max( X );
-		max[ Y ] = target.max( Y );
+		min[ 0 ] = target.min( 0 );
+		min[ 1 ] = target.min( 1 );
+		max[ 0 ] = target.max( 0 );
+		max[ 1 ] = target.max( 1 );
 
 		final IterableInterval< A > srcIterable = Views.iterable( Views.interval( source, new FinalInterval( min, max ) ) );
 		final Cursor< B > targetCursor = target.localizingCursor();
@@ -103,8 +103,8 @@ public class Volatile2DRandomAccessibleProjector< T, A extends Volatile< T >, B 
 			while ( targetCursor.hasNext() )
 			{
 				final B b = targetCursor.next();
-				sourceRandomAccess.setPosition( targetCursor.getLongPosition( X ), X );
-				sourceRandomAccess.setPosition( targetCursor.getLongPosition( Y ), Y );
+				sourceRandomAccess.setPosition( targetCursor.getLongPosition( 0 ), 0 );
+				sourceRandomAccess.setPosition( targetCursor.getLongPosition( 1 ), 1 );
 
 				converter.convert( sourceRandomAccess.get(), b );
 			}


### PR DESCRIPTION
DimX and dimY are the dimensions representing the plane of the
RandomAccessible to be rendered. Any of these can be > 1. Target
is always two dimensional and therefore should use X,Y to access
the plane dimensions.

Sorry for the typo in the branch-name.