### PR TITLE
Add RotateViewTest and fix naming

### DIFF
--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -1227,6 +1227,32 @@ public class Views
 	}
 
 	/**
+	 * Inverse bijective permutation of the integer coordinates of one dimension
+	 * of a {@link RandomAccessibleInterval}.
+	 *
+	 * @param source
+	 *            must have dimension(dimension) == permutation.length
+	 * @param permutation
+	 *            must be a bijective permutation over its index set, i.e. for a
+	 *            lut of length n, the sorted content the array must be
+	 *            [0,...,n-1] which is the index set of the lut.
+	 * @param d
+	 *            dimension index to be permuted
+	 *
+	 * @return {@link IntervalView} of permuted source.
+	 */
+	public static < T > IntervalView< T > permuteCoordinatesInverse( final RandomAccessibleInterval< T > source, final int[] permutation, final int d )
+	{
+		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
+		assert source.min( d ) == 0: "Source with min[d] coordinate != 0 passed to coordinate permutation.";
+		assert source.dimension( d ) == permutation.length: "Source with dimension[d] != LUT.length passed to coordinate permutation.";
+
+		final int nDim = source.numDimensions();
+		final SingleDimensionPermutationTransform transform = new SingleDimensionPermutationTransform( permutation, nDim, nDim, d ).inverse();
+		return Views.interval( new TransformView< T >( source, transform.inverse() ), source );
+	}
+
+	/**
 	 * Compose two {@link RandomAccessible} sources into a
 	 * {@link RandomAccessible} of {@link Pair}.
 	 *

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -1214,16 +1214,13 @@ public class Views
 	 *            dimension index to be permuted
 	 *
 	 * @return {@link IntervalView} of permuted source.
+	 * 
+	 * @deprecated use {@link Views#permuteCoordinatesInverse(RandomAccessibleInterval, int[], int)}
 	 */
+	@Deprecated
 	public static < T > IntervalView< T > permuteCoordinateInverse( final RandomAccessibleInterval< T > source, final int[] permutation, final int d )
 	{
-		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
-		assert source.min( d ) == 0: "Source with min[d] coordinate != 0 passed to coordinate permutation.";
-		assert source.dimension( d ) == permutation.length: "Source with dimension[d] != LUT.length passed to coordinate permutation.";
-
-		final int nDim = source.numDimensions();
-		final SingleDimensionPermutationTransform transform = new SingleDimensionPermutationTransform( permutation, nDim, nDim, d ).inverse();
-		return Views.interval( new TransformView< T >( source, transform.inverse() ), source );
+		return permuteCoordinatesInverse(source, permutation, d);
 	}
 
 	/**

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -1052,10 +1052,7 @@ public class Views
 	 *
 	 * @return {@link TransformView} containing the result.
 	 */
-	public static < T > TransformView< T > shear(
-			final RandomAccessible< T > source,
-			final int shearDimension,
-			final int referenceDimension )
+	public static < T > TransformView< T > shear( final RandomAccessible< T > source, final int shearDimension, final int referenceDimension )
 	{
 		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
 		return new TransformView< T >( source, transform.inverse() );
@@ -1075,10 +1072,7 @@ public class Views
 	 *
 	 * @return {@link TransformView} containing the result.
 	 */
-	public static < T > TransformView< T > unshear(
-			final RandomAccessible< T > source,
-			final int shearDimension,
-			final int referenceDimension )
+	public static < T > TransformView< T > unshear( final RandomAccessible< T > source, final int shearDimension, final int referenceDimension )
 	{
 		final InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
 		return new TransformView< T >( source, transform.inverse() );
@@ -1102,11 +1096,7 @@ public class Views
 	 *         interval's dimension are determined by applying the
 	 *         {@link ShearTransform#transform} method on the input interval.
 	 */
-	public static < T > IntervalView< T > shear(
-			final RandomAccessible< T > source,
-			final Interval interval,
-			final int shearDimension,
-			final int referenceDimension )
+	public static < T > IntervalView< T > shear( final RandomAccessible< T > source, final Interval interval, final int shearDimension, final int referenceDimension )
 	{
 		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
 		return Views.interval( Views.shear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval ) ).getInterval() );
@@ -1130,11 +1120,7 @@ public class Views
 	 *         interval's dimension are determined by applying the
 	 *         {@link ShearTransform#transform} method on the input interval.
 	 */
-	public static < T > IntervalView< T > unshear(
-			final RandomAccessible< T > source,
-			final Interval interval,
-			final int shearDimension,
-			final int referenceDimension )
+	public static < T > IntervalView< T > unshear( final RandomAccessible< T > source, final Interval interval, final int shearDimension, final int referenceDimension )
 	{
 		final InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
 		return Views.interval( Views.unshear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval ) ).getInterval() );
@@ -1154,9 +1140,7 @@ public class Views
 	 *
 	 * @return {@link IntervalView} of permuted source.
 	 */
-	public static < T > IntervalView< T > permuteCoordinates(
-			final RandomAccessibleInterval< T > source,
-			final int[] permutation )
+	public static < T > IntervalView< T > permuteCoordinates( final RandomAccessibleInterval< T > source, final int[] permutation )
 	{
 		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
 		assert PermutationTransform.checkInterval( source, permutation ): "Source interval boundaries do not match permutation.";
@@ -1181,10 +1165,7 @@ public class Views
 	 *
 	 * @return {@link IntervalView} of permuted source.
 	 */
-	public static < T > IntervalView< T > permuteCoordinates(
-			final RandomAccessibleInterval< T > source,
-			final int[] permutation,
-			final int d )
+	public static < T > IntervalView< T > permuteCoordinates( final RandomAccessibleInterval< T > source, final int[] permutation, final int d )
 	{
 		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
 		assert source.min( d ) == 0: "Source with min[d] coordinate != 0 passed to coordinate permutation.";
@@ -1209,9 +1190,7 @@ public class Views
 	 *
 	 * @return {@link IntervalView} of permuted source.
 	 */
-	public static < T > IntervalView< T > permuteCoordinatesInverse(
-			final RandomAccessibleInterval< T > source,
-			final int[] permutation )
+	public static < T > IntervalView< T > permuteCoordinatesInverse( final RandomAccessibleInterval< T > source, final int[] permutation )
 	{
 		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
 		assert PermutationTransform.checkInterval( source, permutation ): "Source interval boundaries do not match permutation.";
@@ -1236,10 +1215,7 @@ public class Views
 	 *
 	 * @return {@link IntervalView} of permuted source.
 	 */
-	public static < T > IntervalView< T > permuteCoordinateInverse(
-			final RandomAccessibleInterval< T > source,
-			final int[] permutation,
-			final int d )
+	public static < T > IntervalView< T > permuteCoordinateInverse( final RandomAccessibleInterval< T > source, final int[] permutation, final int d )
 	{
 		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
 		assert source.min( d ) == 0: "Source with min[d] coordinate != 0 passed to coordinate permutation.";
@@ -1258,9 +1234,7 @@ public class Views
 	 * @param sourceB
 	 * @return
 	 */
-	public static < A, B > RandomAccessible< Pair< A, B > > pair(
-			final RandomAccessible< A > sourceA,
-			final RandomAccessible< B > sourceB )
+	public static < A, B > RandomAccessible< Pair< A, B > > pair( final RandomAccessible< A > sourceA, final RandomAccessible< B > sourceB )
 	{
 		return new RandomAccessiblePair< A, B >( sourceA, sourceB );
 	}
@@ -1271,13 +1245,13 @@ public class Views
 	 * <em>n</em>-dimensional {@link RandomAccessible RandomAccessibles} of T.
 	 *
 	 * @param source
-	 * @param axes the axes to become the inner axes (embedded into the co-domain)
+	 * @param axes
+	 *            the axes to become the inner axes (embedded into the
+	 *            co-domain)
 	 *
 	 * @return
 	 */
-	public static < T > RandomAccessible< ? extends RandomAccessible< T > > hyperSlices(
-			final RandomAccessible< T > source,
-			final int... axes )
+	public static < T > RandomAccessible< ? extends RandomAccessible< T > > hyperSlices( final RandomAccessible< T > source, final int... axes )
 	{
 		return new HyperSlicesView< T >( source, axes );
 	}
@@ -1439,7 +1413,6 @@ public class Views
 		return concatenate( concatenationAxis, StackView.StackAccessMode.DEFAULT, sources );
 	}
 
-
 	/**
 	 *
 	 * Concatenate an array of {@link RandomAccessibleInterval} along the
@@ -1484,7 +1457,7 @@ public class Views
 		assert sources.size() > 0;
 
 		final ArrayList< RandomAccessibleInterval< T > > hyperSlices = new ArrayList<>();
-		for ( RandomAccessibleInterval< T > source : sources )
+		for ( final RandomAccessibleInterval< T > source : sources )
 			for ( long index = source.min( concatenationAxis ); index <= source.max( concatenationAxis ); ++index )
 				hyperSlices.add( Views.hyperSlice( source, concatenationAxis, index ) );
 

--- a/src/test/java/net/imglib2/view/RotationViewTest.java
+++ b/src/test/java/net/imglib2/view/RotationViewTest.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.view;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.stream.LongStream;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.LongType;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link Views#rotate(RandomAccessibleInterval, int, int)}
+ * functionality.
+ *
+ * @author Gabe Selzer
+ *
+ */
+public class RotationViewTest
+{
+
+	@Test
+	public void test()
+	{
+
+		final long[] sizes = { 3, 4 };
+
+		final long n = LongStream.of( sizes ).reduce( 1, ( x, y ) -> x * y );
+
+		final long[] data = new long[ ( int ) n ];
+
+		for ( int i = 0; i < n; i++ )
+		{
+			data[ i ] = i;
+		}
+
+		final RandomAccessibleInterval< LongType > source = ArrayImgs.longs( data, sizes );
+		final RandomAccess< LongType > sourceRA = source.randomAccess();
+		final RandomAccessibleInterval< LongType > actual = Views.rotate( source, 0, 1 );
+		final RandomAccess< LongType > actualRA = actual.randomAccess();
+
+		// check each value matches with their rotated counterparts
+		for ( int i = 0; i < sizes[ 0 ]; i++ )
+		{
+			for ( int j = 0; j < sizes[ 1 ]; j++ )
+			{
+				sourceRA.setPosition( new long[] { i, j } );
+				actualRA.setPosition( new long[] { -j, i } );
+
+				assertEquals( sourceRA.get().get(), actualRA.get().get() );
+			}
+		}
+
+		// check to make sure the bounds are the same
+		assertEquals( source.min( 0 ), actual.min( 1 ) );
+		assertEquals( source.max( 0 ), actual.max( 1 ) );
+		assertEquals( source.min( 1 ), -actual.max( 0 ) );
+		assertEquals( source.max( 1 ), -actual.min( 0 ) );
+
+	}
+
+}


### PR DESCRIPTION
This pull request adds a rotation test to the Views testing suite. It checks to make sure that both the individual values and the bounds are rotated. This PR also renames permuteCoordinateInverse to permuteCoordinatesInverse to make naming consistent across methods.