### PR TITLE
fix a bug in Views related to SlicingTransforms.

### DIFF
--- a/src/main/java/net/imglib2/transform/integer/SlicingTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/SlicingTransform.java
@@ -365,4 +365,27 @@ public class SlicingTransform extends AbstractMixedTransform implements Slicing,
 
 		return mat;
 	}
+
+	/**
+	 * Check whether the transforms has a full mapping of source to target
+	 * components (no source component is discarded).
+	 *
+	 * @return whether there is a full mapping of source to target components.
+	 */
+	public boolean hasFullSourceMapping()
+	{
+		final boolean[] sourceMapped = new boolean[ numSourceDimensions ];
+		for ( int d = 0; d < numTargetDimensions; ++d )
+		{
+			if ( !zero[ d ] )
+			{
+				sourceMapped[ component[ d ] ] = true;
+			}
+		}
+		for ( int d = 0; d < numSourceDimensions; ++d )
+		{
+			if ( !sourceMapped[ d ] ) { return false; }
+		}
+		return true;
+	}
 }

--- a/src/main/java/net/imglib2/view/TransformBuilder.java
+++ b/src/main/java/net/imglib2/view/TransformBuilder.java
@@ -446,6 +446,7 @@ public class TransformBuilder< T >
 
 	protected RandomAccessible< T > wrapSlicingTransform( final RandomAccessible< T > s, final SlicingTransform t )
 	{
+		final boolean full = t.hasFullSourceMapping();
 		return new RandomAccessible< T >()
 		{
 			@Override
@@ -455,14 +456,18 @@ public class TransformBuilder< T >
 			}
 
 			@Override
-			public SlicingRandomAccess< T > randomAccess()
+			public RandomAccess< T > randomAccess()
 			{
+				if ( full )
+					return new FullSourceMapSlicingRandomAccess< T >( s.randomAccess(), t );
 				return new SlicingRandomAccess< T >( s.randomAccess(), t );
 			}
 
 			@Override
-			public SlicingRandomAccess< T > randomAccess( final Interval interval )
+			public RandomAccess< T > randomAccess( final Interval interval )
 			{
+				if ( full )
+					return new FullSourceMapSlicingRandomAccess< T >( s.randomAccess(), t );
 				return new SlicingRandomAccess< T >( s.randomAccess(), t );
 			}
 		};


### PR DESCRIPTION
fixes a bug in Views related to SlicingTransforms which do not map all components of the source vector. This is now handled correctly by SlicingRandomAccess. A new FullSourceMapSlicingRandomAccess was added which handles the (common) situation that all source components are used. This is what intuitively is understood as a slicing, but the SlicingTransform covers more cases.

In particular the bug occured with the following setup:
3D (XYT) image --> Views.addDimension to get 4D (XYTZ) --> Views.permute to get 4D (XYZT) --> Views.hyperSlice to get 3D (XYZ). This is covered by SlicingTransform, but the Z component of the final 3D (XYZ) view is not mapped to any component of the original 3D (XYT) image.

Crazy that there are still new Views bugs showing up after all this time...