### PR TITLE
Fix unsigned long type

### DIFF
--- a/src/main/java/net/imglib2/type/AbstractBit64Type.java
+++ b/src/main/java/net/imglib2/type/AbstractBit64Type.java
@@ -69,8 +69,10 @@ public abstract class AbstractBit64Type<T extends AbstractBit64Type<T>> extends 
 		
 		if ( nBits < 1 || nBits > 64 )
 			throw new IllegalArgumentException( "Supports only bit depths between 1 and 64, can't take " + nBits );
-
-		this.mask = ((long)(Math.pow(2, nBits) -1));
+		else if ( nBits == 64 )
+			this.mask = -1l; // all 1s
+		else
+			this.mask = ((long)(Math.pow(2, nBits) -1));
 		this.invMask = ~mask;
 	}
 

--- a/src/main/java/net/imglib2/type/logic/BitType.java
+++ b/src/main/java/net/imglib2/type/logic/BitType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.logic;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.LongAccess;
@@ -153,6 +155,12 @@ public class BitType extends AbstractIntegerType<BitType> implements BooleanType
 	}
 
 	@Override
+	public BigInteger getBigInteger()
+	{
+		return get() ? BigInteger.ONE : BigInteger.ZERO;
+	}
+
+	@Override
 	public void setInteger( final int f )
 	{
 		if ( f >= 1 )
@@ -166,6 +174,15 @@ public class BitType extends AbstractIntegerType<BitType> implements BooleanType
 	{
 		if ( f >= 1 )
 			set( true );
+		else
+			set( false );
+	}
+
+	@Override
+	public void setBigInteger(BigInteger b)
+	{
+		if ( b.compareTo(BigInteger.ZERO) > 0 )
+			set ( true );
 		else
 			set( false );
 	}

--- a/src/main/java/net/imglib2/type/numeric/IntegerType.java
+++ b/src/main/java/net/imglib2/type/numeric/IntegerType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric;
 
+import java.math.BigInteger;
+
 /**
  * TODO
  * 
@@ -44,7 +46,11 @@ public interface IntegerType< T extends IntegerType< T >> extends RealType< T >
 
 	public long getIntegerLong();
 
+	public BigInteger getBigInteger();
+
 	public void setInteger( int f );
 
 	public void setInteger( long f );
+
+	public void setBigInteger( BigInteger b );
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
@@ -35,6 +35,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.LongAccess;
 import net.imglib2.type.AbstractBitType;
@@ -117,10 +119,16 @@ public abstract class AbstractIntegerBitType<T extends AbstractIntegerBitType<T>
 	public long getIntegerLong() { return get(); }
 
 	@Override
+	public BigInteger getBigInteger() { return BigInteger.valueOf( get() ); }
+
+	@Override
 	public void setInteger( final int f ) { set( f ); }
 
 	@Override
 	public void setInteger( final long f ) { set( f ); }
+
+	@Override
+	public void setBigInteger( final BigInteger b) { set( b.longValue() ); }
 
 	/** The maximum value that can be stored is {@code Math.pow(2, nBits) -1}. */
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/ByteType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/ByteType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.ByteAccess;
@@ -114,6 +116,12 @@ public class ByteType extends GenericByteType< ByteType >
 		return get();
 	}
 
+	@Override 
+	public BigInteger getBigInteger()
+	{
+		return BigInteger.valueOf( get() );
+	}
+
 	@Override
 	public void setInteger( final int f )
 	{
@@ -124,6 +132,12 @@ public class ByteType extends GenericByteType< ByteType >
 	public void setInteger( final long f )
 	{
 		set( ( byte ) f );
+	}
+
+	@Override
+	public void setBigInteger( final BigInteger b )
+	{
+		set( b.byteValue() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/IntType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/IntType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.IntAccess;
@@ -115,6 +117,12 @@ public class IntType extends GenericIntType< IntType >
 	}
 
 	@Override
+	public BigInteger getBigInteger()
+	{
+		return BigInteger.valueOf( get() );
+	}
+
+	@Override
 	public void setInteger( final int f )
 	{
 		set( f );
@@ -124,6 +132,12 @@ public class IntType extends GenericIntType< IntType >
 	public void setInteger( final long f )
 	{
 		set( ( int ) f );
+	}
+
+	@Override
+	public void setBigInteger(BigInteger b)
+	{
+		set( b.intValue() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/LongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/LongType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.LongAccess;
@@ -134,6 +136,12 @@ final public class LongType extends AbstractIntegerType< LongType > implements N
 	}
 
 	@Override
+	public BigInteger getBigInteger()
+	{
+		return BigInteger.valueOf( get() );
+	}
+
+	@Override
 	public void setInteger( final int f )
 	{
 		set( f );
@@ -143,6 +151,12 @@ final public class LongType extends AbstractIntegerType< LongType > implements N
 	public void setInteger( final long f )
 	{
 		set( f );
+	}
+
+	@Override
+	public void setBigInteger(BigInteger b)
+	{
+		set( b.longValue() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/ShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/ShortType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.ShortAccess;
@@ -115,6 +117,12 @@ public class ShortType extends GenericShortType< ShortType >
 	}
 
 	@Override
+	public BigInteger getBigInteger()
+	{
+		return BigInteger.valueOf( get() );
+	}
+
+	@Override
 	public void setInteger( final int f )
 	{
 		set( ( short ) f );
@@ -124,6 +132,12 @@ public class ShortType extends GenericShortType< ShortType >
 	public void setInteger( final long f )
 	{
 		set( ( short ) f );
+	}
+
+	@Override
+	public void setBigInteger( final BigInteger b)
+	{
+		set( b.shortValue() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
@@ -187,6 +187,11 @@ public class Unsigned128BitType extends AbstractIntegerType<Unsigned128BitType> 
 	}
 
 	@Override
+	public BigInteger getBigInteger() {
+		return get();
+	}
+
+	@Override
 	public void setInteger( final int value ) {
 		final int k = i * 2;
 		dataAccess.setValue( k, value );
@@ -198,6 +203,11 @@ public class Unsigned128BitType extends AbstractIntegerType<Unsigned128BitType> 
 		final int k = i * 2;
 		dataAccess.setValue( k, value );
 		dataAccess.setValue( k + 1, 0 );
+	}
+
+	@Override
+	public void setBigInteger(BigInteger b) {
+		set( b );
 	}
 
 	/** The maximum value that can be stored is {@code Math.pow(2, 128) -1},

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.ByteAccess;
@@ -175,6 +177,12 @@ public class UnsignedByteType extends GenericByteType< UnsignedByteType >
 	}
 
 	@Override
+	public BigInteger getBigInteger()
+	{
+		return BigInteger.valueOf( get() );
+	}
+
+	@Override
 	public void setInteger( final int f )
 	{
 		set( f );
@@ -184,6 +192,12 @@ public class UnsignedByteType extends GenericByteType< UnsignedByteType >
 	public void setInteger( final long f )
 	{
 		set( ( int ) f );
+	}
+
+	@Override
+	public void setBigInteger(BigInteger b)
+	{
+		set( b.intValue() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.IntAccess;
@@ -204,6 +206,12 @@ public class UnsignedIntType extends GenericIntType< UnsignedIntType >
 	}
 
 	@Override
+	public BigInteger getBigInteger()
+	{
+		return BigInteger.valueOf( get() );
+	}
+
+	@Override
 	public void setInteger( final int f )
 	{
 		set( f );
@@ -213,6 +221,12 @@ public class UnsignedIntType extends GenericIntType< UnsignedIntType >
 	public void setInteger( final long f )
 	{
 		set( f );
+	}
+
+	@Override
+	public void setBigInteger(BigInteger b)
+	{
+		set( b.longValue() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.LongAccess;
@@ -209,8 +211,16 @@ public class UnsignedLongType extends AbstractIntegerType<UnsignedLongType> impl
 	@Override
 	public void setInteger( final long f ) { set( f ); }
 
+	/** The maximum value that can be stored is {@code Math.pow( 2, 64 ) - 1},
+	 * which can't be represented with exact precision using a double */
 	@Override
-	public double getMaxValue() { return 0xffffffffL; }
+	public double getMaxValue() { return Math.pow( 2, 64 ) - 1; } //imprecise
+
+	/** Returns the true maximum value as a BigInteger, since it cannot be 
+	 * precisely represented as a {@code double}. */
+	public BigInteger getMaxBigIntegerValue() {
+		return new BigInteger("+FFFFFFFFFFFFFFFF", 16);
+	}
 	@Override
 	public double getMinValue()  { return 0; }
 

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
@@ -74,6 +74,14 @@ public class UnsignedLongType extends AbstractIntegerType<UnsignedLongType> impl
 		set( value );
 	}
 
+	// this is the constructor if you want it to be a variable 
+	public UnsignedLongType ( final BigInteger value )
+	{
+		img = null;
+		dataAccess = new LongArray ( 1 );
+		set( value.longValue() );
+	}
+
 	// this is the constructor if you want to specify the dataAccess
 	public UnsignedLongType( final LongAccess access )
 	{

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
@@ -203,6 +203,9 @@ public class UnsignedLongType extends AbstractIntegerType<UnsignedLongType> impl
 	@Override
 	public String toString() { return "" + get(); }
 
+	/** This method returns the value of the UnsignedLongType as a signed long. 
+	 * To get the unsigned value, use {@link UnsignedLongType#getAsBigInteger()}.
+	 */
 	public long get() {
 		return dataAccess.getValue( i );
 	}

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
@@ -209,6 +209,16 @@ public class UnsignedLongType extends AbstractIntegerType<UnsignedLongType> impl
 	public long get() {
 		return dataAccess.getValue( i );
 	}
+
+	/** This method returns the unsigned representation of this UnsignedLongType
+	 * as a {@code BigInteger}. */
+	@Override
+	public BigInteger getBigInteger ()
+	{
+		final BigInteger mask = new BigInteger("FFFFFFFFFFFFFFFF", 16);
+		return BigInteger.valueOf( get() ).and(mask);
+	}
+
 	public void set( final long value ) {
 		dataAccess.setValue( i, value);
 	}
@@ -221,6 +231,10 @@ public class UnsignedLongType extends AbstractIntegerType<UnsignedLongType> impl
 	public void setInteger( final int f ) { set( f ); }
 	@Override
 	public void setInteger( final long f ) { set( f ); }
+	@Override
+	public void setBigInteger( final BigInteger b ) { set( b.longValue() ); }
+
+	public void set( final BigInteger bi ) { set( bi.longValue() ); }
 
 	/** The maximum value that can be stored is {@code Math.pow( 2, 64 ) - 1},
 	 * which can't be represented with exact precision using a double */

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.ShortAccess;
@@ -184,6 +186,12 @@ public class UnsignedShortType extends GenericShortType< UnsignedShortType >
 	}
 
 	@Override
+	public BigInteger getBigInteger()
+	{
+		return BigInteger.valueOf( get() );
+	}
+
+	@Override
 	public void setInteger( final int f )
 	{
 		set( f );
@@ -193,6 +201,12 @@ public class UnsignedShortType extends GenericShortType< UnsignedShortType >
 	public void setInteger( final long f )
 	{
 		set( ( int ) f );
+	}
+
+	@Override
+	public void setBigInteger(BigInteger b)
+	{
+		set( b.intValue() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
@@ -35,6 +35,8 @@
 
 package net.imglib2.type.numeric.integer;
 
+import java.math.BigInteger;
+
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.NativeImgFactory;
 import net.imglib2.img.basictypeaccess.LongAccess;
@@ -146,10 +148,19 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type<UnsignedVar
 	public long getIntegerLong() { return get(); }
 
 	@Override
+	public BigInteger getBigInteger() {
+		if( get() < 0 )
+			return BigInteger.valueOf(get()).add(new BigInteger("2", 10).pow(nBits));
+		return BigInteger.valueOf( get() ); }
+
+	@Override
 	public void setInteger( final int f ) { setBits( f ); }
 
 	@Override
 	public void setInteger( final long f ) { setBits( f ); }
+
+	@Override
+	public void setBigInteger(BigInteger b) { setBits( b.longValue() ); }
 
 	/** The maximum value that can be stored is {@code Math.pow(2, nBits) -1}. */
 	@Override

--- a/src/test/java/net/imglib2/type/logic/BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/logic/BitTypeTest.java
@@ -36,13 +36,16 @@
  */
 package net.imglib2.type.logic;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigInteger;
 import java.util.Random;
 
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.logic.BitType;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -103,6 +106,35 @@ public class BitTypeTest {
 			t.set( b );
 			assertTrue( t.get() == b );
 		}
+	}
+
+	/**
+	 * Tests that {@link BitType#getBigInteger()} returns the BigInteger 
+	 * representation of a BitType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final BitType l = new BitType(false);
+
+		assertEquals( BigInteger.ZERO, l.getBigInteger() );
+	}
+
+	/**
+	 * Tests {@link BitType#setBigInteger(BigInteger)} and ensures that the value
+	 * returned is within BitType range.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final BitType ul = new BitType( false );
+
+		assertEquals( ul.get(), false );
+
+		final BigInteger bi = new BigInteger( "AAAAAA3141343BBBBBBBBBBB4134", 16 );
+		ul.setBigInteger( bi );
+
+		assertEquals( ul.get(), true );
 	}
 
 //	/**

--- a/src/test/java/net/imglib2/type/numeric/integer/ByteTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/ByteTypeTest.java
@@ -1,0 +1,42 @@
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+
+public class ByteTypeTest {
+
+	/**
+	 * Test which verifies {@link ByteType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of a ByteType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final ByteType l = new ByteType( (byte) 124 );
+		assertEquals( BigInteger.valueOf( 124l ), l.getBigInteger() );
+
+		final ByteType l2 = new ByteType( (byte) -18 );
+		assertEquals( BigInteger.valueOf( -18l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link ByteType#setBigInteger(BigInteger)} can set
+	 * ByteTypes with a {@code BigInteger} and still return a {@code byte} value.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final ByteType l = new ByteType( (byte) 93 );
+
+		assertEquals( l.get(), (byte) 93 );
+
+		final BigInteger bi = BigInteger.valueOf( -71l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), (byte) -71 );
+	}
+
+}

--- a/src/test/java/net/imglib2/type/numeric/integer/IntTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/IntTypeTest.java
@@ -1,0 +1,43 @@
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+
+public class IntTypeTest {
+
+	/**
+	 * Test which verifies {@link IntType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an IntType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final IntType l = new IntType( 10948 );
+		assertEquals( BigInteger.valueOf( 10948l ), l.getBigInteger() );
+
+		final IntType l2 = new IntType( -40913824 );
+		assertEquals( BigInteger.valueOf( -40913824l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link IntType#setBigInteger(BigInteger)}
+	 * can set IntTypes with a {@code BigInteger} and still return an
+	 * {@code int} value.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final IntType l = new IntType( 0 );
+
+		assertEquals( l.get(), 0 );
+
+		final BigInteger bi = BigInteger.valueOf( 7987431l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), 7987431 );
+	}
+
+}

--- a/src/test/java/net/imglib2/type/numeric/integer/LongTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/LongTypeTest.java
@@ -1,0 +1,42 @@
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+
+public class LongTypeTest {
+
+	/**
+	 * Test which verifies {@link LongType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an LongType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final LongType l = new LongType( 901374907l );
+		assertEquals( BigInteger.valueOf( 901374907l ), l.getBigInteger() );
+
+		final LongType l2 = new LongType( -98174938174l );
+		assertEquals( BigInteger.valueOf( -98174938174l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link LongType#setBigInteger(BigInteger)} can set
+	 * LongTypes with a {@code BigInteger} and still return a {@code long} value.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final LongType l = new LongType( 72l );
+
+		assertEquals( l.get(), 72l );
+
+		final BigInteger bi = BigInteger.valueOf( 1093840120l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), 1093840120l );
+	}
+
+}

--- a/src/test/java/net/imglib2/type/numeric/integer/ShortTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/ShortTypeTest.java
@@ -1,0 +1,43 @@
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+
+public class ShortTypeTest {
+
+	/**
+	 * Test which verifies {@link ShortType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of a ShortType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final ShortType l = new ShortType( (short) 31498 );
+		assertEquals( BigInteger.valueOf( 31498l ), l.getBigInteger() );
+
+		final ShortType l2 = new ShortType( (short) -24691 );
+		assertEquals( BigInteger.valueOf( -24691l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link ShortType#setBigInteger(BigInteger)} can set
+	 * ShortTypes with a {@code BigInteger} and still return a {@code short}
+	 * value.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final ShortType l = new ShortType( (short) 1082 );
+
+		assertEquals( l.get(), (short) 1082 );
+
+		final BigInteger bi = BigInteger.valueOf( 48906l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), (short) -16630 );
+	}
+
+}

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
@@ -104,4 +104,37 @@ public class Unsigned128BitTypeTest
 
 		assertFalse( i.equals( b ) );
 	}
+
+	/**
+	 * Test which verifies {@link Unsigned128BitType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an Unsigned128BitType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final BigInteger bi = new BigInteger("CAFE123498230498CAFE", 16);
+		final Unsigned128BitType l = new Unsigned128BitType( bi );
+		assertEquals( bi, l.getBigInteger() );
+
+		final BigInteger bi2 = BigInteger.valueOf( -279l );
+		final Unsigned128BitType l2 = new Unsigned128BitType( bi2 );
+		assertEquals( BigInteger.valueOf( 65257l ), l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link Unsigned128BitType#setBigInteger(BigInteger)}
+	 * can set Unsigned128BitTypes with a {@code BigInteger} and still return an
+	 * {@code int} value.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final BigInteger b = new BigInteger("BABE09481BEEF", 16);
+		final Unsigned128BitType l = new Unsigned128BitType( b );
+		assertEquals( l.get(), b );
+
+		final BigInteger bi = BigInteger.valueOf( 7987431l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), bi );
+	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned12BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned12BitTypeTest.java
@@ -33,8 +33,10 @@
  */
 package net.imglib2.type.numeric.integer;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigInteger;
 import java.util.Random;
 
 import net.imglib2.img.array.ArrayImg;
@@ -71,5 +73,36 @@ public class Unsigned12BitTypeTest
 			t.set( v );
 			assertTrue( t.get() == v );
 		}
+	}
+
+	/**
+	 * Test which verifies {@link Unsigned12BitType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an Unsigned12BitType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final Unsigned12BitType l = new Unsigned12BitType( 300l );
+		assertEquals( BigInteger.valueOf( 300l ), l.getBigInteger() );
+
+		final Unsigned12BitType l2 = new Unsigned12BitType( 5700l );
+		assertEquals( BigInteger.valueOf( 1604l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link Unsigned12BitType#setBigInteger(BigInteger)}
+	 * can set Unsigned12BitTypes with a {@code BigInteger} and still return an
+	 * {@code int} value that is in the proper range.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final Unsigned12BitType l = new Unsigned12BitType( 1029l );
+
+		assertEquals( l.get(), 1029l );
+
+		final BigInteger bi = BigInteger.valueOf( -122l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), 3974l );
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned2BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned2BitTypeTest.java
@@ -33,8 +33,10 @@
  */
 package net.imglib2.type.numeric.integer;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigInteger;
 import java.util.Random;
 
 import net.imglib2.img.array.ArrayImg;
@@ -71,5 +73,36 @@ public class Unsigned2BitTypeTest
 			t.set( v );
 			assertTrue( t.get() == v );
 		}
+	}
+
+	/**
+	 * Test which verifies {@link Unsigned2BitType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an Unsigned2BitType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final Unsigned2BitType l = new Unsigned2BitType( 2 );
+		assertEquals( BigInteger.valueOf( 2l ), l.getBigInteger() );
+
+		final Unsigned2BitType l2 = new Unsigned2BitType( 0l );
+		assertEquals( BigInteger.ZERO , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link Unsigned2BitType#setBigInteger(BigInteger)}
+	 * can set Unsigned2BitTypes with a {@code BigInteger} and still return an
+	 * {@code int} value that is in the proper range.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final Unsigned2BitType l = new Unsigned2BitType( 10l );
+
+		assertEquals( l.get(), 2l );
+
+		final BigInteger bi = BigInteger.valueOf( -122l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), 2l );
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned4BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned4BitTypeTest.java
@@ -33,8 +33,10 @@
  */
 package net.imglib2.type.numeric.integer;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigInteger;
 import java.util.Random;
 
 import net.imglib2.img.array.ArrayImg;
@@ -71,5 +73,36 @@ public class Unsigned4BitTypeTest
 			t.set( v );
 			assertTrue( t.get() == v );
 		}
+	}
+
+	/**
+	 * Test which verifies {@link Unsigned4BitType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an Unsigned4BitType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final Unsigned4BitType l = new Unsigned4BitType( 14l );
+		assertEquals( BigInteger.valueOf( 14l ), l.getBigInteger() );
+
+		final Unsigned4BitType l2 = new Unsigned4BitType( -7l );
+		assertEquals( BigInteger.valueOf( 9l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link Unsigned4BitType#setBigInteger(BigInteger)}
+	 * can set Unsigned4BitType with a {@code BigInteger} and still return an
+	 * {@code int} value that is in the proper range.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final Unsigned4BitType l = new Unsigned4BitType( 4l );
+
+		assertEquals( l.get(), 4l );
+
+		final BigInteger bi = BigInteger.valueOf( 163l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), 3l );
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedByteTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedByteTypeTest.java
@@ -35,6 +35,8 @@ package net.imglib2.type.numeric.integer;
 
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigInteger;
+
 import org.junit.Test;
 
 public class UnsignedByteTypeTest
@@ -82,5 +84,36 @@ public class UnsignedByteTypeTest
 		final UnsignedByteType u = new UnsignedByteType( i );
 
 		assertEquals( 44, u.get() );
+	}
+
+	/**
+	 * Test which verifies {@link UnsignedByteType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an UnsignedByteType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final UnsignedByteType l = new UnsignedByteType( 255 );
+		assertEquals( BigInteger.valueOf( 255l ), l.getBigInteger() );
+
+		final UnsignedByteType l2 = new UnsignedByteType( -127 );
+		assertEquals( BigInteger.valueOf( 129l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link UnsignedByteType#setBigInteger(BigInteger)} can
+	 * set UnsignedByteTypes with a {@code BigInteger} and still return an the
+	 * proper {@code int} value.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final UnsignedByteType l = new UnsignedByteType( 255 );
+
+		assertEquals( l.get(), 255 );
+
+		final BigInteger bi = BigInteger.valueOf( 400l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), 144 );
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedIntTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedIntTypeTest.java
@@ -35,6 +35,8 @@ package net.imglib2.type.numeric.integer;
 
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigInteger;
+
 import org.junit.Test;
 
 public class UnsignedIntTypeTest
@@ -83,5 +85,36 @@ public class UnsignedIntTypeTest
 		final UnsignedIntType u = new UnsignedIntType( l );
 
 		assertEquals( 4294965258L, u.get() );
+	}
+
+	/**
+	 * Test which verifies {@link UnsignedIntType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an UnsignedIntType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final UnsignedIntType l = new UnsignedIntType( 120345l );
+		assertEquals( BigInteger.valueOf( 120345l ), l.getBigInteger() );
+
+		final UnsignedIntType l2 = new UnsignedIntType( -1209843l );
+		assertEquals( BigInteger.valueOf( 4293757453l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link UnsignedIntType#setBigInteger(BigInteger)}
+	 * can set UnsignedIntTypes with a {@code BigInteger} and still return a
+	 * {@code long} value within the proper range.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final UnsignedIntType l = new UnsignedIntType( 6943 );
+
+		assertEquals( l.get(), 6943 );
+
+		final BigInteger bi = BigInteger.valueOf( 400984314908l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), 1552356380l );
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
@@ -3,6 +3,8 @@ package net.imglib2.type.numeric.integer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigInteger;
+
 import org.junit.Test;
 
 
@@ -76,6 +78,20 @@ public class UnsignedLongTypeTest {
 		u.set( 0L );
 		t.set( 698L );
 		assertTrue( u.compareTo( t ) <= -1 );
+
+	}
+
+	@Test 
+	public void testBIConstructor() {
+
+		BigInteger bi = new BigInteger("2", 10);
+		BigInteger sub = new BigInteger("1239847", 10);
+		bi = bi.pow(89);
+		bi = bi.subtract(sub);
+
+		final UnsignedLongType l = new UnsignedLongType(bi);
+
+		assertEquals(bi.longValue(), l.get() );
 
 	}
 

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
@@ -1,3 +1,37 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2015 Tobias Pietzsch, Stephan Preibisch, Barry DeZonia,
+ * Stephan Saalfeld, Curtis Rueden, Albert Cardona, Christian Dietz, Jean-Yves
+ * Tinevez, Johannes Schindelin, Jonathan Hale, Lee Kamentsky, Larry Lindsey, Mark
+ * Hiner, Michael Zinsmaier, Martin Horn, Grant Harris, Aivar Grislis, John
+ * Bogovic, Steffen Jaensch, Stefan Helfrich, Jan Funke, Nick Perry, Mark Longair,
+ * Melissa Linkert and Dimiter Prodanov.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
 package net.imglib2.type.numeric.integer;
 
 import static org.junit.Assert.assertEquals;
@@ -13,6 +47,9 @@ public class UnsignedLongTypeTest {
 	private UnsignedLongType u = new UnsignedLongType();
 	private UnsignedLongType t = new UnsignedLongType();
 
+	/** Tests that {@link UnsignedLongType#compareTo(UnsignedLongType)} works for
+	 * comparing a positive number to a negative number and vice versa.
+	 */
 	@Test
 	public void testComparePosNeg(){
 
@@ -30,6 +67,9 @@ public class UnsignedLongTypeTest {
 
 	}
 
+	/** Tests that {@link UnsignedLongType#compareTo(UnsignedLongType)} works for
+	 * comparing two negative numbers.
+	 */
 	@Test
 	public void testCompareNegatives(){
 
@@ -47,6 +87,9 @@ public class UnsignedLongTypeTest {
 
 	}
 
+	/** Tests that {@link UnsignedLongType#compareTo(UnsignedLongType)} works for
+	 * comparing two positive numbers.
+	 */
 	@Test
 	public void testComparePositives(){
 
@@ -64,6 +107,9 @@ public class UnsignedLongTypeTest {
 
 	}
 
+	/** Tests that {@link UnsignedLongType#compareTo(UnsignedLongType)} works
+	 * when comparing values to zero.
+	 */
 	@Test
 	public void testCompareZero() {
 
@@ -81,18 +127,54 @@ public class UnsignedLongTypeTest {
 
 	}
 
-	@Test 
+	/**
+	 * Tests {@link UnsignedLongType#UnsignedLongType(BigInteger)} works for out
+	 * of range values.
+	 */
+	@Test
 	public void testBIConstructor() {
 
-		BigInteger bi = new BigInteger("2", 10);
-		BigInteger sub = new BigInteger("1239847", 10);
-		bi = bi.pow(89);
-		bi = bi.subtract(sub);
+		final BigInteger bi = new BigInteger( "ABCD14984904EFEFEFE4324904294D17A", 16 );
+		final UnsignedLongType l = new UnsignedLongType( bi );
 
-		final UnsignedLongType l = new UnsignedLongType(bi);
-
-		assertEquals(bi.longValue(), l.get() );
-
+		assertEquals( bi.longValue(), l.get() );
 	}
 
+	/**
+	 * Tests that {@link UnsignedLongType#getBigInteger()} returns the unsigned
+	 * representation of an {@link UnsignedLongType} regardless of if it was
+	 * constructed with a {@code long} or a {@code BigInteger}.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final BigInteger mask = new BigInteger( "FFFFFFFFFFFFFFFF", 16 );
+		final BigInteger bi = new BigInteger( "DEAD12345678BEEF", 16 );
+		final UnsignedLongType l = new UnsignedLongType( bi );
+
+		assertEquals( bi.and( mask ), l.getBigInteger() );
+
+		final UnsignedLongType l2 = new UnsignedLongType( -473194873871904l );
+
+		assertEquals(BigInteger.valueOf( -473194873871904l ).and( mask ),
+			l2.getBigInteger() );
+	}
+
+	/**
+	 * Tests that {@link UnsignedLongType#setBigInteger(BigInteger)} works and
+	 * can still return the proper long value.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final long l = -184713894790123847l;
+		final UnsignedLongType ul = new UnsignedLongType( l );
+
+		assertEquals( ul.get(), l );
+
+		final BigInteger bi = new BigInteger( "AAAAAA3141343BBBBBBBBBBB4134", 16 );
+		ul.setBigInteger( bi );
+
+		assertEquals( ul.get(), bi.longValue() );
+	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
@@ -1,0 +1,82 @@
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+
+public class UnsignedLongTypeTest {
+
+	private UnsignedLongType u = new UnsignedLongType();
+	private UnsignedLongType t = new UnsignedLongType();
+
+	@Test
+	public void testComparePosNeg(){
+
+		u.set( -1L );
+		t.set( 1L );
+		assertTrue( u.compareTo( t ) >= 1 );
+
+		u.set( 9223372036854775807L );
+		t.set( -9223372036854775808L );
+		assertTrue( u.compareTo( t ) <= -1 );
+
+		u.set( -109817491384701984L );
+		t.set( 12L );
+		assertTrue( u.compareTo( t ) >= 1 );
+
+	}
+
+	@Test
+	public void testCompareNegatives(){
+
+		u.set( -9000L );
+		t.set( -9000L );
+		assertEquals( u.compareTo( t ), 0 );
+
+		u.set( -16L );
+		t.set( -10984012840123984L );
+		assertTrue( u.compareTo( t ) >= 1 );
+
+		u.set( -500L );
+		t.set( -219L );
+		assertTrue( u.compareTo( t ) <= -1 );
+
+	}
+
+	@Test
+	public void testComparePositives(){
+
+		u.set( 100L );
+		t.set( 100L );
+		assertEquals( u.compareTo( t ), 0);
+
+		u.set( 3098080948019L );
+		t.set( 1L );
+		assertTrue( u.compareTo( t ) >= 1 );
+
+		u.set( 199L );
+		t.set( 299L );
+		assertTrue( u.compareTo( t ) <= -1 );
+
+	}
+
+	@Test
+	public void testCompareZero() {
+
+		u.set( 0L );
+		t.set( 0L );
+		assertEquals( u.compareTo( t ), 0 );
+
+		u.set( -17112921L );
+		t.set( 0L );
+		assertTrue( u.compareTo( t ) >= 1 );
+
+		u.set( 0L );
+		t.set( 698L );
+		assertTrue( u.compareTo( t ) <= -1 );
+
+	}
+
+}

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedShortTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedShortTypeTest.java
@@ -35,6 +35,8 @@ package net.imglib2.type.numeric.integer;
 
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigInteger;
+
 import org.junit.Test;
 
 public class UnsignedShortTypeTest
@@ -82,5 +84,36 @@ public class UnsignedShortTypeTest
 		final UnsignedShortType u = new UnsignedShortType( i );
 
 		assertEquals( 64939, u.get() );
+	}
+
+	/**
+	 * Test which verifies {@link UnsignedShortType#getBigInteger()} returns the
+	 * {@code BigInteger} representation of an UnsignedShortType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final UnsignedShortType l = new UnsignedShortType( 1000 );
+		assertEquals( BigInteger.valueOf( 1000l ), l.getBigInteger() );
+
+		final UnsignedShortType l2 = new UnsignedShortType( 32001 );
+		assertEquals( BigInteger.valueOf( 32001l ) , l2.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies {@link UnsignedShortType#setBigInteger(BigInteger)}
+	 * can set UnsignedShortTypes with a {@code BigInteger} and still return an
+	 * {@code int} value within range.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final UnsignedShortType l = new UnsignedShortType( 93 );
+
+		assertEquals( l.get(), 93 );
+
+		final BigInteger bi = BigInteger.valueOf( -33125l );
+		l.setBigInteger( bi );
+		assertEquals( l.get(), 32411 );
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthTypeTest.java
@@ -1,0 +1,53 @@
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+
+public class UnsignedVariableBitLengthTypeTest {
+
+	/**
+	 * Test which verifies {@link UnsignedVariableBitLengthType#getBigInteger()}
+	 * returns the {@code BigInteger} representation of an
+	 * UnsignedVariableBitLengthType.
+	 */
+	@Test
+	public void testGetBigInteger() {
+
+		final UnsignedVariableBitLengthType l = new
+				UnsignedVariableBitLengthType( 1234l, 16 );
+		assertEquals( BigInteger.valueOf( 1234l ), l.getBigInteger() );
+
+		final UnsignedVariableBitLengthType l2 = new
+				UnsignedVariableBitLengthType( -196, 8);
+		assertEquals( BigInteger.valueOf( 60l ), l2.getBigInteger() );
+
+		final UnsignedVariableBitLengthType l3 = new
+				UnsignedVariableBitLengthType( -9223372036854775807l, 64 );
+		assertEquals( BigInteger.valueOf( -9223372036854775807l ).and( 
+			new BigInteger("FFFFFFFFFFFFFFFF", 16) ), l3.getBigInteger() );
+	}
+
+	/**
+	 * Test which verifies
+	 * {@link UnsignedVariableBitLengthType#setBigInteger(BigInteger)} can set
+	 * UnsignedVariableBitLengthTypes with a {@code BigInteger} and still return
+	 * a {@code long} value that is in the correct range.
+	 */
+	@Test
+	public void testSetBigInteger() {
+
+		final UnsignedVariableBitLengthType ul = new
+				UnsignedVariableBitLengthType( 6347, 14 );
+		assertEquals( ul.get(), 6347 );
+
+		ul.setBigInteger( BigInteger.valueOf( 15004l ) );
+		assertEquals( ul.get(), 15004l );
+
+		ul.setBigInteger( BigInteger.valueOf( 25625l ) );
+		assertEquals( ul.get(), 9241l );
+	}
+}


### PR DESCRIPTION
Hello!

These are the fixes for UnsignedLongType, as mentioned in #102 . That being said, upon further inspection I noticed that the compareTo method was fine. So I left the compareTo method alone, but I did keep the tests I made for it.

Additionally on this branch I added the methods getBigInteger, and setBigInteger to the IntegerType interface. This was done to allow for n-bit integer arithmetic, as well as the issue mentioned in #105 . The only problem I had with implementing these, was that [UnboundedIntegerType](https://github.com/imagej/imagej-common/blob/master/src/main/java/net/imagej/types/UnboundedIntegerType.java) in ImageJ-Common implements IntegerType.

Lastly, I also fixed a masking issue with 64 bits in UnsignedVariableBitLengthType.

Please let me know your thoughts on these changes or if you have any questions. Thank you in advance for your feedback!