### PR TITLE
Fix assumptions on length of passes to setPosition

### DIFF
--- a/src/main/java/net/imglib2/img/array/ArrayRandomAccess.java
+++ b/src/main/java/net/imglib2/img/array/ArrayRandomAccess.java
@@ -160,7 +160,8 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	@Override
 	public void setPosition( final Localizable localizable )
 	{
-		localizable.localize( position );
+		for(int d = 0; d < n; d++)
+			position[d] = localizable.getIntPosition(d);
 		int index = 0;
 		for ( int d = 0; d < n; ++d )
 			index += position[ d ] * img.steps[ d ];

--- a/src/main/java/net/imglib2/img/list/AbstractLongListImg.java
+++ b/src/main/java/net/imglib2/img/list/AbstractLongListImg.java
@@ -330,7 +330,8 @@ public abstract class AbstractLongListImg< T > extends AbstractImg< T >
 		@Override
 		public void setPosition( final Localizable localizable )
 		{
-			localizable.localize( position );
+			for(int d = 0; d < n; d++)
+				position[d] = localizable.getLongPosition(d);
 			i = position[ 0 ];
 			for ( int d = 1; d < n; ++d )
 				i += position[ d ] * step[ d ];

--- a/src/main/java/net/imglib2/img/list/ListRandomAccess.java
+++ b/src/main/java/net/imglib2/img/list/ListRandomAccess.java
@@ -137,7 +137,8 @@ public class ListRandomAccess< T > extends AbstractLocalizableInt implements Ran
 	@Override
 	public void setPosition( final Localizable localizable )
 	{
-		localizable.localize( position );
+		for(int d = 0; d < n; d++)
+			position[d] = localizable.getIntPosition(d);
 		i = position[ 0 ];
 		for ( int d = 1; d < n; ++d )
 			i += position[ d ] * img.step[ d ];

--- a/src/main/java/net/imglib2/position/transform/AbstractPositionableTransform.java
+++ b/src/main/java/net/imglib2/position/transform/AbstractPositionableTransform.java
@@ -157,7 +157,8 @@ public abstract class AbstractPositionableTransform< LocalizablePositionable ext
 	@Override
 	public void setPosition( final Localizable localizable )
 	{
-		localizable.localize( position );
+		for(int d = 0; d < n; d++)
+			position[d] = localizable.getLongPosition(d);
 		target.setPosition( localizable );
 	}
 

--- a/src/main/java/net/imglib2/position/transform/Floor.java
+++ b/src/main/java/net/imglib2/position/transform/Floor.java
@@ -160,7 +160,8 @@ public class Floor< LocalizablePositionable extends Localizable & Positionable >
 	@Override
 	public void setPosition( final RealLocalizable localizable )
 	{
-		localizable.localize( position );
+		for(int d = 0; d < n; d++)
+			position[d] = localizable.getDoublePosition(d);
 		for ( int d = 0; d < n; ++d )
 			discrete[ d ] = floor( position[ d ] );
 		target.setPosition( discrete );

--- a/src/main/java/net/imglib2/position/transform/FloorOffset.java
+++ b/src/main/java/net/imglib2/position/transform/FloorOffset.java
@@ -199,7 +199,8 @@ public class FloorOffset< LocalizablePositionable extends Localizable & Position
 	@Override
 	public void setPosition( final RealLocalizable localizable )
 	{
-		localizable.localize( position );
+		for(int d = 0; d < n; d++)
+			position[d] = localizable.getDoublePosition(d);
 		for ( int d = 0; d < n; ++d )
 			discrete[ d ] = f( position[ d ], offset[ d ] );
 		target.setPosition( discrete );

--- a/src/main/java/net/imglib2/position/transform/Round.java
+++ b/src/main/java/net/imglib2/position/transform/Round.java
@@ -160,7 +160,8 @@ public class Round< LocalizablePositionable extends Localizable & Positionable >
 	@Override
 	public void setPosition( final RealLocalizable localizable )
 	{
-		localizable.localize( position );
+		for(int d = 0; d < n; d++)
+			position[d] = localizable.getDoublePosition(d);
 		for ( int d = 0; d < n; ++d )
 			discrete[ d ] = round( position[ d ] );
 		target.setPosition( discrete );


### PR DESCRIPTION
This PR fixes all of the other instances of `setPosition` using `localizable.localize(position)` and refactors them to use
```
for ( int d = 0; d < n; d++ )
 		position[ d ] = localizable.getLongPosition( d );

```

This avoids errors when the `localizable` has dimensions that are not equal to the `position`.

See #181.