### PR TITLE
 Integer ShearTransforms with configurable shearing factor

### DIFF
--- a/src/main/java/net/imglib2/transform/integer/shear/AbstractShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/AbstractShearTransform.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,6 +31,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+
 package net.imglib2.transform.integer.shear;
 
 import java.util.Arrays;

--- a/src/main/java/net/imglib2/transform/integer/shear/AbstractShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/AbstractShearTransform.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,128 +31,177 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-/**
- * 
- */
 package net.imglib2.transform.integer.shear;
+
+import java.util.Arrays;
 
 import net.imglib2.Localizable;
 import net.imglib2.Positionable;
 import net.imglib2.transform.InvertibleTransform;
+import net.imglib2.transform.integer.BoundingBox;
 import net.imglib2.transform.integer.BoundingBoxTransform;
 
+
 /**
- * 
+ *
  * Most simple case of a shear transform that just implements
  * for a integer valued coordinate:
- * coordinate[ shearDimension ] += coordinate[ referenceDimension ] (forward)
- * coordinate[ shearDimension ] -= coordinate[ referenceDimension ] (backward)
- * 
+ * coordinate[ shearDimension ] += coordinate[ referenceDimension ] * shearFactor (forward)
+ * coordinate[ shearDimension ] -= coordinate[ referenceDimension ] * shearFactor (backward)
+ *
  * This abstract class holds the inverse and implements applyInverse in
  * terms of inverse.apply
- * 
+ *
  * @author Philipp Hanslovsky
+ * @author Keith Schulze
  *
  */
 public abstract class AbstractShearTransform implements InvertibleTransform, BoundingBoxTransform
 {
-	
-	
-	protected final int nDim;
-	protected final int shearDimension;
-	protected final int referenceDimension;
-	
-	protected AbstractShearTransform inverse;
-	
-	
-	protected AbstractShearTransform(
-			int nDim,
-			int shearDimension,
-			int referenceDimension )
-	{
-		this( nDim, shearDimension, referenceDimension, null );
-	}
-	
-	
-	protected AbstractShearTransform(
+
+
+	private final int nDim;
+	private final int shearDimension;
+	private final int referenceDimension;
+	private final int shearFactor;
+
+
+	/**
+	 * @param nDim						Number of dimensions (source and target dimensions must be the same)
+	 * @param shearDimension			Dimension to be sheared.
+	 * @param referenceDimension		Dimension used as reference for shear.
+	 * @param shearFactor				Interval for shear i.e., amount to shift shear dimension with respect
+	 *									an increment in the reference referenceDimension.
+	 * @throws IllegalArgumentException	if nDim < 2, shearDimension >= nDim, referenceDimension >= nDim,
+	 *									referenceDimension == shearDimension
+	 */
+	AbstractShearTransform(
 			int nDim,
 			int shearDimension,
 			int referenceDimension,
-			AbstractShearTransform inverse )
+			int shearFactor)
 	{
-		this.nDim               = nDim;
-		this.shearDimension     = shearDimension;
+		if (nDim < 2) throw new IllegalArgumentException("nDim cannot be < 2");
+		else if (shearDimension >= nDim) throw new IllegalArgumentException("shearDimension cannot be greater than nDim.");
+		else if (referenceDimension >= nDim) throw new IllegalArgumentException("referenceDimension cannot be greater than nDim.");
+		else if (referenceDimension == shearDimension) throw new IllegalArgumentException("referenceDimension cannot be equal to shearDimension.");
+
+		this.nDim = nDim;
+		this.shearDimension = shearDimension;
 		this.referenceDimension = referenceDimension;
-		this.inverse            = inverse;
-	}
-	
-	
-	public int getReferenceDimension() {
-		return referenceDimension;
+		this.shearFactor = shearFactor;
 	}
 
 
-	@Override
-	public int numSourceDimensions() 
-	{
-		return this.numDimensions();
-	}
-	
-
-	@Override
-	public int numTargetDimensions() 
-	{
-		return this.numDimensions();
-	}
-	
-	
-	public int numDimensions() 
+	public int numDimensions()
 	{
 		return nDim;
 	}
-	
-	
+
+
+	@Override
+	public int numSourceDimensions()
+	{
+		return this.numDimensions();
+	}
+
+
+	@Override
+	public int numTargetDimensions()
+	{
+		return this.numDimensions();
+	}
+
+
 	public int getShearDimension()
 	{
 		return this.shearDimension;
 	}
-	
+
+	public int getReferenceDimension() {
+		return referenceDimension;
+	}
 
 	@Override
-	public void applyInverse( long[] source, long[] target ) 
+	public void apply( long[] source, long[] target )
 	{
-		// for inverse, source and target need to be switched
-		this.inverse.apply( target, source );
+		assert source.length == this.nDim && target.length == this.nDim;
+
+		System.arraycopy( source, 0, target, 0, source.length );
+		target[this.shearDimension] += source[this.referenceDimension] * this.shearFactor;
 	}
-	
+
 
 	@Override
-	public void applyInverse(int[] source, int[] target) 
+	public void apply( int[] source, int[] target )
 	{
-		// for inverse, source and target need to be switched
-		this.inverse.apply( target, source );
+		assert source.length == this.nDim && target.length == this.nDim;
+
+		System.arraycopy( source, 0, target, 0, source.length );
+		target[this.shearDimension] += source[this.referenceDimension] * this.shearFactor;
 	}
-	
+
 
 	@Override
-	public void applyInverse( Positionable source, Localizable target ) 
+	public void apply( Localizable source, Positionable target )
 	{
-		// for inverse, source and target need to be switched
-		this.inverse.apply( target, source );
+		assert source.numDimensions() == nDim && target.numDimensions() == nDim;
+
+		target.setPosition( source );
+		target.setPosition( source.getLongPosition( this.shearDimension ) + source.getLongPosition( this.referenceDimension ) * this.shearFactor, this.shearDimension );
 	}
-	
+
 
 	@Override
-	public AbstractShearTransform inverse() 
+	public void applyInverse( long[] source, long[] target )
 	{
-		return this.inverse;
-	}
-	
-	
-	public abstract long[] getShear();
+		assert source.length == this.nDim && target.length == this.nDim;
 
-	
-	public abstract AbstractShearTransform copy();
-	
-	
+		System.arraycopy( target, 0, source, 0, target.length );
+		source[this.shearDimension] -= target[this.referenceDimension] * this.shearFactor;
+	}
+
+
+	@Override
+	public void applyInverse( int[] source, int[] target )
+	{
+		assert source.length == this.nDim && target.length == this.nDim;
+
+		System.arraycopy( target, 0, source, 0, target.length );
+		source[this.shearDimension] -= target[this.referenceDimension] * this.shearFactor;
+	}
+
+
+	@Override
+	public void applyInverse( Positionable source, Localizable target )
+	{
+		assert source.numDimensions() == this.nDim && target.numDimensions() == this.nDim;
+
+		source.setPosition( target );
+		source.setPosition( target.getLongPosition( this.shearDimension ) - target.getLongPosition( this.referenceDimension ) * this.shearFactor, this.shearDimension );
+	}
+
+
+	public AbstractShearTransform copy()
+	{
+		return new ShearTransform( this.nDim, this.shearDimension, this.referenceDimension, this.shearFactor );
+	}
+
+
+	@Override
+	public AbstractShearTransform inverse()
+	{
+		return new ShearTransform( this.nDim, this.shearDimension, this.referenceDimension, -this.shearFactor );
+	}
+
+
+	@Override
+	public BoundingBox transform( BoundingBox bb )
+	{
+		bb.orderMinMax();
+		long[] c2 = Arrays.copyOf(bb.corner2, bb.corner2.length);
+		long diff = c2[this.referenceDimension] - bb.corner1[this.referenceDimension];
+		c2[this.shearDimension] += diff * this.shearFactor;
+		return new BoundingBox( bb.corner1, c2 );
+	}
 }

--- a/src/main/java/net/imglib2/transform/integer/shear/InverseShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/InverseShearTransform.java
@@ -31,6 +31,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+
 package net.imglib2.transform.integer.shear;
 
 

--- a/src/main/java/net/imglib2/transform/integer/shear/InverseShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/InverseShearTransform.java
@@ -31,21 +31,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-/**
- * 
- */
 package net.imglib2.transform.integer.shear;
 
-import net.imglib2.Localizable;
-import net.imglib2.Positionable;
-import net.imglib2.transform.integer.BoundingBox;
 
 /**
  * Backward implementation of the most simple case of a shear transform:
- * coordinate[ shearDimension ] -= coordinate[ referenceDimension ]
+ * coordinate[ shearDimension ] -= coordinate[ referenceDimension ] * shearFactor
  * 
  * 
  * @author Philipp Hanslovsky
+ * @author Keith Schulze
  *
  */
 public class InverseShearTransform extends AbstractShearTransform
@@ -56,18 +51,16 @@ public class InverseShearTransform extends AbstractShearTransform
 	 * @param nDim					Number of dimensions (source and target dimensions must be the same)
 	 * @param shearDimension		Dimension to be sheared.
 	 * @param referenceDimension	Dimension used as reference for shear.
+	 * @param shearFactor			Interval for shear i.e., amount to shift shear dimension with respect
+	 *								an increment in the reference referenceDimension.
 	 */
 	public InverseShearTransform(
 			int nDim,
 			int shearDimension,
-			int referenceDimension )
+			int referenceDimension,
+			int shearFactor )
 	{
-		super( nDim, shearDimension, referenceDimension );
-		this.inverse = new ShearTransform( 
-				nDim, 
-				shearDimension,
-				referenceDimension,
-				this );
+		super( nDim, shearDimension, referenceDimension, -shearFactor );
 	}
 
 	
@@ -77,69 +70,12 @@ public class InverseShearTransform extends AbstractShearTransform
 	 * @param nDim					Number of dimensions (source and target dimensions must be the same)
 	 * @param shearDimension		Dimension to be sheared.
 	 * @param referenceDimension	Dimension used as reference for shear.
-	 * @param inverse				
 	 */
 	protected InverseShearTransform( 
 			int nDim, 
 			int shearDimension,
-			int referenceDimension, 
-			AbstractShearTransform inverse )
+			int referenceDimension )
 	{
-		super( nDim, shearDimension, referenceDimension, inverse );
+		this( nDim, shearDimension, referenceDimension, 1 );
 	}
-
-
-	@Override
-	public void apply( long[] source, long[] target ) 
-	{
-		assert source.length >= this.nDim && target.length >= nDim;
-		System.arraycopy( source, 0, target, 0, source.length );
-		target[ shearDimension ] -= target[ referenceDimension ];
-	}
-	
-
-	@Override
-	public void apply( int[] source, int[] target )
-	{
-		assert source.length >= this.nDim && target.length >= nDim;
-		System.arraycopy( source, 0, target, 0, source.length );
-		target[ shearDimension ] -= target[ referenceDimension ];
-	}
-	
-
-	@Override
-	public void apply( Localizable source, Positionable target ) 
-	{
-		assert source.numDimensions() >= this.nDim && target.numDimensions() >= nDim;
-		target.setPosition( source );
-		target.setPosition( source.getLongPosition( shearDimension ) - source.getLongPosition( referenceDimension ), shearDimension );
-	}
-
-	@Override
-	public AbstractShearTransform copy()
-	{
-		return new InverseShearTransform( nDim, shearDimension, referenceDimension ); // return this; ?
-	}
-
-
-	@Override
-	public long[] getShear() 
-	{
-		long[] shear = new long[ this.nDim ];
-		shear[ this.shearDimension ] = -1;
-		return shear;
-	}
-
-	
-	@Override public BoundingBox transform( BoundingBox bb )
-	{
-		bb.orderMinMax();
-		long[] c = bb.corner1;
-		// assume that corner2[ i ] > corner1[ i ]
-		long diff = bb.corner2[ this.referenceDimension ] - c[ this.referenceDimension ];
-		c[ this.shearDimension ] -=diff;
-		return bb;
-	}
-
-	
 }

--- a/src/main/java/net/imglib2/transform/integer/shear/ShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/ShearTransform.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,116 +31,49 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-/**
- * 
- */
 package net.imglib2.transform.integer.shear;
 
-import net.imglib2.Localizable;
-import net.imglib2.Positionable;
-import net.imglib2.transform.integer.BoundingBox;
 
 /**
- * Forward implementation of the most simple case of a shear transform:
- * coordinate[ shearDimension ] += coordinate[ referenceDimension ]
- * 
+ * Invertible shear transform that shears by whole pixel units.
+ * coordinate[shearDimension] += coordinate[referenceDimension] * shearFactor
+ *
  * @author Philipp Hanslovsky
+ * @author Keith Schulze
  *
  */
 public class ShearTransform extends AbstractShearTransform
 {
-	
 
 	/**
+	 * @param nDim						Number of dimensions (source and target dimensions must be the same)
+	 * @param shearDimension			Dimension to be sheared.
+	 * @param referenceDimension		Dimension used as reference for shear.
+	 * @param shearFactor				Interval for shear i.e., amount to shift shear dimension with respect
+	 *									an increment in the reference referenceDimension.
+	 */
+	public ShearTransform(
+			int nDim,
+			int shearDimension,
+			int referenceDimension,
+			int shearFactor)
+	{
+		super(nDim, shearDimension, referenceDimension, shearFactor);
+	}
+
+
+	/**
+	 * Auxillary constructor where the shearFactor defaults to 1.
+	 *
 	 * @param nDim					Number of dimensions (source and target dimensions must be the same)
 	 * @param shearDimension		Dimension to be sheared.
 	 * @param referenceDimension	Dimension used as reference for shear.
 	 */
 	public ShearTransform(
-			int nDim, 
+			int nDim,
 			int shearDimension,
-			int referenceDimension ) 
+			int referenceDimension)
 	{
-		super( nDim, shearDimension, referenceDimension );
-		this.inverse = new InverseShearTransform( 
-				nDim, 
-				shearDimension,
-				referenceDimension,
-				this );
+		this( nDim, shearDimension, referenceDimension, 1 );
 	}
-	
-	
-	/**
-	 * Protected constructor for passing an inverse to avoid construction of unnecessary objects.
-	 * 
-	 * @param nDim					Number of dimensions (source and target dimensions must be the same)
-	 * @param shearDimension		Dimension to be sheared.
-	 * @param referenceDimension	Dimension used as reference for shear.
-	 * @param inverse				
-	 */
-	protected ShearTransform( 
-			int nDim, 
-			int shearDimension,
-			int referenceDimension, 
-			AbstractShearTransform inverse ) 
-	{
-		super( nDim, shearDimension, referenceDimension, inverse );
-	}
-
-
-	@Override
-	public void apply( long[] source, long[] target ) 
-	{
-		assert source.length >= this.nDim && target.length >= nDim;
-		System.arraycopy( source, 0, target, 0, source.length );
-		target[ shearDimension ] += target[ referenceDimension ];
-	}
-	
-
-	@Override
-	public void apply( int[] source, int[] target )
-	{
-		assert source.length >= this.nDim && target.length >= nDim;
-		System.arraycopy( source, 0, target, 0, source.length );
-		target[ shearDimension ] += target[ referenceDimension ];
-	}
-	
-
-	@Override
-	public void apply( Localizable source, Positionable target ) 
-	{
-		assert source.numDimensions() >= this.nDim && target.numDimensions() >= nDim;
-		target.setPosition( source );
-		target.setPosition( source.getLongPosition( shearDimension ) + source.getLongPosition( referenceDimension ), shearDimension );
-	}
-	
-
-	@Override
-	public ShearTransform copy()
-	{
-//		do just return this; ?
-		return new ShearTransform( this.nDim, this.shearDimension, this.referenceDimension );
-	}
-
-
-	@Override
-	public long[] getShear()
-	{
-		long[] shear = new long[ this.nDim ];
-		shear[ this.shearDimension ] = 1;
-		return shear;
-	}
-	
-	
-	@Override public BoundingBox transform( BoundingBox bb )
-	{
-		bb.orderMinMax();
-		long[] c = bb.corner2;
-		// assume that corner2[ i ] > corner1[ i ]
-		long diff = c[ this.referenceDimension ] - bb.corner1[ this.referenceDimension ];
-		c[ this.shearDimension ] +=diff;
-		return bb;
-	}
-	
-
 }

--- a/src/main/java/net/imglib2/transform/integer/shear/ShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/ShearTransform.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,6 +31,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+
 package net.imglib2.transform.integer.shear;
 
 

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -62,7 +62,6 @@ import net.imglib2.transform.integer.MixedTransform;
 import net.imglib2.transform.integer.permutation.AbstractPermutationTransform;
 import net.imglib2.transform.integer.permutation.PermutationTransform;
 import net.imglib2.transform.integer.permutation.SingleDimensionPermutationTransform;
-import net.imglib2.transform.integer.shear.InverseShearTransform;
 import net.imglib2.transform.integer.shear.ShearTransform;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.NumericType;
@@ -1041,7 +1040,36 @@ public class Views
 	/**
 	 * Positive shear transform of a RandomAccessible using
 	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[ shearDimension ] +
+	 * c[ referenceDimension ] * shearFactor
+	 *
+	 * @param source
+	 *            input, e.g. extended {@link RandomAccessibleInterval}
+	 * @param shearDimension
+	 *            dimension to be sheared
+	 * @param referenceDimension
+	 *            reference dimension for shear
+	 * @param shearFactor
+	 *			  amount to shift the shear dimension with respect to the
+	 *			  referenceDimension
+	 *
+	 * @return {@link TransformView} containing the result.
+	 */
+	public static < T > TransformView< T > shear(
+			final RandomAccessible< T > source,
+			final int shearDimension,
+			final int referenceDimension,
+			final int shearFactor )
+	{
+		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension, shearFactor );
+		return new TransformView< T >( source, transform.inverse() );
+	}
+
+	/**
+	 * Positive shear transform of a RandomAccessible using
+	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[ shearDimension ] +
 	 * c[ referenceDimension ]
+	 *
+	 * Simply calls {@link Views#shear} with a shearFactor = 1.
 	 *
 	 * @param source
 	 *            input, e.g. extended {@link RandomAccessibleInterval}
@@ -1054,14 +1082,42 @@ public class Views
 	 */
 	public static < T > TransformView< T > shear( final RandomAccessible< T > source, final int shearDimension, final int referenceDimension )
 	{
-		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
-		return new TransformView< T >( source, transform.inverse() );
+		return shear(source, shearDimension, referenceDimension, 1);
 	}
 
 	/**
 	 * Negative shear transform of a RandomAccessible using
-	 * {@link InverseShearTransform}, i.e. c[ shearDimension ] = c[
+	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[
+	 * shearDimension ] - c[ referenceDimension ] * shearFactor
+	 *
+	 * @param source
+	 *            input, e.g. extended {@link RandomAccessibleInterval}
+	 * @param shearDimension
+	 *            dimension to be sheared
+	 * @param referenceDimension
+	 *            reference dimension for shear
+	 * @param shearFactor
+	 *			  amount to shift the shear dimension with respect to the
+	 *			  referenceDimension
+	 *
+	 * @return {@link TransformView} containing the result.
+	 */
+	public static < T > TransformView< T > unshear(
+			final RandomAccessible< T > source,
+			final int shearDimension,
+			final int referenceDimension,
+			final int shearFactor )
+	{
+		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension, shearFactor );
+		return new TransformView< T >( source, transform );
+	}
+
+	/**
+	 * Negative shear transform of a RandomAccessible using
+	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[
 	 * shearDimension ] - c[ referenceDimension ]
+	 *
+	 * Simply calls {@link Views#shear} with a shearFactor = 1.
 	 *
 	 * @param source
 	 *            input, e.g. extended {@link RandomAccessibleInterval}
@@ -1074,14 +1130,47 @@ public class Views
 	 */
 	public static < T > TransformView< T > unshear( final RandomAccessible< T > source, final int shearDimension, final int referenceDimension )
 	{
-		final InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
-		return new TransformView< T >( source, transform.inverse() );
+		return unshear(source, shearDimension, referenceDimension, 1);
+	}
+
+	/**
+	 * Positive shear transform of a RandomAccessible using
+	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[ shearDimension ] +
+	 * c[ referenceDimension ] * shearFactor
+	 *
+	 * @param source
+	 *            input, e.g. extended {@link RandomAccessibleInterval}
+	 * @param interval
+	 *            original interval
+	 * @param shearDimension
+	 *            dimension to be sheared
+	 * @param referenceDimension
+	 *            reference dimension for shear
+	 * @param shearFactor
+	 *			  amount to shift the shear dimension with respect to the
+	 *			  referenceDimension
+	 *
+	 * @return {@link IntervalView} containing the result. The returned
+	 *         interval's dimension are determined by applying the
+	 *         {@link ShearTransform#transform} method on the input interval.
+	 */
+	public static < T > IntervalView< T > shear(
+			final RandomAccessible< T > source,
+			final Interval interval,
+			final int shearDimension,
+			final int referenceDimension,
+			final int shearFactor )
+	{
+		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension, shearFactor );
+		return Views.interval( new TransformView< T >( source, transform.inverse() ), transform.transform( new BoundingBox( interval ) ).getInterval() );
 	}
 
 	/**
 	 * Positive shear transform of a RandomAccessible using
 	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[ shearDimension ] +
 	 * c[ referenceDimension ]
+	 *
+	 * Simply calls {@link Views#shear} with a shearFactor = 1.
 	 *
 	 * @param source
 	 *            input, e.g. extended {@link RandomAccessibleInterval}
@@ -1098,14 +1187,47 @@ public class Views
 	 */
 	public static < T > IntervalView< T > shear( final RandomAccessible< T > source, final Interval interval, final int shearDimension, final int referenceDimension )
 	{
-		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
-		return Views.interval( Views.shear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval ) ).getInterval() );
+		return shear(source, interval, shearDimension, referenceDimension, 1);
 	}
 
 	/**
 	 * Negative shear transform of a RandomAccessible using
-	 * {@link InverseShearTransform}, i.e. c[ shearDimension ] = c[
+	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[
+	 * shearDimension ] - c[ referenceDimension ] * shearFactor
+	 *
+	 * @param source
+	 *            input, e.g. extended {@link RandomAccessibleInterval}
+	 * @param interval
+	 *            original interval
+	 * @param shearDimension
+	 *            dimension to be sheared
+	 * @param referenceDimension
+	 *            reference dimension for shear
+	 * @param shearFactor
+	 *			  amount to shift the shear dimension with respect to the
+	 *			  referenceDimension
+	 *
+	 * @return {@link IntervalView} containing the result. The returned
+	 *         interval's dimension are determined by applying the
+	 *         {@link ShearTransform#transform} method on the input interval.
+	 */
+	public static < T > IntervalView< T > unshear(
+			final RandomAccessible< T > source,
+			final Interval interval,
+			final int shearDimension,
+			final int referenceDimension,
+			final int shearFactor )
+	{
+		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension, shearFactor );
+		return Views.interval( new TransformView< T >(source, transform), transform.inverse().transform( new BoundingBox( interval ) ).getInterval() );
+	}
+
+	/**
+	 * Negative shear transform of a RandomAccessible using
+	 * {@link ShearTransform}, i.e. c[ shearDimension ] = c[
 	 * shearDimension ] - c[ referenceDimension ]
+	 *
+	 * Simply calls {@link Views#shear} with a shearFactor = 1.
 	 *
 	 * @param source
 	 *            input, e.g. extended {@link RandomAccessibleInterval}
@@ -1122,8 +1244,7 @@ public class Views
 	 */
 	public static < T > IntervalView< T > unshear( final RandomAccessible< T > source, final Interval interval, final int shearDimension, final int referenceDimension )
 	{
-		final InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
-		return Views.interval( Views.unshear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval ) ).getInterval() );
+		return unshear(source, interval, shearDimension, referenceDimension, 1);
 	}
 
 	/**

--- a/src/test/java/net/imglib2/transform/integer/shear/ShearTransformTest.java
+++ b/src/test/java/net/imglib2/transform/integer/shear/ShearTransformTest.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,6 +31,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+
 package net.imglib2.transform.integer.shear;
 
 import java.util.Random;

--- a/src/test/java/net/imglib2/transform/integer/shear/ShearTransformTest.java
+++ b/src/test/java/net/imglib2/transform/integer/shear/ShearTransformTest.java
@@ -9,10 +9,10 @@
  * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
  * Jean-Yves Tinevez and Michael Zinsmaier.
  * %%
- * Redistribution and use in refDim and binary forms, with or without
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of refDim code must retain the above copyright notice,
+ * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation


### PR DESCRIPTION
Currently, ShearTransform only allows n-dimensional image to be sheared along the shear dimension, with respect to the reference dimension, by a factor of 1. This PR is a refactor of the ShearTransform to allow transform with a `shearFactor` other than 1.

```java
// forward transform
c[ shearDimension ] = c[ shearDimension ] + c[ referenceDimension ] * shearFactor

// backward/inverse transform
c[ shearDimension ] = c[ shearDimension ] - c[ referenceDimension ] * shearFactor 
// or c[ shearDimension ] = c[ shearDimension ] + c[ referenceDimension ] * -shearFactor

```

Tries to avoid any breaking changes to the existing API, consisting of classes for forward ShearTransform, backward InverseShearTransform and AbstactShearTransform with common functionality; however, introducing a shearFactor simplifies implementation, since the inverse transformation simply requires the inverse of the `shearFactor`. Hence, basically all functionality is now in the AbstractShearTransform class, while ShearTransform and InverseShearTransform just provide basic constructors that ensure the `shearFactor` is set correctly. Perhaps it might be worth deprecating the InverseShearTransform and AbstractShearTransform classes (and then removing them in the next major version), and just moving all functionality to ShearTransform?

Views have also been updated to include static methods that allow a shearFactor to be specified.