### PR TITLE
Mark lightweight data objects with a common iface

### DIFF
--- a/src/main/java/net/imglib2/View.java
+++ b/src/main/java/net/imglib2/View.java
@@ -32,61 +32,28 @@
  * #L%
  */
 
-package net.imglib2.interpolation;
-
-import net.imglib2.EuclideanSpace;
-import net.imglib2.RealInterval;
-import net.imglib2.RealRandomAccess;
-import net.imglib2.RealRandomAccessible;
-import net.imglib2.View;
+package net.imglib2;
 
 /**
- * A {@link RealRandomAccessible} that is generated through interpolation.
+ * An interface which marks an object that is a lightweight wrapper or "view"
+ * around actual data.
+ * <p>
+ * This is useful to introspect at runtime whether a data object might benefit
+ * from being copied to "burn in" the information, for reasons such as:
+ * </p>
+ * <ul>
+ * <li>To avoid costly recomputation, at the expense of more memory use.</li>
+ * <li>To avoid corrupting the wrapped data structure when the object is
+ * mutated.</li>
+ * </ul>
  * 
- * @author ImgLib2 developers
- * @author Stephan Saalfeld <saalfeld@mpi-cbg.de>
+ * @author Curtis Rueden
  * @author Tobias Pietzsch
+ * @author Christian Dietz (University of Konstanz)
+ * @see net.imglib2.view.Views
+ * @see net.imglib2.converter.Converters
  */
-final public class Interpolant< T, F extends EuclideanSpace > implements RealRandomAccessible< T >, View
+public interface View
 {
-	final protected F source;
-
-	final InterpolatorFactory< T, F > factory;
-
-	public Interpolant( final F source, final InterpolatorFactory< T, F > factory )
-	{
-		this.source = source;
-		this.factory = factory;
-	}
-
-	@Override
-	public int numDimensions()
-	{
-		return source.numDimensions();
-	}
-
-	@Override
-	public RealRandomAccess< T > realRandomAccess()
-	{
-		return factory.create( source );
-	}
-
-	@Override
-	public RealRandomAccess< T > realRandomAccess( final RealInterval interval )
-	{
-		return factory.create( source, interval );
-	}
-	
-	public F getSource()
-	{
-		return source;
-	}
-	
-	/**
-	 * @return {@link InterpolatorFactory} used for interpolation
-	 */
-	public InterpolatorFactory< T, F > getInterpolatorFactory()
-	{
-		return factory;
-	}
+	// NB: Marker interface.
 }

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableInterval.java
@@ -38,12 +38,13 @@ import java.util.Iterator;
 
 import net.imglib2.AbstractWrappedInterval;
 import net.imglib2.IterableInterval;
+import net.imglib2.View;
 
 /**
  * TODO
  * 
  */
-abstract public class AbstractConvertedIterableInterval< A, B > extends AbstractWrappedInterval< IterableInterval< A > > implements IterableInterval< B >
+abstract public class AbstractConvertedIterableInterval< A, B > extends AbstractWrappedInterval< IterableInterval< A > > implements IterableInterval< B >, View
 {
 	public AbstractConvertedIterableInterval( final IterableInterval< A > source )
 	{

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableRandomAccessibleInterval.java
@@ -41,12 +41,13 @@ import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.View;
 
 /**
  * TODO
  * 
  */
-abstract public class AbstractConvertedIterableRandomAccessibleInterval< A, B, S extends RandomAccessible< A > & IterableInterval< A > > extends AbstractWrappedInterval< S > implements IterableInterval< B >, RandomAccessibleInterval< B >
+abstract public class AbstractConvertedIterableRandomAccessibleInterval< A, B, S extends RandomAccessible< A > & IterableInterval< A > > extends AbstractWrappedInterval< S > implements IterableInterval< B >, RandomAccessibleInterval< B >, View
 {
 	public AbstractConvertedIterableRandomAccessibleInterval( final S source )
 	{

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessible.java
@@ -36,12 +36,13 @@ package net.imglib2.converter;
 
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
+import net.imglib2.View;
 
 /**
  * TODO
  * 
  */
-abstract public class AbstractConvertedRandomAccessible< A, B > implements RandomAccessible< B >
+abstract public class AbstractConvertedRandomAccessible< A, B > implements RandomAccessible< B >, View
 {
 	final protected RandomAccessible< A > source;
 

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
@@ -37,6 +37,7 @@ package net.imglib2.converter.read;
 import net.imglib2.AbstractWrappedInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.View;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.Type;
 
@@ -44,7 +45,7 @@ import net.imglib2.type.Type;
  * TODO
  * 
  */
-public class ConvertedRandomAccessibleInterval< A, B extends Type< B > > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >
+public class ConvertedRandomAccessibleInterval< A, B extends Type< B > > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >, View
 {
 	final protected Converter< ? super A, ? super B > converter;
 

--- a/src/main/java/net/imglib2/view/ExtendedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/view/ExtendedRandomAccessibleInterval.java
@@ -38,6 +38,7 @@ import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.View;
 import net.imglib2.outofbounds.OutOfBounds;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.util.Intervals;
@@ -51,7 +52,7 @@ import net.imglib2.util.Intervals;
  * @author Stephan Saalfeld <saalfeld@mpi-cbg.de>
  * @author Tobias Pietzsch
  */
-final public class ExtendedRandomAccessibleInterval< T, F extends RandomAccessibleInterval< T > > implements RandomAccessible< T >
+final public class ExtendedRandomAccessibleInterval< T, F extends RandomAccessibleInterval< T > > implements RandomAccessible< T >, View
 {
 	final protected F source;
 

--- a/src/main/java/net/imglib2/view/IntervalView.java
+++ b/src/main/java/net/imglib2/view/IntervalView.java
@@ -43,6 +43,7 @@ import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.View;
 import net.imglib2.view.iteration.IterableTransformBuilder;
 
 /**
@@ -52,7 +53,7 @@ import net.imglib2.view.iteration.IterableTransformBuilder;
  * created through the {@link Views#interval(RandomAccessible, Interval)} method
  * instead.
  */
-public class IntervalView< T > extends AbstractInterval implements RandomAccessibleInterval< T >, IterableInterval< T >
+public class IntervalView< T > extends AbstractInterval implements RandomAccessibleInterval< T >, IterableInterval< T >, View
 {
 	/**
 	 * The source {@link RandomAccessible}.

--- a/src/main/java/net/imglib2/view/IterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/view/IterableRandomAccessibleInterval.java
@@ -43,6 +43,7 @@ import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.View;
 
 /**
  * Generates {@link Cursor Cursors} that iterate a
@@ -52,7 +53,7 @@ import net.imglib2.RandomAccessibleInterval;
  * @author Stephan Saalfeld
  * @author Stephan Saalfeld <saalfeld@mpi-cbg.de>
  */
-public class IterableRandomAccessibleInterval< T > extends AbstractWrappedInterval< RandomAccessibleInterval< T > > implements IterableInterval< T >, RandomAccessibleInterval< T >
+public class IterableRandomAccessibleInterval< T > extends AbstractWrappedInterval< RandomAccessibleInterval< T > > implements IterableInterval< T >, RandomAccessibleInterval< T >, View
 {
 	final long size;
 

--- a/src/main/java/net/imglib2/view/MixedTransformView.java
+++ b/src/main/java/net/imglib2/view/MixedTransformView.java
@@ -37,6 +37,7 @@ package net.imglib2.view;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
+import net.imglib2.View;
 import net.imglib2.transform.integer.Mixed;
 import net.imglib2.transform.integer.MixedTransform;
 

--- a/src/main/java/net/imglib2/view/RandomAccessibleOnRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/view/RandomAccessibleOnRealRandomAccessible.java
@@ -41,6 +41,7 @@ import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RealRandomAccess;
 import net.imglib2.RealRandomAccessible;
+import net.imglib2.View;
 
 /**
  * {@link RandomAccessible} on a {@link RealRandomAccessible}. For optimal
@@ -53,7 +54,7 @@ import net.imglib2.RealRandomAccessible;
  * @author ImgLib2 developers
  * @author Stephan Saalfeld <saalfeld@mpi-cbg.de>
  */
-public class RandomAccessibleOnRealRandomAccessible< T > extends AbstractEuclideanSpace implements RandomAccessible< T >
+public class RandomAccessibleOnRealRandomAccessible< T > extends AbstractEuclideanSpace implements RandomAccessible< T >, View
 {
 	final protected RealRandomAccessible< T > target;
 

--- a/src/main/java/net/imglib2/view/StackView.java
+++ b/src/main/java/net/imglib2/view/StackView.java
@@ -42,6 +42,7 @@ import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.View;
 import net.imglib2.util.Util;
 
 /**
@@ -53,7 +54,7 @@ import net.imglib2.util.Util;
  * 
  * @author Tobias Pietzsch <tobias.pietzsch@gmail.com>
  */
-public class StackView< T > extends AbstractInterval implements RandomAccessibleInterval< T >
+public class StackView< T > extends AbstractInterval implements RandomAccessibleInterval< T >, View
 {
 	/**
 	 * Describes how a {@link RandomAccess} on the <em>(n+1)</em>-dimensional

--- a/src/main/java/net/imglib2/view/SubsampleView.java
+++ b/src/main/java/net/imglib2/view/SubsampleView.java
@@ -37,6 +37,7 @@ import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
+import net.imglib2.View;
 
 /**
  * {@link SubsampleView} is a view that provides access to only every
@@ -49,7 +50,7 @@ import net.imglib2.RandomAccessible;
  * 
  * @author Stephan Saalfeld <saalfeld@mpi-cbg.de>
  */
-public class SubsampleView< T > implements RandomAccessible< T >
+public class SubsampleView< T > implements RandomAccessible< T >, View
 {
 	final protected RandomAccessible< T > source;
 

--- a/src/main/java/net/imglib2/view/TransformedRandomAccessible.java
+++ b/src/main/java/net/imglib2/view/TransformedRandomAccessible.java
@@ -35,6 +35,7 @@
 package net.imglib2.view;
 
 import net.imglib2.RandomAccessible;
+import net.imglib2.View;
 import net.imglib2.transform.Transform;
 
 /**
@@ -44,7 +45,7 @@ import net.imglib2.transform.Transform;
  * 
  * @author Tobias Pietzsch
  */
-public interface TransformedRandomAccessible< T > extends RandomAccessible< T >
+public interface TransformedRandomAccessible< T > extends RandomAccessible< T >, View
 {
 	/**
 	 * Get the source of the TransformedRandomAccessible. This is the next

--- a/src/main/java/net/imglib2/view/composite/CompositeIntervalView.java
+++ b/src/main/java/net/imglib2/view/composite/CompositeIntervalView.java
@@ -37,6 +37,7 @@ import net.imglib2.Interval;
 import net.imglib2.Positionable;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealPositionable;
+import net.imglib2.View;
 import net.imglib2.view.Views;
 
 /**
@@ -44,7 +45,7 @@ import net.imglib2.view.Views;
  * 
  * @author Stephan Saalfeld <saalfeld@mpi-cbg.de>
  */
-public class CompositeIntervalView< T, C extends Composite< T > > extends CompositeView< T, C > implements RandomAccessibleInterval< C >
+public class CompositeIntervalView< T, C extends Composite< T > > extends CompositeView< T, C > implements RandomAccessibleInterval< C >, View
 {
 	final Interval interval;
 

--- a/src/main/java/net/imglib2/view/composite/CompositeView.java
+++ b/src/main/java/net/imglib2/view/composite/CompositeView.java
@@ -37,6 +37,7 @@ import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
+import net.imglib2.View;
 
 /**
  * {@link CompositeView} collapses the trailing dimension of a
@@ -46,7 +47,7 @@ import net.imglib2.RandomAccessible;
  * 
  * @author Stephan Saalfeld <saalfeld@mpi-cbg.de>
  */
-public class CompositeView< T, C extends Composite< T > > implements RandomAccessible< C >
+public class CompositeView< T, C extends Composite< T > > implements RandomAccessible< C >, View
 {
 	final protected CompositeFactory< T, C > compositeFactory;
 


### PR DESCRIPTION
The concept of a "view" is in several places across ImgLib2; it is convenient to have them all share a common interface.

Firstly, this allows for runtime introspection, so that programs can decide whether it is warranted to make a copy of the data (i.e., to "burn it in"), to avoid:

1. Costly recomputation when the lightweight data is accessed; and
2. Corrupting underlying data when the lightweight data mutates.

Secondly, this interface provides a common point for exploring the ImgLib2 API, so that programmers can easily browse which lightweight data structures exist, and how they are implemented.