### PR TITLE
Add index-position-conversion for Interval.

### DIFF
--- a/src/main/java/net/imglib2/util/IntervalIndexer.java
+++ b/src/main/java/net/imglib2/util/IntervalIndexer.java
@@ -35,6 +35,7 @@
 package net.imglib2.util;
 
 import net.imglib2.Dimensions;
+import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.Positionable;
 
@@ -42,9 +43,10 @@ import net.imglib2.Positionable;
  * N-dimensional data is often stored in a flat 1-dimensional array. This class
  * provides convenience methods to translate between N-dimensional indices
  * (positions) and 1-dimensional indices.
- * 
- * 
+ *
+ *
  * @author Tobias Pietzsch
+ * @author Philipp Hanslovsky
  */
 public class IntervalIndexer
 {
@@ -335,6 +337,28 @@ public class IntervalIndexer
 	final static public long indexToPositionWithOffset( final long index, final long[] dimensions, final long[] steps, final long[] offsets, final int dimension )
 	{
 		return indexToPosition( index, dimensions, steps, dimension ) + offsets[ dimension ];
+	}
+
+	public static long positionToIndexForInterval( final Localizable position, final Interval interval )
+	{
+		final int maxDim = interval.numDimensions() - 1;
+		long i = position.getLongPosition( maxDim ) - interval.min( maxDim );
+		for ( int d = maxDim - 1; d >= 0; --d )
+			i = i * interval.dimension( d ) + position.getLongPosition( d ) - interval.min( d );
+		return i;
+	}
+
+	public static void indexToPositionForInterval( long index, final Interval interval, final Positionable position )
+	{
+		final int maxDim = interval.numDimensions() - 1;
+		for ( int d = 0; d < maxDim; ++d )
+		{
+			final long dim = interval.dimension( d );
+			final long j = index / dim;
+			position.setPosition( index - j * dim + interval.min( d ), d );
+			index = j;
+		}
+		position.setPosition( index + interval.min( maxDim ), maxDim );
 	}
 
 	/**

--- a/src/test/java/net/imglib2/util/IntervalIndexerTest.java
+++ b/src/test/java/net/imglib2/util/IntervalIndexerTest.java
@@ -1,0 +1,84 @@
+package net.imglib2.util;
+
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.Point;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+
+/**
+ *
+ * @author Philipp Hanslovsky
+ *
+ *
+ *         This tests only consistency of the newly added methods
+ *         {@link IntervalIndexer#indexToPositionForInterval} and
+ *         {@link IntervalIndexer#positionToIndexForInterval} with previously
+ *         existing methods.
+ */
+public class IntervalIndexerTest
+{
+
+	private final long[] dim = new long[] { 6, 7, 8, 9 };
+
+	private final int numOffsets = 10;
+
+	private final Random rng = new Random( 100 );
+
+	@Test
+	public void test()
+	{
+		for ( int i = 0; i < numOffsets; ++i )
+		{
+
+			final long[] min = new long[ dim.length ];
+			final long[] max = new long[ dim.length ];
+			for ( int k = 0; k < min.length; ++k )
+			{
+				min[ k ] = rng.nextInt();
+				max[ k ] = min[ k ] + dim[ k ] - 1;
+			}
+			final RandomAccessibleInterval< DoubleType > interval = ConstantUtils.constantRandomAccessibleInterval(
+					new DoubleType(),
+					dim.length,
+					new FinalInterval( min, max ) );
+			testIndexToPosition( interval );
+			testPositionToIndex( interval );
+		}
+	}
+
+	public void testIndexToPosition( final Interval interval )
+	{
+		final long numElements = Intervals.numElements( interval );
+		final long[] pos = new long[ dim.length ];
+		final long[] min = Intervals.minAsLongArray( interval );
+		final long[] store = new long[ dim.length ];
+		final Point positionable = Point.wrap( store );
+		for ( long index = 0; index < numElements; ++index )
+		{
+			IntervalIndexer.indexToPositionWithOffset( index, dim, min, pos );
+			IntervalIndexer.indexToPositionForInterval( index, interval, positionable );
+			Assert.assertArrayEquals( pos, store );
+		}
+	}
+
+	public void testPositionToIndex( final RandomAccessibleInterval< ? > interval )
+	{
+		final long[] pos = new long[ dim.length ];
+		final long[] min = Intervals.minAsLongArray( interval );
+		for ( final Cursor< ? > cursor = Views.flatIterable( interval ).localizingCursor(); cursor.hasNext(); )
+		{
+			cursor.fwd();
+			cursor.localize( pos );
+			Assert.assertEquals( IntervalIndexer.positionWithOffsetToIndex( pos, dim, min ), IntervalIndexer.positionToIndexForInterval( cursor, interval ) );
+		}
+	}
+
+}


### PR DESCRIPTION
Previously, it was not possible to convert indices and positions for `Interval`s with non zero min. This implements the functionality of `IntervalIndexer.indexToPositionWithOffset` and `IntervalIndexer.positionWithOffsetToIndex` but with `Interval` and `Positionable`/`Localizable` as input rather than arrays.