### PR TITLE
Add getByteCount() method to PrimitiveType enum

### DIFF
--- a/src/main/java/net/imglib2/type/PrimitiveType.java
+++ b/src/main/java/net/imglib2/type/PrimitiveType.java
@@ -50,18 +50,18 @@ import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
  */
 public enum PrimitiveType
 {
-	BYTE(Byte.BYTES),
-	CHAR(Character.BYTES),
-	SHORT(Short.BYTES),
-	INT(Integer.BYTES),
-	LONG(Long.BYTES),
-	FLOAT(Float.BYTES),
-	DOUBLE(Double.BYTES),
-	UNDEFINED(-1);
+	BYTE( Byte.BYTES ),
+	CHAR( Character.BYTES ),
+	SHORT( Short.BYTES ),
+	INT( Integer.BYTES ),
+	LONG( Long.BYTES ),
+	FLOAT( Float.BYTES ),
+	DOUBLE( Double.BYTES ),
+	UNDEFINED( -1 );
 
 	private final int byteCount;
 
-	private PrimitiveType( int byteCount )
+	private PrimitiveType( final int byteCount )
 	{
 		this.byteCount = byteCount;
 	}

--- a/src/main/java/net/imglib2/type/PrimitiveType.java
+++ b/src/main/java/net/imglib2/type/PrimitiveType.java
@@ -46,15 +46,28 @@ import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
  * </p>
  *
  * @author Tobias Pietzsch
+ * @author Curtis Rueden
  */
 public enum PrimitiveType
 {
-	BYTE,
-	CHAR,
-	SHORT,
-	INT,
-	LONG,
-	FLOAT,
-	DOUBLE,
-	UNDEFINED;
+	BYTE(Byte.BYTES),
+	CHAR(Character.BYTES),
+	SHORT(Short.BYTES),
+	INT(Integer.BYTES),
+	LONG(Long.BYTES),
+	FLOAT(Float.BYTES),
+	DOUBLE(Double.BYTES),
+	UNDEFINED(-1);
+
+	private final int byteCount;
+
+	private PrimitiveType( int byteCount )
+	{
+		this.byteCount = byteCount;
+	}
+
+	int getByteCount()
+	{
+		return byteCount;
+	}
 }


### PR DESCRIPTION
Now you can ask each `PrimitiveType` how many bytes it represents. This allows for code like:
```java
UnsignedByteType t = new UnsignedByteType();
Fraction totalBytes = t.getEntitiesPerPixel();
totalBytes.mul(new Fraction(t.getNativeTypeFactory().getPrimitiveType().getByteCount(), 1));
```
Which results in a `Fraction` indicating the number of bytes per element.