### PR TITLE
Add LinearAccessible interface and Views

### DIFF
--- a/src/main/java/net/imglib2/LinearAccess.java
+++ b/src/main/java/net/imglib2/LinearAccess.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2;
+
+import net.imglib2.img.array.ArrayImg;
+
+/**
+ *
+ * @author Philipp Hanslovsky
+ *
+ *         Access a source {@link LinearAccessible} by linear indexing. An
+ *         example use case is array like access for an {@link ArrayImg}.
+ *
+ * @param <T>
+ */
+public interface LinearAccess< T > extends Sampler< T >
+{
+
+	@Override
+	LinearAccess< T > copy();
+
+	/**
+	 *
+	 * Set position at which data be read on call to {@link Sampler#get()}.
+	 */
+	void set( int position );
+
+	/**
+	 *
+	 * Set position at which data be read on call to {@link Sampler#get()}.
+	 */
+	void set( long position );
+
+	/**
+	 *
+	 * Set position and immediately return {@link T} at this position.
+	 */
+	default T get( final int position )
+	{
+		set( position );
+		return get();
+	}
+
+	/**
+	 *
+	 * Set position and immediately return {@link T} at this position.
+	 */
+	default T get( final long position )
+	{
+		set( position );
+		return get();
+	}
+
+	/**
+	 *
+	 * Get the last position that was set through {@link LinearAccess#set(int)},
+	 * {@link LinearAccess#set(long)}, or indirectly through
+	 * {@link LinearAccess#get(int)}, {@link LinearAccess#get(long)}.
+	 */
+	long getPosition();
+
+}

--- a/src/main/java/net/imglib2/LinearAccessible.java
+++ b/src/main/java/net/imglib2/LinearAccessible.java
@@ -1,0 +1,60 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2;
+
+/**
+ *
+ * @author Philipp Hanslovsky
+ *
+ * @param <T>
+ */
+public interface LinearAccessible< T >
+{
+
+	/**
+	 *
+	 * @return {@link LinearAccess} that translates access at linear indices
+	 *         into access into the underlying data.
+	 */
+	LinearAccess< T > linearAccess();
+
+	/**
+	 *
+	 * @return The number of elements in this {@link LinearAccessible}. The
+	 *         {@link LinearAccess} should be valid {@link T} for all integral
+	 *         positions [0, size).
+	 */
+	long size();
+
+}

--- a/src/main/java/net/imglib2/LinearAccessibleFactory.java
+++ b/src/main/java/net/imglib2/LinearAccessibleFactory.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2;
+
+/**
+ *
+ * Create a {@link LinearAccessible} of given size and type.
+ *
+ * @author Philipp Hanslovsky
+ *
+ * @param <T>
+ */
+public interface LinearAccessibleFactory< T >
+{
+
+	public LinearAccessible< T > create( long size, T t );
+
+}

--- a/src/main/java/net/imglib2/img/array/ArrayLinearAccess.java
+++ b/src/main/java/net/imglib2/img/array/ArrayLinearAccess.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.array;
+
+import net.imglib2.LinearAccess;
+import net.imglib2.type.NativeType;
+
+/**
+ *
+ * Implementation of {@link LinearAccess} for {@link ArrayImg}
+ *
+ * @author Philipp Hanslovsky
+ *
+ * @param <T>
+ */
+public class ArrayLinearAccess< T extends NativeType< T > > implements LinearAccess< T >
+{
+	protected final T type;
+
+	private ArrayLinearAccess( final ArrayLinearAccess< T > access )
+	{
+		this.type = access.type.duplicateTypeOnSameNativeImg();
+
+		type.updateContainer( this );
+		type.updateIndex( access.type.getIndex() );
+	}
+
+	public ArrayLinearAccess( final ArrayImg< T, ? > img )
+	{
+		this.type = img.createLinkedType();
+
+		type.updateContainer( this );
+		type.updateIndex( 0 );
+	}
+
+	@Override
+	public T get()
+	{
+		return type;
+	}
+
+	@Override
+	public ArrayLinearAccess< T > copy()
+	{
+		return new ArrayLinearAccess<>( this );
+	}
+
+	@Override
+	public void set( final int position )
+	{
+		type.updateIndex( position );
+	}
+
+	@Override
+	public void set( final long position )
+	{
+		type.updateIndex( ( int ) position );
+	}
+
+	@Override
+	public long getPosition()
+	{
+		return type.getIndex();
+	}
+
+}

--- a/src/main/java/net/imglib2/img/planar/PlanarLinearAccess.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLinearAccess.java
@@ -1,0 +1,136 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.planar;
+
+import net.imglib2.LinearAccess;
+import net.imglib2.img.planar.PlanarImg.PlanarContainerSampler;
+import net.imglib2.type.NativeType;
+
+/**
+ *
+ * Implementation of {@link LinearAccess} for {@link PlanarImg}
+ *
+ * @author Philipp Hanslovsky
+ *
+ * @param <T>
+ */
+public class PlanarLinearAccess< T extends NativeType< T > > implements LinearAccess< T >, PlanarContainerSampler
+{
+	protected final T type;
+
+	private final int sliceSize;
+
+	private final int lastIndex;
+
+	private final int lastSliceIndex;
+
+	private int index;
+
+	private int sliceIndex;
+
+	private PlanarLinearAccess( final PlanarLinearAccess< T > access )
+	{
+		this.type = access.type.duplicateTypeOnSameNativeImg();
+
+		this.lastIndex = access.lastIndex;
+		this.lastSliceIndex = access.lastSliceIndex;
+		this.sliceSize = access.sliceSize;
+
+		this.index = access.index;
+		this.sliceIndex = access.sliceIndex;
+
+		type.updateContainer( this );
+		type.updateIndex( access.index );
+	}
+
+	public PlanarLinearAccess( final PlanarImg< T, ? > img )
+	{
+		this.type = img.createLinkedType();
+
+		this.sliceSize = ( img.numDimensions() > 1 ? img.dimensions[ 1 ] : 1 ) * img.dimensions[ 0 ];
+		this.lastIndex = this.sliceSize - 1;
+		this.lastSliceIndex = img.numSlices() - 1;
+
+		this.index = 0;
+		this.sliceIndex = 0;
+
+		type.updateContainer( this );
+		type.updateIndex( this.index );
+	}
+
+	@Override
+	public T get()
+	{
+		return type;
+	}
+
+	@Override
+	public PlanarLinearAccess< T > copy()
+	{
+		return new PlanarLinearAccess<>( this );
+	}
+
+	@Override
+	public void set( final long position )
+	{
+		set( ( int ) position );
+	}
+
+	@Override
+	public void set( final int position )
+	{
+		final int sliceIndex = position / sliceSize;
+		if ( sliceIndex != this.sliceIndex )
+		{
+			this.sliceIndex = sliceIndex;
+			type.updateContainer( this );
+		}
+
+		this.index = position - this.sliceIndex * sliceSize;
+		type.updateIndex( this.index );
+	}
+
+	@Override
+	public long getPosition()
+	{
+		return this.sliceIndex * sliceSize + this.index;
+	}
+
+	@Override
+	public int getCurrentSliceIndex()
+	{
+		return this.sliceIndex;
+	}
+
+}

--- a/src/main/java/net/imglib2/view/linear/AbstractLinearAccessibleViewOnRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/view/linear/AbstractLinearAccessibleViewOnRandomAccessibleInterval.java
@@ -1,0 +1,178 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.view.linear;
+
+import net.imglib2.Interval;
+import net.imglib2.LinearAccessible;
+import net.imglib2.Positionable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealPositionable;
+import net.imglib2.util.Intervals;
+
+/**
+ *
+ * View any {@link RandomAccessibleInterval} as {@link LinearAccessible}. For
+ * convenience, this class implements {@link RandomAccessibleInterval}.
+ *
+ * @author Philipp Hanslovsky
+ *
+ * @param <T>
+ */
+public abstract class AbstractLinearAccessibleViewOnRandomAccessibleInterval< T > implements RandomAccessibleInterval< T >, LinearAccessible< T >
+{
+
+	protected final RandomAccessibleInterval< T > source;
+
+	protected final int numDimensions;
+
+	protected final long size;
+
+	public AbstractLinearAccessibleViewOnRandomAccessibleInterval( final RandomAccessibleInterval< T > source )
+	{
+		super();
+		this.source = source;
+		this.numDimensions = source.numDimensions();
+		this.size = Intervals.numElements( source );
+	}
+
+	@Override
+	public RandomAccess< T > randomAccess()
+	{
+		return source.randomAccess();
+	}
+
+	@Override
+	public RandomAccess< T > randomAccess( final Interval interval )
+	{
+		return randomAccess();
+	}
+
+	@Override
+	public int numDimensions()
+	{
+		return numDimensions;
+	}
+
+	@Override
+	public long min( final int d )
+	{
+		return source.min( d );
+	}
+
+	@Override
+	public void min( final long[] min )
+	{
+		source.min( min );
+	}
+
+	@Override
+	public void min( final Positionable min )
+	{
+		source.min( min );
+	}
+
+	@Override
+	public long max( final int d )
+	{
+		return source.max( d );
+	}
+
+	@Override
+	public void max( final long[] max )
+	{
+		source.max( max );
+	}
+
+	@Override
+	public void max( final Positionable max )
+	{
+		source.max( max );
+	}
+
+	@Override
+	public double realMin( final int d )
+	{
+		return source.realMin( d );
+	}
+
+	@Override
+	public void realMin( final double[] min )
+	{
+		source.realMin( min );
+	}
+
+	@Override
+	public void realMin( final RealPositionable min )
+	{
+		source.realMin( min );
+	}
+
+	@Override
+	public double realMax( final int d )
+	{
+		return source.realMax( d );
+	}
+
+	@Override
+	public void realMax( final double[] max )
+	{
+		source.realMax( max );
+	}
+
+	@Override
+	public void realMax( final RealPositionable max )
+	{
+		source.realMax( max );
+	}
+
+	@Override
+	public void dimensions( final long[] dimensions )
+	{
+		source.dimensions( dimensions );
+	}
+
+	@Override
+	public long dimension( final int d )
+	{
+		return source.dimension( d );
+	}
+
+	@Override
+	public long size()
+	{
+		return size;
+	}
+
+}

--- a/src/main/java/net/imglib2/view/linear/LinearAccessibleViewOnArrayImg.java
+++ b/src/main/java/net/imglib2/view/linear/LinearAccessibleViewOnArrayImg.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.view.linear;
+
+import net.imglib2.LinearAccessible;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayLinearAccess;
+import net.imglib2.type.NativeType;
+
+/**
+ *
+ * View {@link ArrayImg} as {@link LinearAccessible} (efficient).
+ *
+ * @author Philipp Hanslovsky
+ *
+ * @param <T>
+ */
+public class LinearAccessibleViewOnArrayImg< T extends NativeType< T > > extends AbstractLinearAccessibleViewOnRandomAccessibleInterval< T >
+{
+
+	private final ArrayImg< T, ? > source;
+
+	public LinearAccessibleViewOnArrayImg( final ArrayImg< T, ? > source )
+	{
+		super( source );
+		this.source = source;
+	}
+
+	@Override
+	public ArrayLinearAccess< T > linearAccess()
+	{
+		return new ArrayLinearAccess<>( source );
+	}
+
+}

--- a/src/main/java/net/imglib2/view/linear/LinearAccessibleViewOnPlanarImg.java
+++ b/src/main/java/net/imglib2/view/linear/LinearAccessibleViewOnPlanarImg.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.view.linear;
+
+import net.imglib2.LinearAccessible;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.planar.PlanarImg;
+import net.imglib2.img.planar.PlanarLinearAccess;
+import net.imglib2.type.NativeType;
+
+/**
+ *
+ * View {@link ArrayImg} as {@link LinearAccessible}.
+ *
+ * @author Philipp Hanslovsky
+ *
+ * @param <T>
+ */
+public class LinearAccessibleViewOnPlanarImg< T extends NativeType< T > > extends AbstractLinearAccessibleViewOnRandomAccessibleInterval< T >
+{
+
+	private final PlanarImg< T, ? > source;
+
+	public LinearAccessibleViewOnPlanarImg( final PlanarImg< T, ? > source )
+	{
+		super( source );
+		this.source = source;
+	}
+
+	@Override
+	public PlanarLinearAccess< T > linearAccess()
+	{
+		return new PlanarLinearAccess<>( source );
+	}
+
+}

--- a/src/main/java/net/imglib2/view/linear/LinearAccessibleViewOnRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/view/linear/LinearAccessibleViewOnRandomAccessibleInterval.java
@@ -1,0 +1,117 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.view.linear;
+
+import net.imglib2.LinearAccess;
+import net.imglib2.LinearAccessible;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.util.IntervalIndexer;
+
+/**
+ *
+ * View arbitrary {@link RandomAccessibleInterval} as {@link LinearAccessible}.
+ * This is the inefficient fallback for any {@link RandomAccessibleInterval}
+ * that does not provide an efficient {@link LinearAccess}.
+ *
+ * @author Philipp Hanslovsky
+ *
+ * @param <T>
+ */
+public class LinearAccessibleViewOnRandomAccessibleInterval< T > extends AbstractLinearAccessibleViewOnRandomAccessibleInterval< T >
+{
+	public LinearAccessibleViewOnRandomAccessibleInterval( final RandomAccessibleInterval< T > source )
+	{
+		super( source );
+	}
+
+	@Override
+	public LinearAccess< T > linearAccess()
+	{
+		return new RandomAccessibleIntervalLinearAccess( source );
+	}
+
+	public class RandomAccessibleIntervalLinearAccess implements LinearAccess< T >
+	{
+
+		private final RandomAccess< T > access;
+
+		private final long position;
+
+		public RandomAccessibleIntervalLinearAccess( final RandomAccessible< T > source )
+		{
+			this( source.randomAccess(), 0 );
+		}
+
+		public RandomAccessibleIntervalLinearAccess( final RandomAccess< T > access, final long position )
+		{
+			super();
+			this.access = access;
+			this.position = position;
+		}
+
+		@Override
+		public T get()
+		{
+			return access.get();
+		}
+
+		@Override
+		public LinearAccess< T > copy()
+		{
+			return new RandomAccessibleIntervalLinearAccess( access.copyRandomAccess(), position );
+		}
+
+		@Override
+		public void set( final int position )
+		{
+			set( ( long ) position );
+		}
+
+		@Override
+		public void set( final long position )
+		{
+			IntervalIndexer.indexToPosition( position, source, access );
+		}
+
+		@Override
+		public long getPosition()
+		{
+			return position;
+		}
+
+	}
+
+}

--- a/src/test/java/net/imglib2/LinearAccessibleTest.java
+++ b/src/test/java/net/imglib2/LinearAccessibleTest.java
@@ -1,0 +1,121 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2;
+
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.img.planar.PlanarImg;
+import net.imglib2.img.planar.PlanarImgs;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.type.operators.ValueEquals;
+import net.imglib2.view.Views;
+import net.imglib2.view.linear.LinearAccessibleViewOnArrayImg;
+import net.imglib2.view.linear.LinearAccessibleViewOnPlanarImg;
+import net.imglib2.view.linear.LinearAccessibleViewOnRandomAccessibleInterval;
+
+/**
+ *
+ * Test for various {@link LinearAccessible} implementations. These
+ * implementations are tested: {@link ArrayImg}, {@link PlanarImg},
+ * {@link RandomAccessibleInterval} (general).
+ *
+ * @author Philipp Hanslovsky
+ *
+ */
+public class LinearAccessibleTest
+{
+
+	private final long[] dimensions = { 20, 30, 40 };
+
+	private final long size = dimensions[ 0 ] * dimensions[ 1 ] * dimensions[ 2 ];
+
+	private final Random rng = new Random( 100 );
+
+	@Test
+	public void testRandomAccessibleInterval()
+	{
+		final CellImg< DoubleType, ?, ? > img = new CellImgFactory< DoubleType >( new int[] { 10, 11, 12 } ).create( dimensions, new DoubleType() );
+		for ( final DoubleType i : Views.iterable( img ) )
+		{
+			i.set( rng.nextDouble() );
+		}
+		testLinearAccessible( new LinearAccessibleViewOnRandomAccessibleInterval<>( img ) );
+
+	}
+
+	@Test
+	public void testPlanarImg()
+	{
+		final PlanarImg< FloatType, FloatArray > img = PlanarImgs.floats( dimensions );
+		for ( final FloatType i : img )
+		{
+			i.set( rng.nextFloat() );
+		}
+		testLinearAccessible( new LinearAccessibleViewOnPlanarImg<>( img ) );
+	}
+
+	@Test
+	public void testArrayImg()
+	{
+		final ArrayImg< LongType, LongArray > img = ArrayImgs.longs( dimensions );
+		for ( final LongType i : img )
+		{
+			i.set( rng.nextLong() );
+		}
+		testLinearAccessible( new LinearAccessibleViewOnArrayImg<>( img ) );
+	}
+
+	public < T extends ValueEquals< T >, A extends RandomAccessibleInterval< T > & LinearAccessible< T > > void testLinearAccessible( final A a )
+	{
+		Assert.assertEquals( size, a.size() );
+		final Cursor< T > c = Views.iterable( a ).cursor();
+		final LinearAccess< T > l = a.linearAccess();
+		for ( long i = 0; c.hasNext(); ++i )
+		{
+			Assert.assertTrue( c.next().valueEquals( l.get( i ) ) );
+		}
+	}
+
+}


### PR DESCRIPTION
`LinearAccessible` can be accessed through a linear index by a `LinearAccess`. This allows very fast access for certain types of `RandomAccessibleInerval`, e.g. `ArrayImg`. `Views.linearAccess` allows to access any `RandomAccessibleinerval` by linear index, using fast implementations where available.