### PR TITLE
make Views.iterable() correctly deal with RandomAccessibleInterval<T>…

### DIFF
--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -35,6 +35,7 @@
 package net.imglib2.view;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 import net.imglib2.EuclideanSpace;
@@ -736,7 +737,13 @@ public class Views
 	public static < T > IterableInterval< T > iterable( final RandomAccessibleInterval< T > randomAccessibleInterval )
 	{
 		if ( IterableInterval.class.isInstance( randomAccessibleInterval ) )
-			return ( IterableInterval< T > ) randomAccessibleInterval;
+		{
+			final Class< ? > raiType = Util.getTypeFromInterval( randomAccessibleInterval ).getClass();
+			final Iterator< ? > iter = ( ( IterableInterval< ? > ) randomAccessibleInterval ).iterator();
+			final Object o = iter.hasNext() ? iter.next() : null;
+			if ( raiType.isInstance( o ) )
+				return ( IterableInterval< T > ) randomAccessibleInterval;
+		}
 		return new IterableRandomAccessibleInterval< T >( randomAccessibleInterval );
 	}
 
@@ -755,7 +762,13 @@ public class Views
 	public static < T > IterableInterval< T > flatIterable( final RandomAccessibleInterval< T > randomAccessibleInterval )
 	{
 		if ( IterableInterval.class.isInstance( randomAccessibleInterval ) && FlatIterationOrder.class.isInstance( ( ( IterableInterval< T > ) randomAccessibleInterval ).iterationOrder() ) )
-			return ( IterableInterval< T > ) randomAccessibleInterval;
+		{
+			final Class< ? > raiType = Util.getTypeFromInterval( randomAccessibleInterval ).getClass();
+			final Iterator< ? > iter = ( ( IterableInterval< ? > ) randomAccessibleInterval ).iterator();
+			final Object o = iter.hasNext() ? iter.next() : null;
+			if ( raiType.isInstance( o ) )
+				return ( IterableInterval< T > ) randomAccessibleInterval;
+		}
 		return new IterableRandomAccessibleInterval< T >( randomAccessibleInterval );
 	}
 


### PR DESCRIPTION
… that are IterabeInterval but not of type T.

This fix is related to imglib2-roi and requires some explanation/discussion:
The problem it fixes is the following:
Assume we have `Img<BitType img` that describes a region (pixels inside are `true`, pixels outside are `false`).
Then `Regions.iterable(img)` will give you an `IterableRegion<BitType>`.
`IterableRegion<BitType>` is `RandomAccessibleInterval<BitType>` and `IterableInterval<Void>`.
If you iterate it, it will only iterate the pixels inside the region (only the `true` pixels of the `img`). It is `IterableInterval<Void>` to make this a bit more explicit, e.g., distinguish `Regions.iterable` from `Views.iterable` etc. For example, Regions.sample() takes an `IterableInterval<Void>`, so if you accidentaly wrote `Views.iterable` instead of `Regions.iterable` compiler type checking will pick that up.

No the following problem occurs. You have a `IterableRegion<BitType>` and want to use it as a `RandomAccessible<BitType>` in some code that doesn't care about it's region properties. Then that code might want to do `Views.iterable` to get a `IterableInterval<BitType>`. So `Views.iterable` needs to be able to see the `IterableInterval` type (`Void`) doesn't match the `RandomAccessibleInterval` type (`BitType`) and do "the right thing".


Actually, "the right thing" would somehow give cursors of the original `Img<BitType>`, but this is not so easy to achieve, because an `IterableRegion` cannot be both `IterableInterval<BitType>` and `IterableInterval<Void>`.

So this PR is more of a work-around. It's a fix that gives the right results without changing any API but we might want to revisit the issue later...

@axtimwalde @StephanPreibisch @dietzc @ctrueden
Any comments?