### PR TITLE
Add convenience functions for Accesses to ArrayImgs

### DIFF
--- a/src/main/java/net/imglib2/img/array/ArrayImgs.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImgs.java
@@ -34,6 +34,12 @@
 
 package net.imglib2.img.array;
 
+import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.img.basictypeaccess.DoubleAccess;
+import net.imglib2.img.basictypeaccess.FloatAccess;
+import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.img.basictypeaccess.LongAccess;
+import net.imglib2.img.basictypeaccess.ShortAccess;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
@@ -51,6 +57,7 @@ import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.integer.ShortType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
@@ -76,6 +83,7 @@ import net.imglib2.util.Fraction;
  * </pre>
  *
  * @author Stephan Saalfeld
+ * @author Philipp Hanslovsky
  */
 final public class ArrayImgs
 {
@@ -105,6 +113,18 @@ final public class ArrayImgs
 	}
 
 	/**
+	 * Creates an {@link ArrayImg}&lt;{@link UnsignedByteType},
+	 * {@link ByteAccess}&gt; using a {@link ByteAccess} passed as argument.
+	 */
+	final public static < A extends ByteAccess > ArrayImg< UnsignedByteType, A > unsignedBytes( final A access, final long... dim )
+	{
+		final ArrayImg< UnsignedByteType, A > img = new ArrayImg<>( access, dim, new Fraction() );
+		final UnsignedByteType t = new UnsignedByteType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
 	 * Create an {@link ArrayImg}&lt;{@link ByteType}, {@link ByteArray}&gt;.
 	 */
 	@SuppressWarnings( "unchecked" )
@@ -121,6 +141,18 @@ final public class ArrayImgs
 	{
 		final ByteArray access = new ByteArray( array );
 		final ArrayImg< ByteType, ByteArray > img = new ArrayImg< ByteType, ByteArray >( access, dim, new Fraction() );
+		final ByteType t = new ByteType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link ByteType}, {@link ByteAccess}&gt;
+	 * using a {@link ByteAccess} passed as argument.
+	 */
+	final public static < A extends ByteAccess > ArrayImg< ByteType, A > bytes( final A access, final long... dim )
+	{
+		final ArrayImg< ByteType, A > img = new ArrayImg<>( access, dim, new Fraction() );
 		final ByteType t = new ByteType( img );
 		img.setLinkedType( t );
 		return img;
@@ -150,6 +182,18 @@ final public class ArrayImgs
 	}
 
 	/**
+	 * Creates an {@link ArrayImg}&lt;{@link UnsignedShortType},
+	 * {@link ShortAccess}&gt; using a {@link ShortAccess} passed as argument.
+	 */
+	final public static < A extends ShortAccess > ArrayImg< UnsignedShortType, A > unsignedShorts( final A access, final long... dim )
+	{
+		final ArrayImg< UnsignedShortType, A > img = new ArrayImg<>( access, dim, new Fraction() );
+		final UnsignedShortType t = new UnsignedShortType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
 	 * Create an {@link ArrayImg}&lt;{@link ShortType}, {@link ShortArray}&gt;.
 	 */
 	@SuppressWarnings( "unchecked" )
@@ -166,6 +210,18 @@ final public class ArrayImgs
 	{
 		final ShortArray access = new ShortArray( array );
 		final ArrayImg< ShortType, ShortArray > img = new ArrayImg< ShortType, ShortArray >( access, dim, new Fraction() );
+		final ShortType t = new ShortType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link ShortType}, {@link ShortAccess}&gt;
+	 * using a {@link ShortAccess} passed as argument.
+	 */
+	final public static < A extends ShortAccess > ArrayImg< ShortType, A > shorts( final A access, final long... dim )
+	{
+		final ArrayImg< ShortType, A > img = new ArrayImg<>( access, dim, new Fraction() );
 		final ShortType t = new ShortType( img );
 		img.setLinkedType( t );
 		return img;
@@ -194,6 +250,18 @@ final public class ArrayImgs
 	}
 
 	/**
+	 * Creates an {@link ArrayImg}&lt;{@link UnsignedIntType},
+	 * {@link IntAccess}&gt; using a {@link IntAccess} passed as argument.
+	 */
+	final public static < A extends IntAccess > ArrayImg< UnsignedIntType, A > unsignedInts( final A access, final long... dim )
+	{
+		final ArrayImg< UnsignedIntType, A > img = new ArrayImg<>( access, dim, new Fraction() );
+		final UnsignedIntType t = new UnsignedIntType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
 	 * Create an {@link ArrayImg}&lt;{@link IntType}, {@link IntArray}&gt;.
 	 */
 	@SuppressWarnings( "unchecked" )
@@ -211,6 +279,30 @@ final public class ArrayImgs
 		final IntArray access = new IntArray( array );
 		final ArrayImg< IntType, IntArray > img = new ArrayImg< IntType, IntArray >( access, dim, new Fraction() );
 		final IntType t = new IntType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link IntType}, {@link IntAccess}&gt;
+	 * using a {@link IntAccess} passed as argument.
+	 */
+	final public static < A extends IntAccess > ArrayImg< IntType, A > ints( final A access, final long... dim )
+	{
+		final ArrayImg< IntType, A > img = new ArrayImg<>( access, dim, new Fraction() );
+		final IntType t = new IntType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link UnsignedLongType},
+	 * {@link LongAccess}&gt; using a {@link LongAccess} passed as argument.
+	 */
+	final public static < A extends LongAccess > ArrayImg< UnsignedLongType, A > unsignedLongs( final A access, final long... dim )
+	{
+		final ArrayImg< UnsignedLongType, A > img = new ArrayImg<>( access, dim, new Fraction() );
+		final UnsignedLongType t = new UnsignedLongType( img );
 		img.setLinkedType( t );
 		return img;
 	}
@@ -238,12 +330,36 @@ final public class ArrayImgs
 	}
 
 	/**
+	 * Creates an {@link ArrayImg}&lt;{@link LongType}, {@link LongAccess}&gt;
+	 * using a {@link LongAccess} passed as argument.
+	 */
+	final public static < A extends LongAccess > ArrayImg< LongType, A > longs( final A access, final long... dim )
+	{
+		final ArrayImg< LongType, A > img = new ArrayImg<>( access, dim, new Fraction() );
+		final LongType t = new LongType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
 	 * Create an {@link ArrayImg}&lt;{@link BitType}, {@link LongArray}&gt;.
 	 */
 	@SuppressWarnings( "unchecked" )
 	final static public ArrayImg< BitType, LongArray > bits( final long... dim )
 	{
 		return ( ArrayImg< BitType, LongArray > ) new ArrayImgFactory< BitType >().create( dim, new BitType() );
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link BitType}, {@link LongAccess}&gt;
+	 * using a {@link LongAccess} passed as argument.
+	 */
+	final static public < A extends LongAccess > ArrayImg< BitType, A > bits( final A access, final long... dim )
+	{
+		final ArrayImg< BitType, A > img = new ArrayImg<>( access, dim, new Fraction( 1, 64 ) );
+		final BitType t = new BitType( img );
+		img.setLinkedType( t );
+		return img;
 	}
 
 	/**
@@ -263,6 +379,18 @@ final public class ArrayImgs
 	{
 		final FloatArray access = new FloatArray( array );
 		final ArrayImg< FloatType, FloatArray > img = new ArrayImg< FloatType, FloatArray >( access, dim, new Fraction() );
+		final FloatType t = new FloatType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link FloatType}, {@link FloatAccess}&gt;
+	 * using a {@link FloatAccess} passed as argument.
+	 */
+	final static public < A extends FloatAccess > ArrayImg< FloatType, A > floats( final A access, final long... dim )
+	{
+		final ArrayImg< FloatType, A > img = new ArrayImg<>( access, dim, new Fraction() );
 		final FloatType t = new FloatType( img );
 		img.setLinkedType( t );
 		return img;
@@ -291,6 +419,18 @@ final public class ArrayImgs
 	}
 
 	/**
+	 * Creates an {@link ArrayImg}&lt;{@link DoubleType},
+	 * {@link DoubleAccess}&gt; using a {@link DoubleAccess} passed as argument.
+	 */
+	final static public < A extends DoubleAccess > ArrayImg< DoubleType, A > doubles( final A access, final long... dim )
+	{
+		final ArrayImg< DoubleType, A > img = new ArrayImg<>( access, dim, new Fraction() );
+		final DoubleType t = new DoubleType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
 	 * Create an {@link ArrayImg}&lt;{@link ARGBType}, {@link IntArray}&gt;.
 	 */
 	@SuppressWarnings( "unchecked" )
@@ -307,6 +447,18 @@ final public class ArrayImgs
 	{
 		final IntArray access = new IntArray( array );
 		final ArrayImg< ARGBType, IntArray > img = new ArrayImg< ARGBType, IntArray >( access, dim, new Fraction() );
+		final ARGBType t = new ARGBType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link ARGBType}, {@link IntAccess}&gt;
+	 * using a {@link IntAccess} passed as argument.
+	 */
+	final static public < A extends IntAccess > ArrayImg< ARGBType, A > argbs( final A access, final long... dim )
+	{
+		final ArrayImg< ARGBType, A > img = new ArrayImg<>( access, dim, new Fraction() );
 		final ARGBType t = new ARGBType( img );
 		img.setLinkedType( t );
 		return img;
@@ -335,6 +487,18 @@ final public class ArrayImgs
 	}
 
 	/**
+	 * Creates an {@link ArrayImg}&lt;{@link ComplexFloatType},
+	 * {@link FloatAccess}&gt; using a {@link FloatAccess} passed as argument.
+	 */
+	final public static < A extends FloatAccess > ArrayImg< ComplexFloatType, A > complexFloats( final A access, final long... dim )
+	{
+		final ArrayImg< ComplexFloatType, A > img = new ArrayImg<>( access, dim, new Fraction( 2, 1 ) );
+		final ComplexFloatType t = new ComplexFloatType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
 	 * Create an {@link ArrayImg}&lt;{@link ComplexDoubleType},
 	 * {@link DoubleArray}&gt;.
 	 */
@@ -352,6 +516,18 @@ final public class ArrayImgs
 	{
 		final DoubleArray access = new DoubleArray( array );
 		final ArrayImg< ComplexDoubleType, DoubleArray > img = new ArrayImg< ComplexDoubleType, DoubleArray >( access, dim, new Fraction( 2, 1 ) );
+		final ComplexDoubleType t = new ComplexDoubleType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link ComplexDoubleType},
+	 * {@link DoubleAccess}&gt; using a {@link DoubleAccess} passed as argument.
+	 */
+	final public static < A extends DoubleAccess > ArrayImg< ComplexDoubleType, A > complexDoubles( final A access, final long... dim )
+	{
+		final ArrayImg< ComplexDoubleType, A > img = new ArrayImg<>( access, dim, new Fraction( 2, 1 ) );
 		final ComplexDoubleType t = new ComplexDoubleType( img );
 		img.setLinkedType( t );
 		return img;

--- a/src/test/java/net/imglib2/img/array/ArrayImgsTest.java
+++ b/src/test/java/net/imglib2/img/array/ArrayImgsTest.java
@@ -1,0 +1,216 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.array;
+
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.complex.ComplexDoubleType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+
+/**
+ *
+ * @author Philipp Hanslovsky
+ *
+ */
+public class ArrayImgsTest
+{
+
+	private final long[] dims = { 4, 5 };
+
+	private final int nElements = ( int ) Intervals.numElements( dims );
+
+	@Test
+	public void testHelperMethods()
+	{
+		// bytes
+		{
+			final byte[] data = new byte[ nElements ];
+			for ( int d = 0; d < nElements; ++d )
+				data[ d ] = ( byte ) d;
+			final ByteArray access = new ByteArray( data );
+
+			final ArrayImg< UnsignedByteType, ByteArray > unsignedRef = ArrayImgs.unsignedBytes( data, dims );
+			final ArrayImg< UnsignedByteType, ByteArray > unsignedComp = ArrayImgs.unsignedBytes( access, dims );
+			testRange( unsignedComp, unsignedRef, 0, nElements );
+
+			final ArrayImg< ByteType, ByteArray > ref = ArrayImgs.bytes( data, dims );
+			final ArrayImg< ByteType, ByteArray > comp = ArrayImgs.bytes( access, dims );
+			testRange( comp, ref, 0, nElements );
+		}
+
+		// shorts
+		{
+			final short[] data = new short[ nElements ];
+			for ( int d = 0; d < nElements; ++d )
+				data[ d ] = ( short ) d;
+			final ShortArray access = new ShortArray( data );
+
+			final ArrayImg< UnsignedShortType, ShortArray > unsignedRef = ArrayImgs.unsignedShorts( data, dims );
+			final ArrayImg< UnsignedShortType, ShortArray > unsignedComp = ArrayImgs.unsignedShorts( access, dims );
+			testRange( unsignedComp, unsignedRef, 0, nElements );
+
+			final ArrayImg< ShortType, ShortArray > ref = ArrayImgs.shorts( data, dims );
+			final ArrayImg< ShortType, ShortArray > comp = ArrayImgs.shorts( access, dims );
+			testRange( comp, ref, 0, nElements );
+		}
+
+		// ints & arbgs
+		{
+			final int[] data = new int[ nElements ];
+			for ( int d = 0; d < nElements; ++d )
+				data[ d ] = d;
+			final IntArray access = new IntArray( data );
+
+			final ArrayImg< UnsignedIntType, IntArray > unsignedRef = ArrayImgs.unsignedInts( data, dims );
+			final ArrayImg< UnsignedIntType, IntArray > unsignedComp = ArrayImgs.unsignedInts( access, dims );
+			testRange( unsignedComp, unsignedRef, 0, nElements );
+
+			final ArrayImg< IntType, IntArray > ref = ArrayImgs.ints( data, dims );
+			final ArrayImg< IntType, IntArray > comp = ArrayImgs.ints( access, dims );
+			testRange( comp, ref, 0, nElements );
+
+			final ArrayImg< ARGBType, IntArray > argbRef = ArrayImgs.argbs( data, dims );
+			final ArrayImg< ARGBType, IntArray > argbComp = ArrayImgs.argbs( access, dims );
+			testEquality( argbComp, argbRef );
+		}
+
+		// longs
+		{
+			final long[] data = new long[ nElements ];
+			for ( int d = 0; d < nElements; ++d )
+				data[ d ] = d;
+			final LongArray access = new LongArray( data );
+
+			final ArrayImg< UnsignedLongType, LongArray > unsignedComp = ArrayImgs.unsignedLongs( access, dims );
+			final ArrayCursor< UnsignedLongType > u = unsignedComp.cursor();
+			for ( int i = 0; i < nElements; ++i )
+				Assert.assertEquals( i, u.next().get() );
+
+			final ArrayImg< LongType, LongArray > ref = ArrayImgs.longs( data, dims );
+			final ArrayImg< LongType, LongArray > comp = ArrayImgs.longs( access, dims );
+			testRange( comp, ref, 0, nElements );
+		}
+
+		// (complex) floats
+		{
+			final Random rng = new Random();
+			final float[] data = new float[ 2 * nElements ];
+			for ( int d = 0; d < data.length; ++d )
+				data[ d ] = rng.nextFloat();
+			final FloatArray access = new FloatArray( data );
+
+			final ArrayImg< ComplexFloatType, FloatArray > complexComp = ArrayImgs.complexFloats( access, dims );
+			final ArrayImg< ComplexFloatType, FloatArray > complexRef = ArrayImgs.complexFloats( data, dims );
+			testEquality( complexComp, complexRef );
+
+			final ArrayImg< FloatType, FloatArray > comp = ArrayImgs.floats( access, dims );
+			final ArrayImg< FloatType, FloatArray > ref = ArrayImgs.floats( data, dims );
+			testEquality( comp, ref );
+		}
+
+		// (complex) doubles
+		{
+			final Random rng = new Random();
+			final double[] data = new double[ 2 * nElements ];
+			for ( int d = 0; d < data.length; ++d )
+				data[ d ] = rng.nextFloat();
+			final DoubleArray access = new DoubleArray( data );
+
+			final ArrayImg< ComplexDoubleType, DoubleArray > complexComp = ArrayImgs.complexDoubles( access, dims );
+			final ArrayImg< ComplexDoubleType, DoubleArray > complexRef = ArrayImgs.complexDoubles( data, dims );
+			testEquality( complexComp, complexRef );
+
+			final ArrayImg< DoubleType, DoubleArray > comp = ArrayImgs.doubles( access, dims );
+			final ArrayImg< DoubleType, DoubleArray > ref = ArrayImgs.doubles( data, dims );
+			testEquality( comp, ref );
+		}
+
+		// bits
+		{
+			final long[] data = new long[] { 0 };
+			final int step = 3;
+			for ( long start = 0; start < Long.SIZE; start += step )
+				data[ 0 ] = data[ 0 ] | 1l << start;
+			final ArrayImg< BitType, LongArray > a = ArrayImgs.bits( new LongArray( data ), 8, 4, 2 );
+			final ArrayCursor< BitType > c = a.cursor();
+			for ( int i = 0; c.hasNext(); ++i )
+				Assert.assertEquals( i % 3 == 0, c.next().get() );
+		}
+
+	}
+
+	public static < T extends NativeType< T > & IntegerType< T > > void testRange( final ArrayImg< T, ? > comp, final ArrayImg< T, ? > ref, final int start, final int stop )
+	{
+		final ArrayCursor< T > c = comp.cursor();
+		final ArrayCursor< T > r = ref.cursor();
+		for ( int s = start; s < stop; ++s )
+		{
+			Assert.assertEquals( c.next().getInteger(), s );
+			Assert.assertEquals( r.next().getInteger(), s );
+		}
+	}
+
+	public static < T extends NativeType< T > > void testEquality( final ArrayImg< T, ? > comp, final ArrayImg< T, ? > ref )
+	{
+		for ( ArrayCursor< T > c = comp.cursor(), r = ref.cursor(); c.hasNext(); )
+			Assert.assertTrue( c.next().valueEquals( r.next() ) );
+
+	}
+
+}


### PR DESCRIPTION
This commit adds method signatures like
```java
< A extends IntAccess > void ArrayImgs.ints( A access, final long... dim );
```
This makes using accesses other than `IntArray` etc. more convenient and would be useful for the accesses implemented in `imglib2-unsafe` and for usage in `imglyb` (c-python imglib).