### PR TITLE
Relax interface for StackView and Views.stack

### DIFF
--- a/src/main/java/net/imglib2/view/StackView.java
+++ b/src/main/java/net/imglib2/view/StackView.java
@@ -110,13 +110,13 @@ public class StackView< T > extends AbstractInterval implements RandomAccessible
 
 	private final StackAccessMode stackAccessMode;
 
-	public StackView( final List< RandomAccessibleInterval< T > > hyperslices )
+	public StackView( final List< ? extends RandomAccessibleInterval< T > > hyperslices )
 	{
 		this( hyperslices, StackAccessMode.DEFAULT );
 	}
 
 	@SuppressWarnings( "unchecked" )
-	public StackView( final List< RandomAccessibleInterval< T > > hyperslices, final StackAccessMode stackAccessMode )
+	public StackView( final List< ? extends RandomAccessibleInterval< T > > hyperslices, final StackAccessMode stackAccessMode )
 	{
 		super( hyperslices.get( 0 ).numDimensions() + 1 );
 		this.stackAccessMode = stackAccessMode;

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -976,9 +976,9 @@ public class Views
 	 * @return a <em>(n+1)</em>-dimensional {@link RandomAccessibleInterval}
 	 *         where the final dimension is the index of the hyperslice.
 	 */
-	public static < T > RandomAccessibleInterval< T > stack( final List< RandomAccessibleInterval< T > > hyperslices )
+	public static < T > RandomAccessibleInterval< T > stack( final List< ? extends RandomAccessibleInterval< T > > hyperslices )
 	{
-		return new StackView< T >( hyperslices );
+		return new StackView<>( hyperslices );
 	}
 
 	/**
@@ -1012,9 +1012,9 @@ public class Views
 	 * @return a <em>(n+1)</em>-dimensional {@link RandomAccessibleInterval}
 	 *         where the final dimension is the index of the hyperslice.
 	 */
-	public static < T > RandomAccessibleInterval< T > stack( final StackAccessMode stackAccessMode, final List< RandomAccessibleInterval< T > > hyperslices )
+	public static < T > RandomAccessibleInterval< T > stack( final StackAccessMode stackAccessMode, final List< ? extends RandomAccessibleInterval< T > > hyperslices )
 	{
-		return new StackView< T >( hyperslices, stackAccessMode );
+		return new StackView<>( hyperslices, stackAccessMode );
 	}
 
 	/**


### PR DESCRIPTION
Using `List< ? extends RandomAccessibleInterval< T > >` instead of `List< RandomAccessibleInterval< T > >` allows for passing `List< Img< T > >` or similar.

This addresses #156 

Closes #156 