### PR TITLE
Adds getters to several classes

### DIFF
--- a/src/main/java/net/imglib2/AbstractWrappedRealInterval.java
+++ b/src/main/java/net/imglib2/AbstractWrappedRealInterval.java
@@ -90,4 +90,9 @@ public abstract class AbstractWrappedRealInterval< I extends RealInterval > impl
 	{
 		return sourceInterval.numDimensions();
 	}
+	
+	public I getSource()
+	{
+		return sourceInterval;
+	}
 }

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessible.java
@@ -56,9 +56,15 @@ abstract public class AbstractConvertedRandomAccessible< A, B > implements Rando
 		return source.numDimensions();
 	}
 
+	public RandomAccessible< A > getSource()
+	{
+		return source;
+	}
+
 	@Override
 	abstract public AbstractConvertedRandomAccess< A, B > randomAccess();
 
 	@Override
 	abstract public AbstractConvertedRandomAccess< A, B > randomAccess( final Interval interval );
+	
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
@@ -75,12 +75,15 @@ public class ConvertedIterableInterval< A, B extends Type< B > > extends Abstrac
 	{
 		return new ConvertedCursor< A, B >( sourceInterval.localizingCursor(), converter, converted );
 	}
-	
+
+	/**
+	 * @return an instance of the destination {@link Type}.
+	 */
 	public B getDestinationType()
 	{
 		return converted.copy();
 	}
-	
+
 	public Converter< ? super A, ? super B > getConverter()
 	{
 		return converter;

--- a/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
@@ -75,4 +75,14 @@ public class ConvertedIterableInterval< A, B extends Type< B > > extends Abstrac
 	{
 		return new ConvertedCursor< A, B >( sourceInterval.localizingCursor(), converter, converted );
 	}
+	
+	public B getDestinationType()
+	{
+		return converted.copy();
+	}
+	
+	public Converter< ? super A, ? super B > getConverter()
+	{
+		return converter;
+	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
@@ -68,4 +68,14 @@ public class ConvertedRandomAccessible< A, B extends Type< B > > extends Abstrac
 	{
 		return new ConvertedRandomAccess< A, B >( source.randomAccess( interval ), converter, converted );
 	}
+	
+	public B getDestinationType()
+	{
+		return converted.copy();
+	}
+
+	public Converter< ? super A, ? super B > getConverter()
+	{
+		return converter;
+	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
@@ -68,7 +68,10 @@ public class ConvertedRandomAccessible< A, B extends Type< B > > extends Abstrac
 	{
 		return new ConvertedRandomAccess< A, B >( source.randomAccess( interval ), converter, converted );
 	}
-	
+
+	/**
+	 * @return an instance of the destination {@link Type}.
+	 */
 	public B getDestinationType()
 	{
 		return converted.copy();

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
@@ -68,7 +68,10 @@ public class ConvertedRandomAccessibleInterval< A, B extends Type< B > > extends
 	{
 		return new ConvertedRandomAccess< A, B >( sourceInterval.randomAccess( interval ), converter, converted );
 	}
-	
+
+	/**
+	 * @return an instance of the destination {@link Type}.
+	 */
 	public B getDestinationType()
 	{
 		return converted.copy();

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
@@ -68,4 +68,14 @@ public class ConvertedRandomAccessibleInterval< A, B extends Type< B > > extends
 	{
 		return new ConvertedRandomAccess< A, B >( sourceInterval.randomAccess( interval ), converter, converted );
 	}
+	
+	public B getDestinationType()
+	{
+		return converted.copy();
+	}
+
+	public Converter< ? super A, ? super B > getConverter()
+	{
+		return converter;
+	}
 }

--- a/src/main/java/net/imglib2/interpolation/Interpolant.java
+++ b/src/main/java/net/imglib2/interpolation/Interpolant.java
@@ -75,4 +75,17 @@ final public class Interpolant< T, F extends EuclideanSpace > implements RealRan
 	{
 		return factory.create( source, interval );
 	}
+	
+	public F getSource()
+	{
+		return source;
+	}
+	
+	/**
+	 * @return {@link InterpolatorFactory} used for interpolation
+	 */
+	public InterpolatorFactory< T, F > getInterpolatorFactory()
+	{
+		return factory;
+	}
 }

--- a/src/main/java/net/imglib2/view/ExtendedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/view/ExtendedRandomAccessibleInterval.java
@@ -88,4 +88,9 @@ final public class ExtendedRandomAccessibleInterval< T, F extends RandomAccessib
 	{
 		return source;
 	}
+	
+	public OutOfBoundsFactory< T, ? super F > getOutOfBoundsFactory()
+	{
+		return factory;
+	}
 }

--- a/src/main/java/net/imglib2/view/ExtendedRealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/view/ExtendedRealRandomAccessibleRealInterval.java
@@ -82,4 +82,14 @@ final public class ExtendedRealRandomAccessibleRealInterval< T, F extends RealRa
 		if ( Intervals.contains( source, interval ) ) { return source.realRandomAccess(); }
 		return realRandomAccess();
 	}
+	
+	public F getSource()
+	{
+		return source;
+	}
+
+	public RealOutOfBoundsFactory< T, ? super F > getFactory()
+	{
+		return factory;
+	}
 }

--- a/src/main/java/net/imglib2/view/ExtendedRealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/view/ExtendedRealRandomAccessibleRealInterval.java
@@ -82,13 +82,13 @@ final public class ExtendedRealRandomAccessibleRealInterval< T, F extends RealRa
 		if ( Intervals.contains( source, interval ) ) { return source.realRandomAccess(); }
 		return realRandomAccess();
 	}
-	
+
 	public F getSource()
 	{
 		return source;
 	}
 
-	public RealOutOfBoundsFactory< T, ? super F > getFactory()
+	public RealOutOfBoundsFactory< T, ? super F > getOutOfBoundsFactory()
 	{
 		return factory;
 	}

--- a/src/main/java/net/imglib2/view/StackView.java
+++ b/src/main/java/net/imglib2/view/StackView.java
@@ -33,6 +33,7 @@
  */
 package net.imglib2.view;
 
+import java.util.Arrays;
 import java.util.List;
 
 import net.imglib2.AbstractInterval;
@@ -146,6 +147,19 @@ public class StackView< T > extends AbstractInterval implements RandomAccessible
 				new DefaultRA< T >( slices, interval );
 	}
 
+	public List< RandomAccessibleInterval< T > > getSource()
+	{
+		return Arrays.asList( slices );
+	}
+
+	/**
+	 * @return {@link StackAccessMode} defined in constructor
+	 */
+	public StackAccessMode getStackAccessMode()
+	{
+		return stackAccessMode;
+	}
+	
 	/**
 	 * A {@link RandomAccess} on a {@link StackView}. It keeps a list of
 	 * {@link RandomAccess}es on all constituent hyper-slices of the

--- a/src/main/java/net/imglib2/view/StackView.java
+++ b/src/main/java/net/imglib2/view/StackView.java
@@ -147,7 +147,14 @@ public class StackView< T > extends AbstractInterval implements RandomAccessible
 				new DefaultRA< T >( slices, interval );
 	}
 
-	public List< RandomAccessibleInterval< T > > getSource()
+	/**
+	 * Get the source slices that are stacked in this {@link StackView}. These
+	 * are {@code (numDimensions() - 1)} dimensional
+	 * {@link RandomAccessibleInterval}s.
+	 *
+	 * @return list of source hyperslices.
+	 */
+	public List< RandomAccessibleInterval< T > > getSourceSlices()
 	{
 		return Arrays.asList( slices );
 	}

--- a/src/main/java/net/imglib2/view/SubsampleView.java
+++ b/src/main/java/net/imglib2/view/SubsampleView.java
@@ -270,4 +270,17 @@ public class SubsampleView< T > implements RandomAccessible< T >
 	{
 		return new SubsampleRandomAccess( interval );
 	}
+	
+	public RandomAccessible< T > getSource()
+	{
+		return source;
+	}
+
+	/**
+	 * @return sub-sampling steps
+	 */
+	public long[] getSteps()
+	{
+		return steps.clone();
+	}
 }


### PR DESCRIPTION
allows decomposition (and subsequent recomposition) of the wrapped objects. Useful for serialization. Potentially we want `WrappedSource`, `WrappedInterpolationFactory,... interfaces later. 