### PR TITLE
Fix equals for integer bit types

### DIFF
--- a/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
@@ -169,6 +169,26 @@ public abstract class AbstractComplexType< T extends AbstractComplexType< T >> i
 	}
 
 	@Override
+	public boolean equals( final Object o )
+	{
+		if ( !getClass().isInstance(o) )
+			return false;
+		@SuppressWarnings("unchecked")
+		final T t = (T) o;
+		return getRealDouble() == t.getRealDouble() &&
+			getImaginaryDouble() == t .getImaginaryDouble();
+	}
+
+	@Override
+	public int hashCode()
+	{
+		// NB: Compute similar hash code to java.lang.Double#hashCode().
+		final long rBits = Double.doubleToLongBits(getRealDouble());
+		final long iBits = Double.doubleToLongBits(getImaginaryDouble());
+		return (int) (rBits ^ (rBits >>> 32) ^ iBits ^ (iBits >>> 32));
+	}
+
+	@Override
 	public String toString()
 	{
 		return "(" + getRealDouble() + ") + (" + getImaginaryDouble() + ")i";

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
@@ -97,6 +97,22 @@ public abstract class AbstractIntegerBitType<T extends AbstractIntegerBitType<T>
 	public void setOne() { setInteger( 1 ); }	
 
 	@Override
+	public boolean equals( final Object o ) {
+		if ( !getClass().isInstance(o) )
+			return false;
+		@SuppressWarnings("unchecked")
+		final T t = (T) o;
+		return compareTo(t) == 0;
+	}
+
+	@Override
+	public int hashCode() {
+		// NB: Use the same hash code as java.lang.Long#hashCode().
+		final long value = get();
+		return (int) (value ^ (value >>> 32));
+	}
+
+	@Override
 	public int compareTo( final T c ) 
 	{ 
 		final long a = getIntegerLong();

--- a/src/test/java/net/imglib2/type/numeric/complex/ComplexDoubleTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/complex/ComplexDoubleTypeTest.java
@@ -1,0 +1,88 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2015 Tobias Pietzsch, Stephan Preibisch, Barry DeZonia,
+ * Stephan Saalfeld, Curtis Rueden, Albert Cardona, Christian Dietz, Jean-Yves
+ * Tinevez, Johannes Schindelin, Jonathan Hale, Lee Kamentsky, Larry Lindsey, Mark
+ * Hiner, Michael Zinsmaier, Martin Horn, Grant Harris, Aivar Grislis, John
+ * Bogovic, Steffen Jaensch, Stefan Helfrich, Jan Funke, Nick Perry, Mark Longair,
+ * Melissa Linkert and Dimiter Prodanov.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.type.numeric.complex;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ComplexFloatType}.
+ * 
+ * @author Curtis Rueden
+ */
+public class ComplexDoubleTypeTest
+{
+
+	/**
+	 * Tests {@link ComplexDoubleType#equals(Object)}.
+	 */
+	@Test
+	public void testEquals()
+	{
+		final ComplexDoubleType b = new ComplexDoubleType( 1.234, 5.678 );
+
+		// non-matching types and values
+		final ComplexFloatType i = new ComplexFloatType( 8.765f, 4.321f );
+		assertFalse( b.equals( i ) );
+		assertFalse( i.equals( b ) );
+
+		// non-matching types
+		final ComplexFloatType i2 = new ComplexFloatType( 1.234f, 5.678f );
+		assertFalse( b.equals( i2 ) );
+		assertFalse( i2.equals( b ) );
+
+		// non-matching values
+		final ComplexDoubleType i3 = new ComplexDoubleType( 8.765, 4.321 );
+		assertFalse( b.equals( i3 ) );
+		assertFalse( i3.equals( b ) );
+
+		// matching type and value
+		final ComplexDoubleType i4 = new ComplexDoubleType( 1.234, 5.678 );
+		assertTrue( b.equals( i4 ) );
+		assertTrue( i4.equals( b ) );
+	}
+
+
+	/** Tests {@link ComplexDoubleType#hashCode()}. */
+	@Test
+	public void testHashCode()
+	{
+		final ComplexDoubleType b = new ComplexDoubleType( 1.234, 5.678 );
+		assertEquals( 379318760, b.hashCode() );
+	}
+
+}

--- a/src/test/java/net/imglib2/type/numeric/complex/ComplexFloatTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/complex/ComplexFloatTypeTest.java
@@ -1,0 +1,88 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2015 Tobias Pietzsch, Stephan Preibisch, Barry DeZonia,
+ * Stephan Saalfeld, Curtis Rueden, Albert Cardona, Christian Dietz, Jean-Yves
+ * Tinevez, Johannes Schindelin, Jonathan Hale, Lee Kamentsky, Larry Lindsey, Mark
+ * Hiner, Michael Zinsmaier, Martin Horn, Grant Harris, Aivar Grislis, John
+ * Bogovic, Steffen Jaensch, Stefan Helfrich, Jan Funke, Nick Perry, Mark Longair,
+ * Melissa Linkert and Dimiter Prodanov.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.type.numeric.complex;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ComplexFloatType}.
+ * 
+ * @author Curtis Rueden
+ */
+public class ComplexFloatTypeTest
+{
+
+	/**
+	 * Tests {@link ComplexFloatType#equals(Object)}.
+	 */
+	@Test
+	public void testEquals()
+	{
+		final ComplexFloatType b = new ComplexFloatType( 1.234f, 5.678f );
+
+		// non-matching types and values
+		final ComplexDoubleType i = new ComplexDoubleType( 8.765, 4.321 );
+		assertFalse( b.equals( i ) );
+		assertFalse( i.equals( b ) );
+
+		// non-matching types
+		final ComplexDoubleType i2 = new ComplexDoubleType( 1.234, 5.678 );
+		assertFalse( b.equals( i2 ) );
+		assertFalse( i2.equals( b ) );
+
+		// non-matching values
+		final ComplexFloatType i3 = new ComplexFloatType( 8.765f, 4.321f );
+		assertFalse( b.equals( i3 ) );
+		assertFalse( i3.equals( b ) );
+
+		// matching type and value
+		final ComplexFloatType i4 = new ComplexFloatType( 1.234f, 5.678f );
+		assertTrue( b.equals( i4 ) );
+		assertTrue( i4.equals( b ) );
+	}
+
+
+	/** Tests {@link ComplexFloatType#hashCode()}. */
+	@Test
+	public void testHashCode()
+	{
+		final ComplexFloatType b = new ComplexFloatType( 1.234f, 5.678f );
+		assertEquals( 535103539, b.hashCode() );
+	}
+
+}

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
@@ -122,6 +122,14 @@ public class Unsigned128BitTypeTest
 		assertTrue( i4.equals( b ) );
 	}
 
+	/** Tests {@link Unsigned128BitType#hashCode()}. */
+	@Test
+	public void testHashCode()
+	{
+		final Unsigned128BitType b = new Unsigned128BitType( BigInteger.valueOf( 908742l ) );
+		assertEquals( 908742, b.hashCode() );
+	}
+
 	/**
 	 * Test which verifies {@link Unsigned128BitType#getBigInteger()} returns the
 	 * {@code BigInteger} representation of an Unsigned128BitType.

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
@@ -99,10 +99,27 @@ public class Unsigned128BitTypeTest
 	@Test
 	public void testEquals()
 	{
-		final UnsignedIntType i = new UnsignedIntType( 127l );
 		final Unsigned128BitType b = new Unsigned128BitType( BigInteger.valueOf( 908742l ) );
 
+		// non-matching types and values
+		final UnsignedIntType i = new UnsignedIntType( 127l );
+		assertFalse( b.equals( i ) );
 		assertFalse( i.equals( b ) );
+
+		// non-matching types
+		final UnsignedIntType i2 = new UnsignedIntType( 908742l );
+		assertFalse( b.equals( i2 ) );
+		assertFalse( i2.equals( b ) );
+
+		// non-matching values
+		final Unsigned128BitType i3 = new Unsigned128BitType( BigInteger.valueOf( 127l ) );
+		assertFalse( b.equals( i3 ) );
+		assertFalse( i3.equals( b ) );
+
+		// matching type and value
+		final Unsigned128BitType i4 = new Unsigned128BitType( BigInteger.valueOf( 908742l ) );
+		assertTrue( b.equals( i4 ) );
+		assertTrue( i4.equals( b ) );
 	}
 
 	/**
@@ -137,4 +154,5 @@ public class Unsigned128BitTypeTest
 		l.setBigInteger( bi );
 		assertEquals( l.get(), bi );
 	}
+
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned12BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned12BitTypeTest.java
@@ -34,6 +34,7 @@
 package net.imglib2.type.numeric.integer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
@@ -105,4 +106,43 @@ public class Unsigned12BitTypeTest
 		l.setBigInteger( bi );
 		assertEquals( l.get(), 3974l );
 	}
+
+	/**
+	 * Tests {@link Unsigned12BitType#equals(Object)}.
+	 */
+	@Test
+	public void testEquals()
+	{
+		final Unsigned12BitType b = new Unsigned12BitType( 3526l );
+
+		// non-matching types and values
+		final UnsignedIntType i = new UnsignedIntType( 127l );
+		assertFalse( b.equals( i ) );
+		assertFalse( i.equals( b ) );
+
+		// non-matching types
+		final UnsignedIntType i2 = new UnsignedIntType( 3526l );
+		assertFalse( b.equals( i2 ) );
+		assertFalse( i2.equals( b ) );
+
+		// non-matching values
+		final Unsigned12BitType i3 = new Unsigned12BitType( 127l );
+		assertFalse( b.equals( i3 ) );
+		assertFalse( i3.equals( b ) );
+
+		// matching type and value
+		final Unsigned12BitType i4 = new Unsigned12BitType( 3526l );
+		assertTrue( b.equals( i4 ) );
+		assertTrue( i4.equals( b ) );
+	}
+
+
+	/** Tests {@link Unsigned12BitType#hashCode()}. */
+	@Test
+	public void testHashCode()
+	{
+		final Unsigned12BitType b = new Unsigned12BitType( 3526l );
+		assertEquals( 3526, b.hashCode() );
+	}
+
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned2BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned2BitTypeTest.java
@@ -34,6 +34,7 @@
 package net.imglib2.type.numeric.integer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
@@ -105,4 +106,45 @@ public class Unsigned2BitTypeTest
 		l.setBigInteger( bi );
 		assertEquals( l.get(), 2l );
 	}
+
+	/**
+	 * Tests {@link Unsigned2BitType#equals(Object)}.
+	 */
+	@Test
+	public void testEquals()
+	{
+		final Unsigned2BitType b = new Unsigned2BitType( 3l );
+
+		// non-matching types and values
+		final UnsignedIntType i = new UnsignedIntType( 1l );
+		assertFalse( b.equals( i ) );
+		assertFalse( i.equals( b ) );
+
+		// non-matching types
+		final UnsignedIntType i2 = new UnsignedIntType( 3l );
+		assertFalse( b.equals( i2 ) );
+		assertFalse( i2.equals( b ) );
+
+		// non-matching values
+		final Unsigned2BitType i3 = new Unsigned2BitType( 1l );
+		assertFalse( b.equals( i3 ) );
+		assertFalse( i3.equals( b ) );
+
+		// matching type and value
+		final Unsigned2BitType i4 = new Unsigned2BitType( 3l );
+		assertTrue( b.equals( i4 ) );
+		assertTrue( i4.equals( b ) );
+	}
+
+
+	/** Tests {@link Unsigned2BitType#hashCode()}. */
+	@Test
+	public void testHashCode()
+	{
+		for (int i = 0; i < 4; i++) {
+			final Unsigned2BitType b = new Unsigned2BitType( i );
+			assertEquals( i, b.hashCode() );
+		}
+	}
+
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned4BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned4BitTypeTest.java
@@ -34,6 +34,7 @@
 package net.imglib2.type.numeric.integer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
@@ -104,5 +105,45 @@ public class Unsigned4BitTypeTest
 		final BigInteger bi = BigInteger.valueOf( 163l );
 		l.setBigInteger( bi );
 		assertEquals( l.get(), 3l );
+	}
+
+	/**
+	 * Tests {@link Unsigned4BitType#equals(Object)}.
+	 */
+	@Test
+	public void testEquals()
+	{
+		final Unsigned4BitType b = new Unsigned4BitType( 13l );
+
+		// non-matching types and values
+		final UnsignedIntType i = new UnsignedIntType( 2l );
+		assertFalse( b.equals( i ) );
+		assertFalse( i.equals( b ) );
+
+		// non-matching types
+		final UnsignedIntType i2 = new UnsignedIntType( 13l );
+		assertFalse( b.equals( i2 ) );
+		assertFalse( i2.equals( b ) );
+
+		// non-matching values
+		final Unsigned4BitType i3 = new Unsigned4BitType( 2l );
+		assertFalse( b.equals( i3 ) );
+		assertFalse( i3.equals( b ) );
+
+		// matching type and value
+		final Unsigned4BitType i4 = new Unsigned4BitType( 13l );
+		assertTrue( b.equals( i4 ) );
+		assertTrue( i4.equals( b ) );
+	}
+
+
+	/** Tests {@link Unsigned4BitType#hashCode()}. */
+	@Test
+	public void testHashCode()
+	{
+		for (int i = 0; i < 16; i++) {
+			final Unsigned4BitType b = new Unsigned4BitType( i );
+			assertEquals( i, b.hashCode() );
+		}
 	}
 }


### PR DESCRIPTION
This improves behavior of equals for types extending `AbstractIntegerBitType`:
`Unsigned2BitType`, `Unsigned4BitType` and `Unsigned12BitType`.

The reason it is necessary is because AbstractIntegerBitType extends
AbstractBitType rather than AbstractRealType, and hence does not inherit the
latter's equals, hashCode or compareTo method implementations. (The equals
implementation here is actual equal to the one in AbstractRealType.)

@tpietzsch Does this look OK?