### PR TITLE
Percentile enhancement

### DIFF
--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -159,10 +159,11 @@ public class Util
 	{
 		final double temp[] = values.clone();
 		final int length = temp.length;
+		final int pos = Math.min( length - 1, Math.max( 0, ( int ) Math.round( ( length - 1 ) * percentile ) ) );
 
-		quicksort( temp );
+		KthElement.kthElement( pos, temp );
 
-		return temp[ Math.min( length - 1, Math.max( 0, ( int ) Math.round( ( length - 1 ) * percentile ) ) ) ];
+		return temp[ pos ];
 	}
 
 	public static double averageDouble( final List< Double > values )

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -307,6 +307,11 @@ public class Util
 
 		return median;
 	}
+	
+	public static void quicksort( final long[] data )
+	{
+		quicksort( data, 0, data.length - 1 );
+	}
 
 	public static void quicksort( final long[] data, final int left, final int right )
 	{

--- a/src/test/java/net/imglib2/util/ImgUtilTest.java
+++ b/src/test/java/net/imglib2/util/ImgUtilTest.java
@@ -34,8 +34,13 @@
 
 package net.imglib2.util;
 
+import static net.imglib2.util.Util.percentile;
+import static net.imglib2.util.Util.quicksort;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
@@ -52,6 +57,35 @@ import org.junit.Test;
  */
 public class ImgUtilTest
 {
+	
+	@Test
+	public void testPercentile()
+	{
+		final double[] data = new double[42];
+		for(int i = 0; i < data.length; i++) {
+		    data[i] = Math.random()*42;
+		}
+		final double[] sortedData = data.clone();
+		final double[] quicksortedData = data.clone();
+		Arrays.sort( sortedData );
+		quicksort( quicksortedData );
+		
+		for(int i = 0; i < 3; i++){
+		
+			double percentile = Math.random();
+			
+			int pos = Math.min( data.length - 1,
+								Math.max( 0, ( int ) Math.round( ( data.length - 1 ) * percentile ) ) );
+			
+			final double percentileRes = percentile( data, percentile );
+			
+			assertEquals(quicksortedData[pos], sortedData[pos], 0.001);
+			assertEquals(quicksortedData[pos], percentileRes, 0.001);
+			
+		}
+		
+		
+	}
 
 	@Test
 	public void testCopyDoubleArrayIntIntArrayImgOfT()


### PR DESCRIPTION
(-> #182)
- Modifies `percentile` function to use `KthElement.kthElement` instead of `quicksort`
- adds test for `percentile` function comparing it to `quicksort` and `Arrays.sort` (kind of redundant to the KthElement test though)
- the `quicksort (final long[] data)` function is added for consistency (just saw it while writing the test function)