### PR TITLE
added Java8 Supplier<T> based factory methods to ImgFactory

### DIFF
--- a/src/main/java/net/imglib2/img/ImgFactory.java
+++ b/src/main/java/net/imglib2/img/ImgFactory.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.img;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Dimensions;
 import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.type.NativeType;
@@ -101,4 +103,67 @@ public abstract class ImgFactory< T >
 	 *             if type S is not compatible
 	 */
 	public abstract < S > ImgFactory< S > imgFactory( final S type ) throws IncompatibleTypeException;
+
+	/**
+	 * The {@link ImgFactory} can decide how to create the {@link Img}. A
+	 * {@link NativeImgFactory} will ask the supplied {@link Type} to create a
+	 * suitable {@link NativeImg}.
+	 *
+	 * @return {@link Img}
+	 */
+	public Img< T > create( final Supplier< T > typeSupplier, final long... dim ) {
+		return create( dim, typeSupplier.get() );
+	}
+
+	/**
+	 * The {@link ImgFactory} can decide how to create the {@link Img}. A
+	 * {@link NativeImgFactory} will ask the supplied {@link Type} to create a
+	 * suitable {@link NativeImg}.
+	 *
+	 * @return {@link Img}
+	 */
+	public Img< T > create( final Supplier< T > typeSupplier, final Dimensions dim )
+	{
+		return create( dim, typeSupplier.get() );
+	}
+
+	/**
+	 * The {@link ImgFactory} can decide how to create the {@link Img}. A
+	 * {@link NativeImgFactory} will ask the supplied {@link Type} to create a
+	 * suitable {@link NativeImg}.
+	 *
+	 * <p>
+	 * Note: This is not a vararg function because the underlying int[]
+	 * based methods alreay copies the int[] dimensions into a disposable
+	 * long[] anyways.  This would be an unnecessary copy for int... varargs.
+	 * </p>
+	 *
+	 * @return {@link Img}
+	 */
+	public Img< T > create( final Supplier< T > typeSupplier, final int[] dim )
+	{
+		return create( dim, typeSupplier.get() );
+	}
+
+	/**
+	 * Creates the same {@link ImgFactory} for a different generic parameter if
+	 * possible.
+	 *
+	 * If the supplied type "S" does not suit the needs of the
+	 * {@link ImgFactory} (for example implement {@link NativeType} in all
+	 * {@link NativeImgFactory}, this method will throw an
+	 * {@link IncompatibleTypeException}.
+	 *
+	 * @param <S>
+	 *            the new type
+	 * @param typeSupplier
+	 *            a supplier of S
+	 * @return {@link ImgFactory} of type S
+	 * @throws IncompatibleTypeException
+	 *             if type S is not compatible
+	 */
+	public < S > ImgFactory< S > imgFactory( final Supplier< S > typeSupplier ) throws IncompatibleTypeException
+	{
+		return imgFactory( typeSupplier.get() );
+	}
 }

--- a/src/test/java/net/imglib2/img/ImgFactoryTest.java
+++ b/src/test/java/net/imglib2/img/ImgFactoryTest.java
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+
+/**
+ *
+ *
+ * @author Stephan Saalfeld
+ */
+public class ImgFactoryTest
+{
+	/**
+	 * Test method for {@link net.imglib2.img.ImgFactory#create(java.util.function.Supplier, long[])}.
+	 */
+	@Test
+	public final void testCreateSupplierOfTLongArray()
+	{
+		final ArrayImg< UnsignedByteType, ByteArray > img = ArrayImgs.unsignedBytes(1, 2, 3);
+		final Img< UnsignedByteType > copy = img.factory().create( UnsignedByteType::new, 1, 2, 3 );
+		Assert.assertTrue( ArrayImg.class.isInstance( copy ) );
+		Assert.assertTrue( UnsignedByteType.class.isInstance( copy.iterator().next() ) );
+	}
+}


### PR DESCRIPTION
enables code that looks nicer to my eyes such as

Img<ByteType> img = factory.create(ByteType::new, 1, 2, 3);