### PR TITLE
implemented equals() and hashCode() in ValuePair 

### DIFF
--- a/src/main/java/net/imglib2/util/ValuePair.java
+++ b/src/main/java/net/imglib2/util/ValuePair.java
@@ -62,4 +62,41 @@ public class ValuePair< A, B > implements Pair< A, B >
 	{
 		return b;
 	}
+	
+	@Override
+	public int hashCode()
+	{
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( a == null ) ? 0 : a.hashCode() );
+		result = prime * result + ( ( b == null ) ? 0 : b.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		if ( this == obj )
+			return true;
+		if ( obj == null )
+			return false;
+		if ( !(obj instanceof Pair) )
+			return false;
+		Pair other = (Pair) obj;
+		if ( a == null )
+		{
+			if ( other.getA() != null )
+				return false;
+		}
+		else if ( !a.equals( other.getA() ) )
+			return false;
+		if ( b == null )
+		{
+			if ( other.getB() != null )
+				return false;
+		}
+		else if ( !b.equals( other.getB() ) )
+			return false;
+		return true;
+	}
 }


### PR DESCRIPTION
Pairs should be equal if their contents are equal. 
The proposed methods are slightly modified from Eclipses auto-generated methods so that it will equal any Pair with the same contents.