### PR TITLE
Create API typed on long for ComplexType

### DIFF
--- a/src/main/java/net/imglib2/type/numeric/ComplexType.java
+++ b/src/main/java/net/imglib2/type/numeric/ComplexType.java
@@ -52,13 +52,25 @@ public interface ComplexType< T extends ComplexType< T >> extends NumericType< T
 
 	public void setReal( double f );
 
+	public void setReal( int f );
+
+	public void setReal( long f );
+
 	public void setImaginary( float f );
 
 	public void setImaginary( double f );
 
+	public void setImaginary( int f );
+
+	public void setImaginary( long f );
+
 	public void setComplexNumber( float r, float i );
 
 	public void setComplexNumber( double r, double i );
+
+	public void setComplexNumber( int r, int i );
+
+	public void setComplexNumber( long r, long i );
 
 	public float getPowerFloat();
 

--- a/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
@@ -169,6 +169,20 @@ public abstract class AbstractComplexType< T extends AbstractComplexType< T >> i
 	}
 
 	@Override
+	public void setComplexNumber( final int r, final int i)
+	{
+		setReal( r );
+		setImaginary( i );
+	}
+
+	@Override
+	public void setComplexNumber( final long r, final long i)
+	{
+		setReal( r );
+		setImaginary( i );
+	}
+
+	@Override
 	public boolean equals( final Object o )
 	{
 		if ( !getClass().isInstance(o) )

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
@@ -150,6 +150,18 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 	}
 
 	@Override
+	public void setReal( final int r )
+	{
+		dataAccess.setValue( realI, r );
+	}
+
+	@Override
+	public void setReal( final long r )
+	{
+		dataAccess.setValue( realI, r );
+	}
+
+	@Override
 	public void setImaginary( final float i )
 	{
 		dataAccess.setValue( imaginaryI, i );
@@ -157,6 +169,18 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 
 	@Override
 	public void setImaginary( final double i )
+	{
+		dataAccess.setValue( imaginaryI, i );
+	}
+
+	@Override
+	public void setImaginary( final int i )
+	{
+		dataAccess.setValue( imaginaryI, i );
+	}
+
+	@Override
+	public void setImaginary( final long i )
 	{
 		dataAccess.setValue( imaginaryI, i );
 	}

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
@@ -150,6 +150,18 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	}
 
 	@Override
+	public void setReal( final int r )
+	{
+		dataAccess.setValue( realI, r );
+	}
+
+	@Override
+	public void setReal( final long r )
+	{
+		dataAccess.setValue( realI, r );
+	}
+
+	@Override
 	public void setImaginary( final float i )
 	{
 		dataAccess.setValue( imaginaryI, i );
@@ -159,6 +171,18 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	public void setImaginary( final double i )
 	{
 		dataAccess.setValue( imaginaryI, ( float ) i );
+	}
+
+	@Override
+	public void setImaginary( final int i )
+	{
+		dataAccess.setValue( imaginaryI, i );
+	}
+
+	@Override
+	public void setImaginary( final long i )
+	{
+		dataAccess.setValue( imaginaryI, i );
 	}
 
 	public void set( final float r, final float i )

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
@@ -90,6 +90,10 @@ public abstract class AbstractIntegerBitType<T extends AbstractIntegerBitType<T>
 	public void setReal( final float real ){ setInteger( Util.round( real ) ); }
 	@Override
 	public void setReal( final double real ){ setInteger( Util.round( real ) ); }	
+	@Override
+	public void setReal( final int real ){ setInteger( real ); }	
+	@Override
+	public void setReal( final long real ){ setInteger( real ); }	
 
 	@Override
 	public void setZero() { setInteger( 0 ); }
@@ -182,6 +186,10 @@ public abstract class AbstractIntegerBitType<T extends AbstractIntegerBitType<T>
 	public void setImaginary( final float complex ){}
 	@Override
 	public void setImaginary( final double complex ){}
+	@Override
+	public void setImaginary( final int complex ){}
+	@Override
+	public void setImaginary( final long complex ){}
 
 	@Override
 	public float getPhaseFloat() { return 0; }
@@ -197,6 +205,10 @@ public abstract class AbstractIntegerBitType<T extends AbstractIntegerBitType<T>
 	public void setComplexNumber( final float r, final float i ) { setReal( r ); }
 	@Override
 	public void setComplexNumber( final double r, final double i ) { setReal( r ); }
+	@Override
+	public void setComplexNumber( final int r, final int i ) { setReal( r ); }
+	@Override
+	public void setComplexNumber( final long r, final long i ) { setReal( r ); }
 
 	@Override
 	public void complexConjugate(){}

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerType.java
@@ -75,6 +75,18 @@ public abstract class AbstractIntegerType< T extends AbstractIntegerType< T >> e
 	}
 
 	@Override
+	public void setReal( final int real )
+	{
+		setInteger( real );
+	}
+
+	@Override
+	public void setReal( final long real )
+	{
+		setInteger( real );
+	}
+
+	@Override
 	public void inc()
 	{
 		setInteger( getIntegerLong() + 1 );

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
@@ -126,7 +126,11 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type<UnsignedVar
 	@Override
 	public void setReal( final float real ){ setInteger( Util.round( real ) ); }
 	@Override
-	public void setReal( final double real ){ setInteger( Util.round( real ) ); }	
+	public void setReal( final double real ){ setInteger( Util.round( real ) ); }
+	@Override
+	public void setReal( final int real ){ setInteger( real ); }	
+	@Override
+	public void setReal( final long real ){ setInteger( real ); }	
 
 	@Override
 	public void setZero() { setInteger( 0 ); }
@@ -192,6 +196,10 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type<UnsignedVar
 	public void setImaginary( final float complex ){}
 	@Override
 	public void setImaginary( final double complex ){}
+	@Override
+	public void setImaginary( final int complex ){}
+	@Override
+	public void setImaginary( final long complex ){}
 
 	@Override
 	public float getPhaseFloat() { return 0; }
@@ -207,6 +215,10 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type<UnsignedVar
 	public void setComplexNumber( final float r, final float i ) { setReal( r ); }
 	@Override
 	public void setComplexNumber( final double r, final double i ) { setReal( r ); }
+	@Override
+	public void setComplexNumber( final int r, final int i ) { setReal( r ); }
+	@Override
+	public void setComplexNumber( final long r, final long i ) { setReal( r ); }
 
 	@Override
 	public void complexConjugate(){}

--- a/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
@@ -64,6 +64,14 @@ public abstract class AbstractRealType< T extends AbstractRealType< T >> extends
 	{}
 
 	@Override
+	public void setImaginary( final int complex )
+	{}
+
+	@Override
+	public void setImaginary( final long complex )
+	{}
+
+	@Override
 	public void inc()
 	{
 		setReal( getRealDouble() + 1 );

--- a/src/main/java/net/imglib2/type/numeric/real/DoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/DoubleType.java
@@ -145,6 +145,18 @@ public class DoubleType extends AbstractRealType< DoubleType > implements Native
 	}
 
 	@Override
+	public void setReal( final int real )
+	{
+		set( real );
+	}
+
+	@Override
+	public void setReal( final long real )
+	{
+		set( real );
+	}
+
+	@Override
 	public double getMaxValue()
 	{
 		return Double.MAX_VALUE;

--- a/src/main/java/net/imglib2/type/numeric/real/FloatType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/FloatType.java
@@ -145,6 +145,18 @@ public class FloatType extends AbstractRealType< FloatType > implements NativeTy
 	}
 
 	@Override
+	public void setReal( final int real )
+	{
+		set( real );
+	}
+
+	@Override
+	public void setReal( final long real )
+	{
+		set( real );
+	}
+
+	@Override
 	public double getMaxValue()
 	{
 		return Float.MAX_VALUE;

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
@@ -93,6 +93,18 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	}
 
 	@Override
+	public void setReal( final int f )
+	{
+		t.setReal( f );
+	}
+
+	@Override
+	public void setReal( final long f )
+	{
+		t.setReal( f );
+	}
+
+	@Override
 	public void setImaginary( final float f )
 	{
 		t.setImaginary( f );
@@ -105,6 +117,18 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	}
 
 	@Override
+	public void setImaginary( final int f )
+	{
+		t.setImaginary( f );
+	}
+
+	@Override
+	public void setImaginary( final long f )
+	{
+		t.setImaginary( f );
+	}
+
+	@Override
 	public void setComplexNumber( final float r, final float i )
 	{
 		t.setComplexNumber( r, i );
@@ -112,6 +136,18 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 
 	@Override
 	public void setComplexNumber( final double r, final double i )
+	{
+		t.setComplexNumber( r, i );
+	}
+
+	@Override
+	public void setComplexNumber( final int r, final int i )
+	{
+		t.setComplexNumber( r, i );
+	}
+
+	@Override
+	public void setComplexNumber( final long r, final long i )
 	{
 		t.setComplexNumber( r, i );
 	}


### PR DESCRIPTION
getRealLong, getImginaryLong, setReal(long), setImginary(long) are created in the ComplexType interface, and its implementations are modified accordingly.

This branch addresses issue #110 . To be more clear, that issue points out the unexpected behavior:
```
public <T extends RealType<T>> void setLargeLongNum(T final num) {
    num.setReal(9876543210L);    // number greater than Integer.MAX_VALUE
}
...
LongType num = new LongType();
setLargeLongNum(num);
System.out.println(num.get());    // outputs "2.147483647E9"
...
```

After looking into the source code, it seems to me that it makes sense to call `num.setReal((double) 9876543210L);` instead of the call above, since `double` and `long` both have same length of storage. But users might intuitively think that, although converting `long` to `float` is quite lossy, we should at least get something close to the original number (9876543210L) instead of `Integer.MAX_VALUE`. So should this be considered a bug? or just that it is inherently tricky? Probably this branch is not that necessary.

In addition, I did not create `ComplexLongType`, since I am not sure if we need that, but it would be pretty easy to create. I also did not create tests for this feature, since I think the their `float` and `double` counterparts do not have tests either.