### PR TITLE
added a test for QuaternionToR with large numbers causing NaN and Inf/-Inf results

### DIFF
--- a/src/test/java/net/imglib2/util/LinAlgHelpersTest.java
+++ b/src/test/java/net/imglib2/util/LinAlgHelpersTest.java
@@ -176,6 +176,22 @@ public class LinAlgHelpersTest
 	}
 
 	@Test
+	public void testQuaternionToRLarge()
+	{
+		final double[] q = new double[] { Double.MAX_VALUE, 0, Double.MAX_VALUE, 0 };
+		final double[][] expectedR = new double[][] {
+		                { Double.NaN, 0, Double.POSITIVE_INFINITY },
+				{ 0, Double.POSITIVE_INFINITY, 0 },
+				{ Double.NEGATIVE_INFINITY, 0, Double.NaN }
+		};
+		final double[][] R = new double[ 3 ][ 3 ];
+		LinAlgHelpers.quaternionToR( q, R );
+		assertArrayEquals( expectedR[ 0 ], R[ 0 ], delta );
+		assertArrayEquals( expectedR[ 1 ], R[ 1 ], delta );
+		assertArrayEquals( expectedR[ 2 ], R[ 2 ], delta );
+	}
+
+	@Test
 	public void testQuaternionFromR()
 	{
 		final double[][] R = new double[][] {


### PR DESCRIPTION
Added a test for the function `QuaternionToR` of the class `LinAlgHelpers`. The overflow results in NaN and Inf.