### PR TITLE
RandomAccessibleIntervalCursor: test if we need to switch line before calling randomAccess.fwd()

### DIFF
--- a/src/main/java/net/imglib2/view/RandomAccessibleIntervalCursor.java
+++ b/src/main/java/net/imglib2/view/RandomAccessibleIntervalCursor.java
@@ -109,9 +109,13 @@ public final class RandomAccessibleIntervalCursor< T > extends AbstractInterval 
 	@Override
 	public void fwd()
 	{
-		randomAccess.fwd( 0 );
-		if ( ++index > maxIndexOnLine )
+		if ( ++index > maxIndexOnLine ) {
 			nextLine();
+		}
+		else
+		{
+			randomAccess.fwd( 0 );
+		}
 	}
 
 	private void nextLine()


### PR DESCRIPTION
In most cases randomAccess.fwd(0) should be very cheap, but if we
operate on a CellImg, this can cause a cell to be loaded unnecessarily.