### PR TITLE
add generic functions as RandomAccessible and RealRandomAccessible

### DIFF
--- a/src/main/java/net/imglib2/position/AbstractFunction.java
+++ b/src/main/java/net/imglib2/position/AbstractFunction.java
@@ -1,0 +1,69 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.position;
+
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import net.imglib2.EuclideanSpace;
+
+/**
+ * Abstract base class for functions that generate values through a
+ * {@link BiConsumer}.
+ *
+ * @author Stephan Saalfeld
+ */
+public abstract class AbstractFunction< P, T > implements EuclideanSpace
+{
+	protected final int n;
+	protected final BiConsumer< P, T > function;
+	protected final Supplier< T > typeSupplier;
+
+	public AbstractFunction(
+			final int n,
+			final BiConsumer< P, T > function,
+			final Supplier< T > typeSupplier )
+	{
+		this.n = n;
+		this.function = function;
+		this.typeSupplier = typeSupplier;
+	}
+
+	@Override
+	public int numDimensions()
+	{
+		return n;
+	}
+}

--- a/src/main/java/net/imglib2/position/Function.java
+++ b/src/main/java/net/imglib2/position/Function.java
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.position;
+
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+
+/**
+ * A {@link RandomAccessible} that generates a function value for each
+ * position in discrete coordinate space by side-effect using a
+ * {@link BiConsumer}.
+ *
+ * @author Stephan Saalfeld
+ */
+public class Function< T > extends AbstractFunction< Localizable, T > implements RandomAccessible< T >
+{
+	public Function(
+			final int n,
+			final BiConsumer< Localizable, T > function,
+			final Supplier< T > typeSupplier )
+	{
+		super(n, function, typeSupplier);
+	}
+
+	public class FunctionRandomAccess extends Point implements RandomAccess< T >
+	{
+		private final T t = typeSupplier.get();
+
+		public FunctionRandomAccess()
+		{
+			super( Function.this.n );
+		}
+
+		@Override
+		public T get()
+		{
+			function.accept( this, t );
+			return t;
+		}
+
+		@Override
+		public FunctionRandomAccess copy()
+		{
+			return new FunctionRandomAccess();
+		}
+
+		@Override
+		public FunctionRandomAccess copyRandomAccess()
+		{
+			return copy();
+		}
+	}
+
+	@Override
+	public FunctionRandomAccess randomAccess()
+	{
+		return new FunctionRandomAccess();
+	}
+
+	@Override
+	public FunctionRandomAccess randomAccess( final Interval interval )
+	{
+		return randomAccess();
+	}
+}

--- a/src/main/java/net/imglib2/position/RealFunction.java
+++ b/src/main/java/net/imglib2/position/RealFunction.java
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.position;
+
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import net.imglib2.RealInterval;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.RealRandomAccessible;
+
+/**
+ * A {@link RealRandomAccessible} that generates a function value for each
+ * position in real coordinate space by side-effect using a
+ * {@link BiConsumer}.
+ *
+ * @author Stephan Saalfeld
+ */
+public class RealFunction< T > extends AbstractFunction< RealLocalizable, T > implements RealRandomAccessible< T >
+{
+	public RealFunction(
+			final int n,
+			final BiConsumer< RealLocalizable, T > function,
+			final Supplier< T > typeSupplier )
+	{
+		super( n, function, typeSupplier );
+	}
+
+	public class RealFunctionRealRandomAccess extends RealPoint implements RealRandomAccess< T >
+	{
+		private final T t = typeSupplier.get();
+
+		public RealFunctionRealRandomAccess()
+		{
+			super( RealFunction.this.n );
+		}
+
+		@Override
+		public T get()
+		{
+			function.accept( this, t );
+			return t;
+		}
+
+		@Override
+		public RealFunctionRealRandomAccess copy()
+		{
+			return new RealFunctionRealRandomAccess();
+		}
+
+		@Override
+		public RealFunctionRealRandomAccess copyRealRandomAccess()
+		{
+			return copy();
+		}
+	}
+
+	@Override
+	public RealFunctionRealRandomAccess realRandomAccess()
+	{
+		return new RealFunctionRealRandomAccess();
+	}
+
+	@Override
+	public RealFunctionRealRandomAccess realRandomAccess( final RealInterval interval )
+	{
+		return realRandomAccess();
+	}
+}

--- a/src/test/java/net/imglib2/position/FunctionTest.java
+++ b/src/test/java/net/imglib2/position/FunctionTest.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.position;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import net.imglib2.type.logic.BoolType;
+
+
+public class FunctionTest {
+
+	@Test
+	public void test() {
+
+		final Function< BoolType > function = new Function< BoolType >(
+				4,
+				(pos, val) -> val.set(
+						pos.getDoublePosition(0) > 0 &&
+						pos.getDoublePosition(1) > 1 &&
+						pos.getDoublePosition(2) > 2 &&
+						pos.getDoublePosition(3) > 3 ),
+				BoolType::new );
+
+		Function<BoolType>.FunctionRandomAccess access = function.randomAccess();
+		access.setPosition( new long[] {1, 2, 3, 4} );
+		assertTrue( access.get().get() );
+		access.setPosition( new long[] {0, 2, 3, 4} );
+		assertTrue( !access.get().get() );
+		access.setPosition( new long[] {1, 0, 3, 4} );
+		assertTrue( !access.get().get() );
+		access.setPosition( new long[] {1, 2, -10, 4} );
+		assertTrue( !access.get().get() );
+		access.setPosition( new long[] {10, 50, 5, 5} );
+		assertTrue( access.get().get() );
+	}
+
+}

--- a/src/test/java/net/imglib2/position/RealFunctionTest.java
+++ b/src/test/java/net/imglib2/position/RealFunctionTest.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2017 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.position;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import net.imglib2.type.logic.BoolType;
+
+
+public class RealFunctionTest {
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {}
+
+	@Before
+	public void setUp() throws Exception {}
+
+	@After
+	public void tearDown() throws Exception {}
+
+	@Test
+	public void test() {
+
+		final RealFunction< BoolType > function = new RealFunction< BoolType >(
+				4,
+				(pos, val) -> val.set(
+						pos.getDoublePosition(0) > 0 &&
+						pos.getDoublePosition(1) > 1 &&
+						pos.getDoublePosition(2) > 2 &&
+						pos.getDoublePosition(3) > 3 ),
+				BoolType::new );
+
+		RealFunction<BoolType>.RealFunctionRealRandomAccess access = function.realRandomAccess();
+		access.setPosition( new double[] {1, 2, 3, 4} );
+		assertTrue( access.get().get() );
+		access.setPosition( new double[] {0, 2, 3, 4} );
+		assertTrue( !access.get().get() );
+		access.setPosition( new double[] {1, 0, 3, 4} );
+		assertTrue( !access.get().get() );
+		access.setPosition( new double[] {1, 2, -10, 4} );
+		assertTrue( !access.get().get() );
+		access.setPosition( new double[] {10, 50, 5, 5} );
+		assertTrue( access.get().get() );
+	}
+
+}


### PR DESCRIPTION
that generate values via side effect through a BiConsumer

I found myself implementing specialized variants of this in various projects and this to me looks like a generic convenience approach.  `PositionRandomAccessible` and `RealPositionRealRandomAccessible` in the same package are special purpose implementations of the same concept.  They could be replaced by e.g.
```java
RandomAccessible<LongType> positionRandomAccessible = new Function<LongType>(3, (x, y) -> y.set(x.getLongPosition(0)), LongType::new);
```