### PR TITLE
Add constant OutOfBounds extension for unbound generics

### DIFF
--- a/src/main/java/net/imglib2/outofbounds/AbstractOutOfBoundsValue.java
+++ b/src/main/java/net/imglib2/outofbounds/AbstractOutOfBoundsValue.java
@@ -39,17 +39,17 @@ import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
-import net.imglib2.type.Type;
 
 /**
- * 
+ *
  * @param <T>
- * 
+ *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch
+ * @author Philipp Hanslovsky
  */
-public abstract class AbstractOutOfBoundsValue< T extends Type< T > > extends AbstractLocalizable implements OutOfBounds< T >
+public abstract class AbstractOutOfBoundsValue< T > extends AbstractLocalizable implements OutOfBounds< T >
 {
 	final protected RandomAccess< T > sampler;
 

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueNoGenericBounds.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueNoGenericBounds.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.outofbounds;
+
+import java.util.function.Supplier;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+
+/**
+ *
+ * @param <T>
+ *
+ * @author Stephan Preibisch
+ * @author Stephan Saalfeld
+ * @author Philipp Hanslovsky
+ */
+public class OutOfBoundsConstantValueNoGenericBounds< T > extends AbstractOutOfBoundsValue< T >
+{
+	private final Supplier< T > extensionSupplier;
+
+	private final T extension;
+
+	protected OutOfBoundsConstantValueNoGenericBounds( final OutOfBoundsConstantValueNoGenericBounds< T > outOfBounds )
+	{
+		super( outOfBounds );
+		this.extensionSupplier = outOfBounds.extensionSupplier;
+		this.extension = this.extensionSupplier.get();
+	}
+
+	public < F extends Interval & RandomAccessible< T > > OutOfBoundsConstantValueNoGenericBounds( final F f, final Supplier< T > extensionSupplier )
+	{
+		super( f );
+		this.extensionSupplier = extensionSupplier;
+		this.extension = this.extensionSupplier.get();
+	}
+
+	/* Sampler */
+
+	@Override
+	final public T get()
+	{
+		if ( isOutOfBounds )
+			return extension;
+		return sampler.get();
+	}
+
+	@Override
+	final public OutOfBoundsConstantValueNoGenericBounds< T > copy()
+	{
+		return new OutOfBoundsConstantValueNoGenericBounds<>( this );
+	}
+
+	/* RandomAccess */
+
+	@Override
+	final public OutOfBoundsConstantValueNoGenericBounds< T > copyRandomAccess()
+	{
+		return copy();
+	}
+}

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueNoGenericBoundsFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueNoGenericBoundsFactory.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.outofbounds;
+
+import java.util.function.Supplier;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+
+/**
+ *
+ * @param <T>
+ *
+ * @author Stephan Preibisch
+ * @author Stephan Saalfeld
+ * @author Philipp Hanslovsky
+ */
+public class OutOfBoundsConstantValueNoGenericBoundsFactory< T, F extends Interval & RandomAccessible< T > >
+		implements OutOfBoundsFactory< T, F >
+{
+	private Supplier< T > extensionSupplier;
+
+	public OutOfBoundsConstantValueNoGenericBoundsFactory( final Supplier< T > extensionSupplier )
+	{
+		this.extensionSupplier = extensionSupplier;
+	}
+
+	public void setValue( final Supplier< T > extensionSupplier )
+	{
+		this.extensionSupplier = extensionSupplier;
+	}
+
+	public Supplier< T > getValue()
+	{
+		return extensionSupplier;
+	}
+
+	@Override
+	public OutOfBoundsConstantValueNoGenericBounds< T > create( final F f )
+	{
+		return new OutOfBoundsConstantValueNoGenericBounds<>( f, extensionSupplier );
+	}
+}

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Supplier;
 
 import net.imglib2.EuclideanSpace;
 import net.imglib2.FlatIterationOrder;
@@ -53,6 +54,8 @@ import net.imglib2.interpolation.Interpolant;
 import net.imglib2.interpolation.InterpolatorFactory;
 import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
+import net.imglib2.outofbounds.OutOfBoundsConstantValueNoGenericBounds;
+import net.imglib2.outofbounds.OutOfBoundsConstantValueNoGenericBoundsFactory;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
 import net.imglib2.outofbounds.OutOfBoundsPeriodicFactory;
@@ -168,6 +171,23 @@ public class Views
 	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendMirrorDouble( final F source )
 	{
 		return new ExtendedRandomAccessibleInterval< T, F >( source, new OutOfBoundsMirrorFactory< T, F >( OutOfBoundsMirrorFactory.Boundary.DOUBLE ) );
+	}
+
+	/**
+	 * Extend a RandomAccessibleInterval with a constant-value out-of-bounds
+	 * strategy.
+	 *
+	 * @param source
+	 *            the interval to extend.
+	 * @param extensionSupplier
+	 *            generates the constant extension when requested
+	 * @return (unbounded) RandomAccessible which extends the input interval to
+	 *         infinity.
+	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
+	 */
+	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final Supplier< T > extensionSupplier )
+	{
+		return new ExtendedRandomAccessibleInterval< T, F >( source, new OutOfBoundsConstantValueNoGenericBoundsFactory<>( extensionSupplier) );
 	}
 
 	/**
@@ -1323,6 +1343,22 @@ public class Views
 	public static < T > IntervalView< T > expandMirrorDouble( final RandomAccessibleInterval< T > source, final long... border )
 	{
 		return interval( extendMirrorDouble( source ), Intervals.expand( source, border ) );
+	}
+
+	/**
+	 * Expand a RandomAccessibleInterval as specified by border. source will be
+	 * extended with a constant value specified by the caller.
+	 *
+	 * @param source
+	 *            the interval to expand.
+	 * @param extensionSupplier
+	 *            generates the constant extension when requested
+	 * @return Expansion of the {@link RandomAccessibleInterval} source as
+	 *         specified by t and border.
+	 */
+	public static < T > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final Supplier< T > extensionSupplier, final long... border )
+	{
+		return interval( extendValue( source, extensionSupplier ), Intervals.expand( source, border ) );
 	}
 
 	/**


### PR DESCRIPTION
`OutOfBoundsConstantValue` is bound to `T extends Type< T >` as the provided extension is copied. This does not allow to extend arbitrary generics with a constant value.
I assume that the rationale for that behavior is to avoid accidental modifications of the provided type, which could actually represent meaningful data.

To get around this restriction, I add a replication of `OutOfBoundsConstantValue` and `OutOfBoundsConstantValue` that uses a `Supplier< T >` instead of a `T` to extend the `RandomAccessibleInterval` with a constant value.