### PR TITLE
Clarify when coordinates are defined

### DIFF
--- a/src/main/java/net/imglib2/Cursor.java
+++ b/src/main/java/net/imglib2/Cursor.java
@@ -64,6 +64,12 @@ package net.imglib2;
  * imglib Cursors, in general.
  * </p>
  *
+ * <p>
+ * It is not guaranteed that a Cursor will perform bounds checking. Asking the
+ * position or value of a Cursor that was not advanced to its first element, or
+ * was moved beyond its last element, has undefined results.
+ * </p>
+ *
  * @author Tobias Pietzsch
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/IterableInterval.java
+++ b/src/main/java/net/imglib2/IterableInterval.java
@@ -37,6 +37,16 @@ package net.imglib2;
 /**
  * An {@link IterableRealInterval} whose elements are located at integer
  * coordinates.
+ * <p>
+ * An {@code IterableInterval} is <em>not</em> guaranteed to iterate over all
+ * coordinates of its containing {@link Interval}. In the typical case of a
+ * hyperrectangular image, it will do so; however, there are some
+ * {@code IterableInterval}s which visit only a subset of the {@code Interval}
+ * coordinates. For example, the {@code imglib2-roi} library provides means to
+ * model regions of interest (ROIs), along with the ability to iterate over
+ * coordinates within a particular ROI; see e.g.
+ * {@code net.imglib2.roi.labeling.LabelRegion}.
+ * </p>
  * 
  * @author Tobias Pietzsch
  * @author Stephan Preibisch

--- a/src/main/java/net/imglib2/RandomAccessible.java
+++ b/src/main/java/net/imglib2/RandomAccessible.java
@@ -50,6 +50,14 @@ import net.imglib2.view.Views;
  * expect that the domain is infinite. (In contrast to this,
  * {@link RandomAccessibleInterval}s have a finite domain.)
  * </p>
+ * <p>
+ * A {@code RandomAccessible} might be defined only partially. You should be
+ * aware of this especially when creating {@link RandomAccessibleInterval}s.
+ * While it is straightforward to turn a {@code RandomAccessible} into a
+ * {@code RandomAccessibleInterval} by adding interval boundaries via
+ * {@link Views#interval}, it is your responsibility to ensure that the
+ * {@code RandomAccessible} is fully defined within these boundaries.
+ * </p>
  *
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch

--- a/src/main/java/net/imglib2/RandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/RandomAccessibleInterval.java
@@ -43,6 +43,10 @@ package net.imglib2;
  * A function over an n-dimensional integer interval that can create a random
  * access {@link Sampler}.
  * </p>
+ * <p>
+ * By convention, a RandomAccessibleInterval represents a function that is
+ * <em>defined at all coordinates of the interval</em>.
+ * </p>
  *
  * @author Stephan Saalfeld
  */

--- a/src/main/java/net/imglib2/RealCursor.java
+++ b/src/main/java/net/imglib2/RealCursor.java
@@ -64,6 +64,12 @@ package net.imglib2;
  * imglib Cursors, in general.
  * </p>
  * 
+ * <p>
+ * It is not guaranteed that a RealCursor will perform bounds checking. Asking
+ * the position or value of a RealCursor that was not advanced to its first
+ * element, or was moved beyond its last element, has undefined results.
+ * </p>
+ *
  * @author Tobias Pietzsch
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/RealRandomAccessible.java
+++ b/src/main/java/net/imglib2/RealRandomAccessible.java
@@ -48,6 +48,10 @@ package net.imglib2;
  * expect that the domain is infinite. (In contrast to this,
  * {@link RealRandomAccessibleRealInterval}s have a finite domain.)
  * </p>
+ * <p>
+ * Similarly to a {@link RandomAccessible}, a {@code RealRandomAccessible} might
+ * be defined only partially within the space.
+ * </p>
  * 
  * @author Stephan Saalfeld
  */

--- a/src/main/java/net/imglib2/RealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/RealRandomAccessibleRealInterval.java
@@ -43,6 +43,10 @@ package net.imglib2;
  * A function over an n-dimensional real interval that can create a random
  * access {@link Sampler}.
  * </p>
+ * <p>
+ * By convention, a RealRandomAccessibleRealInterval represents a function that
+ * is <em>defined at all coordinates of the interval</em>.
+ * </p>
  *
  * @author Stephan Saalfeld
  */


### PR DESCRIPTION
I tried to document when each of the major accessible interfaces are defined.

However, there is one I am not sure about: `RealRandomAccessibleRealInterval`. I wrote that it is "not necessarily defined at all coordinates within the interval" but that would be in contrast to `RandomAccessibleInterval` which "is defined at all coordinates of the interval."

@tpietzsch @axtimwalde If I am wrong about this difference I'm happy to adjust the commit here; just let me know.