### PR TITLE
Add Views.moveAxis and Converters.mergeColor

### DIFF
--- a/src/main/java/net/imglib2/converter/ColorChannelOrder.java
+++ b/src/main/java/net/imglib2/converter/ColorChannelOrder.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter;
+
+public enum ColorChannelOrder
+{
+	ARGB( 4 ), RGB( 3 );
+
+	private final int channelCount;
+
+	ColorChannelOrder( int channelCount )
+	{
+		this.channelCount = channelCount;
+	}
+
+	public int channelCount() {
+		return channelCount;
+	}
+}

--- a/src/main/java/net/imglib2/converter/Converters.java
+++ b/src/main/java/net/imglib2/converter/Converters.java
@@ -54,6 +54,7 @@ import net.imglib2.converter.read.ConvertedRandomAccessibleInterval;
 import net.imglib2.converter.read.ConvertedRealRandomAccessible;
 import net.imglib2.converter.read.ConvertedRealRandomAccessibleRealInterval;
 import net.imglib2.converter.readwrite.ARGBChannelSamplerConverter;
+import net.imglib2.converter.readwrite.CompositeARGBSamplerConverter;
 import net.imglib2.converter.readwrite.SamplerConverter;
 import net.imglib2.converter.readwrite.WriteConvertedIterableInterval;
 import net.imglib2.converter.readwrite.WriteConvertedIterableRandomAccessibleInterval;
@@ -357,6 +358,35 @@ public class Converters
 			hyperSlices.add( argbChannel( source, channel ) );
 
 		return Views.stack( hyperSlices );
+	}
+
+	/**
+	 * Create an <em>n</em>-dimensional color image from an
+	 * (<em>n</em>+1)-dimensional image of {@link UnsignedByteType}.
+	 * @param source The last dimension of the image must be the color channel.
+	 *               {@link Views#stack} could be used to create the source, if
+	 *               there is a separate image for each color channel.
+	 * @param channelOrder Order of the color channels.
+	 * @return Color view to the source image that can be used for reading and writing.
+	 */
+	final static public RandomAccessible< ARGBType > mergeARGB( final RandomAccessible< UnsignedByteType > source, ColorChannelOrder channelOrder ) {
+		return Converters.convert( Views.collapse( source ), new CompositeARGBSamplerConverter( channelOrder ) );
+	}
+
+	/**
+	 * Create an <em>n</em>-dimensional color image from an
+	 * (<em>n</em>+1)-dimensional image of {@link UnsignedByteType}.
+	 * @param source The last dimension of the image must be the color channel.
+	 *               {@link Views#stack} could be used to create the source, if
+	 *               there is a separate image for each color channel.
+	 * @param channelOrder Order of the color channels.
+	 * @return Color view to the source image that can be used for reading and writing.
+	 */
+	final static public RandomAccessibleInterval< ARGBType > mergeARGB( final RandomAccessibleInterval< UnsignedByteType > source, ColorChannelOrder channelOrder ) {
+		final int channelAxis = source.numDimensions() - 1;
+		if ( source.min( channelAxis ) > 0 || source.max( channelAxis ) < channelOrder.channelCount() - 1 )
+			throw new IllegalArgumentException();
+		return Converters.convert( Views.collapse( source ), new CompositeARGBSamplerConverter( channelOrder ) );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/converter/readwrite/CompositeARGBSamplerConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/CompositeARGBSamplerConverter.java
@@ -1,0 +1,129 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter.readwrite;
+
+import net.imglib2.Sampler;
+import net.imglib2.converter.ColorChannelOrder;
+import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.view.composite.Composite;
+
+import java.util.function.Function;
+
+public class CompositeARGBSamplerConverter implements SamplerConverter< Composite< UnsignedByteType >, ARGBType >
+{
+
+	private final Function< Sampler< ? extends Composite< UnsignedByteType >>, ? extends IntAccess > factory;
+
+	public CompositeARGBSamplerConverter( ColorChannelOrder order )
+	{
+		this.factory = getAccessFactory( order );
+	}
+
+	private Function<Sampler<? extends Composite<UnsignedByteType>>,? extends IntAccess> getAccessFactory( ColorChannelOrder order )
+	{
+		switch ( order ) {
+		case ARGB: return CompositeARGBAccess::new;
+		case RGB: return CompositeRGBAccess::new;
+		}
+		throw new IllegalArgumentException("Converter only supports ARGB and RGB channel order.");
+	}
+
+	@Override
+	public ARGBType convert( Sampler< ? extends Composite< UnsignedByteType > > sampler )
+	{
+		return new ARGBType( factory.apply( sampler ) );
+	}
+
+	private static final class CompositeARGBAccess implements IntAccess
+	{
+		private final Sampler< ? extends Composite< UnsignedByteType > > sampler;
+
+		public CompositeARGBAccess( Sampler< ? extends Composite< UnsignedByteType > > sampler )
+		{
+			this.sampler = sampler;
+		}
+
+		@Override
+		public int getValue( int index )
+		{
+			Composite< UnsignedByteType > composite = sampler.get();
+			return ( composite.get( 0 ).get() << 24 ) +
+					( composite.get( 1 ).get() << 16 ) +
+					( composite.get( 2 ).get() << 8 ) +
+					composite.get( 3 ).get();
+		}
+
+		@Override
+		public void setValue( int index, int value )
+		{
+			Composite< UnsignedByteType > composite = sampler.get();
+			composite.get( 0 ).set( value >> 24 );
+			composite.get( 1 ).set( value >> 16 );
+			composite.get( 2 ).set( value >> 8 );
+			composite.get( 3 ).set( value );
+		}
+	}
+
+	private static final class CompositeRGBAccess implements IntAccess
+	{
+		private final Sampler< ? extends Composite< UnsignedByteType > > sampler;
+
+		public CompositeRGBAccess( Sampler< ? extends Composite< UnsignedByteType > > sampler )
+		{
+			this.sampler = sampler;
+		}
+
+		@Override
+		public int getValue( int index )
+		{
+			Composite< UnsignedByteType > composite = sampler.get();
+			return 0xff000000 +
+					( composite.get( 0 ).get() << 16 ) +
+					( composite.get( 1 ).get() << 8 ) +
+					composite.get( 2 ).get();
+		}
+
+		@Override
+		public void setValue( int index, int value )
+		{
+			Composite< UnsignedByteType > composite = sampler.get();
+			composite.get( 0 ).set( value >> 16 );
+			composite.get( 1 ).set( value >> 8 );
+			composite.get( 2 ).set( value );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/util/Localizables.java
+++ b/src/main/java/net/imglib2/util/Localizables.java
@@ -1,0 +1,114 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.util;
+
+import net.imglib2.AbstractEuclideanSpace;
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.Sampler;
+import net.imglib2.view.Views;
+
+public class Localizables
+{
+
+	public static long[] asLongArray( Localizable localizable ) {
+		long[] result = new long[ localizable.numDimensions() ];
+		localizable.localize( result );
+		return result;
+	}
+
+	public static RandomAccessible< Localizable > randomAccessible( int n ) {
+		return new LocationRandomAccessible( n );
+	}
+
+	public RandomAccessibleInterval< Localizable > randomAccessibleInterval( Interval interval ) {
+		return Views.interval( randomAccessible( interval.numDimensions() ), interval );
+	}
+
+	// -- Helper classes --
+
+	private static class LocationRandomAccessible extends AbstractEuclideanSpace implements RandomAccessible< Localizable >
+	{
+		public LocationRandomAccessible( int n )
+		{
+			super( n );
+		}
+
+		@Override public RandomAccess< Localizable > randomAccess()
+		{
+			return new LocationRandomAccess( n );
+		}
+
+		@Override public RandomAccess< Localizable > randomAccess( Interval interval )
+		{
+			return randomAccess();
+		}
+	}
+
+	/**
+	 * A RandomAccess that returns it's current position as value.
+	 */
+	private static class LocationRandomAccess extends Point implements RandomAccess< Localizable >
+	{
+		public LocationRandomAccess( int n )
+		{
+			super( n );
+		}
+
+		public LocationRandomAccess( Localizable initialPosition )
+		{
+			super( initialPosition );
+		}
+
+		@Override public RandomAccess< Localizable > copyRandomAccess()
+		{
+			return new LocationRandomAccess( this );
+		}
+
+		@Override public Localizable get()
+		{
+			return this;
+		}
+
+		@Override public Sampler< Localizable > copy()
+		{
+			return copyRandomAccess();
+		}
+	}
+}

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -399,6 +399,42 @@ public class Views
 	}
 
 	/**
+	 * Create view with permuted axes. fromAxis is moved to toAxis. While the
+	 * order of the other axes is preserved.
+	 *
+	 * If fromAxis=2 and toAxis=4, and axis order of image is XYCZT, then
+	 * a view to the image with axis order XYZTC would be created.
+	 */
+	public static < T > RandomAccessible< T > moveAxis( final RandomAccessible< T > image, final int fromAxis, final int toAxis )
+	{
+		if ( fromAxis == toAxis )
+			return image;
+		int direction = toAxis > fromAxis ? 1 : -1;
+		RandomAccessible< T > res = image;
+		for ( int i = fromAxis; i != toAxis; i += direction )
+			res = Views.permute( res, i, i + direction );
+		return res;
+	}
+
+	/**
+	 * Create view with permuted axes. fromAxis is moved to toAxis. While the
+	 * order of the other axes is preserved.
+	 *
+	 * If fromAxis=2 and toAxis=4, and axis order of image is XYCZT, then
+	 * a view to the image with axis order XYZTC would be created.
+	 */
+	public static < T > RandomAccessibleInterval< T > moveAxis( final RandomAccessibleInterval< T > image, final int fromAxis, final int toAxis )
+	{
+		if ( fromAxis == toAxis )
+			return image;
+		int direction = toAxis > fromAxis ? 1 : -1;
+		RandomAccessibleInterval< T > res = image;
+		for ( int i = fromAxis; i != toAxis; i += direction )
+			res = Views.permute( res, i, i + direction );
+		return res;
+	}
+
+	/**
 	 * Translate the source view by the given translation vector. Pixel
 	 * <em>x</em> in the source view has coordinates <em>(x + translation)</em>
 	 * in the resulting view.

--- a/src/test/java/net/imglib2/converter/ConvertersTest.java
+++ b/src/test/java/net/imglib2/converter/ConvertersTest.java
@@ -36,6 +36,7 @@ package net.imglib2.converter;
 
 import java.util.Random;
 
+import net.imglib2.img.Img;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -120,5 +121,47 @@ public class ConvertersTest
 			Assert.assertEquals( b.get(), testValues[ i ] & 0xff );
 			++i;
 		}
+	}
+
+	@Test
+	public void testMergeARBGReading()
+	{
+		Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 3, 4 }, 4 );
+		RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.ARGB );
+		Assert.assertEquals( 0x01020304, argb.randomAccess().get().get() );
+	}
+
+	@Test
+	public void testMergeARBGWriting()
+	{
+		// setup
+		byte[] pixels = new byte[ 4 ];
+		Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( pixels, 4 );
+		// process
+		RandomAccessibleInterval< ARGBType > arbg = Converters.mergeARGB( image, ColorChannelOrder.ARGB );
+		arbg.randomAccess().get().set( new ARGBType( 0x01020304 ) );
+		// test
+		Assert.assertArrayEquals( new byte[] { 1, 2, 3, 4 }, pixels );
+	}
+
+	@Test
+	public void testMergeRGBReading()
+	{
+		Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 3 }, 4 );
+		RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.RGB );
+		Assert.assertEquals( 0xff010203, argb.randomAccess().get().get() );
+	}
+
+	@Test
+	public void testMergbeRGBWriting()
+	{
+		// setup
+		byte[] pixels = new byte[ 3 ];
+		Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( pixels, 3 );
+		// process
+		RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.RGB );
+		// test
+		argb.randomAccess().get().set( new ARGBType( 0x00010203) );
+		Assert.assertArrayEquals( new byte[] { 1, 2, 3 }, pixels );
 	}
 }

--- a/src/test/java/net/imglib2/util/LocalizablesTest.java
+++ b/src/test/java/net/imglib2/util/LocalizablesTest.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.util;
+
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class LocalizablesTest
+{
+	@Test
+	public void testAsLongArray() {
+		Localizable input = new Point( 5,7 );
+		long[] result = Localizables.asLongArray( input );
+		assertArrayEquals( new long[] { 5, 7 }, result );
+	}
+
+	@Test
+	public void testRandomAccessible() {
+		long[] position = { 4, 2 };
+		int n = position.length;
+		RandomAccessible< Localizable > randomAccessible = Localizables.randomAccessible( n );
+		RandomAccess< Localizable > randomAccess = randomAccessible.randomAccess();
+		assertEquals( n, randomAccessible.numDimensions() );
+		assertEquals( n, randomAccess.numDimensions() );
+		randomAccess.setPosition( position );
+		assertArrayEquals( position, Localizables.asLongArray( randomAccess.get() ) );
+	}
+}

--- a/src/test/java/net/imglib2/view/ViewsTest.java
+++ b/src/test/java/net/imglib2/view/ViewsTest.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.view;
+
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Localizables;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class ViewsTest
+{
+	@Test
+	public void testMoveAxisUp() {
+		RandomAccessible< Localizable > input = Localizables.randomAccessible( 4 );
+		RandomAccessible< Localizable > view = Views.moveAxis( input, 1, 3 );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {1, 3, 4, 2} );
+		assertArrayEquals( new long[] {1, 2, 3, 4}, Localizables.asLongArray( ra.get() ) );
+	}
+
+	@Test
+	public void testMoveAxisDown() {
+		RandomAccessible< Localizable > input = Localizables.randomAccessible( 4 );
+		RandomAccessible< Localizable > view = Views.moveAxis( input, 3, 1 );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {1, 4, 2, 3} );
+		assertArrayEquals( new long[] {1, 2, 3, 4}, Localizables.asLongArray( ra.get() ) );
+	}
+
+	@Test
+	public void testMoveAxisUpForInteval() {
+		Img<?> img = ArrayImgs.bytes( 1, 2, 3, 4 );
+		RandomAccessibleInterval< ? > view = Views.moveAxis( img, 1, 3 );
+		assertArrayEquals( new long[]{ 1, 3, 4, 2 }, Intervals.dimensionsAsLongArray( view ) );
+	}
+
+	@Test
+	public void testMoveAxisDownForInteval() {
+		Img<?> img = ArrayImgs.bytes( 1, 2, 3, 4 );
+		RandomAccessibleInterval< ? > view = Views.moveAxis( img, 3, 1 );
+		assertArrayEquals( new long[]{ 1, 4, 2, 3 }, Intervals.dimensionsAsLongArray( view ) );
+	}
+}


### PR DESCRIPTION
This PR add:

* Converters.mergeColor creates a color view of and image of UnsignedByteType. The view supports read&write.
* Views.moveAxis: Very useful to create a color view, if the axis order needs to be changed before Converters.mergeColor can be applied.
* Utility class Localizables: Methods that are very useful to write test, or during prototyping.