### PR TITLE
Add the infrastructure for boolean[]-backed images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>imglib2</artifactId>
-	<version>5.5.1-SNAPSHOT</version>
+	<version>5.6.0-SNAPSHOT</version>
 
 	<name>ImgLib2 Core Library</name>
 	<description>A multidimensional, type-agnostic image processing library.</description>

--- a/src/main/java/net/imglib2/img/array/ArrayImgs.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImgs.java
@@ -34,12 +34,14 @@
 
 package net.imglib2.img.array;
 
+import net.imglib2.img.basictypeaccess.BooleanAccess;
 import net.imglib2.img.basictypeaccess.ByteAccess;
 import net.imglib2.img.basictypeaccess.DoubleAccess;
 import net.imglib2.img.basictypeaccess.FloatAccess;
 import net.imglib2.img.basictypeaccess.IntAccess;
 import net.imglib2.img.basictypeaccess.LongAccess;
 import net.imglib2.img.basictypeaccess.ShortAccess;
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
@@ -48,6 +50,7 @@ import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.type.Type;
 import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.NativeBoolType;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.complex.ComplexDoubleType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
@@ -349,12 +352,54 @@ final public class ArrayImgs
 	}
 
 	/**
+	 * Create an {@link ArrayImg}&lt;{@link NativeBoolType}, {@link BooleanArray}&gt;.
+	 */
+	@SuppressWarnings( "unchecked" )
+	final static public ArrayImg< NativeBoolType, BooleanArray > booleans( final long... dim )
+	{
+		return ( ArrayImg< NativeBoolType, BooleanArray > ) new ArrayImgFactory<>( new NativeBoolType() ).create( dim );
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link NativeBoolType}, {@link BooleanArray}&gt;
+	 * reusing a passed byte[] array.
+	 */
+	final public static ArrayImg< NativeBoolType, BooleanArray > booleans( final boolean[] array, final long... dim )
+	{
+		return booleans( new BooleanArray( array ), dim );
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link NativeBoolType},
+	 * {@link BooleanAccess}&gt; using a {@link BooleanAccess} passed as argument.
+	 */
+	final public static < A extends BooleanAccess > ArrayImg< NativeBoolType, A > booleans( final A access, final long... dim )
+	{
+		final ArrayImg< NativeBoolType, A > img = new ArrayImg<>( access, dim, new Fraction() );
+		final NativeBoolType t = new NativeBoolType( img );
+		img.setLinkedType( t );
+		return img;
+	}
+
+	/**
 	 * Create an {@link ArrayImg}&lt;{@link BitType}, {@link LongArray}&gt;.
 	 */
 	@SuppressWarnings( "unchecked" )
 	final static public ArrayImg< BitType, LongArray > bits( final long... dim )
 	{
 		return ( ArrayImg< BitType, LongArray > ) new ArrayImgFactory<>( new BitType() ).create( dim );
+	}
+
+	/**
+	 * Creates an {@link ArrayImg}&lt;{@link NativeBoolType}, {@link LongAccess}&gt;
+	 * using a {@link LongAccess} passed as argument.
+	 */
+	final static public < A extends BooleanAccess > ArrayImg< NativeBoolType, A > bits( final A access, final long... dim )
+	{
+		final ArrayImg< NativeBoolType, A > img = new ArrayImg<>( access, dim, new Fraction( 1, 64 ) );
+		final NativeBoolType t = new NativeBoolType( img );
+		img.setLinkedType( t );
+		return img;
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/basictypeaccess/ArrayDataAccessFactory.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/ArrayDataAccessFactory.java
@@ -39,8 +39,10 @@ import static net.imglib2.img.basictypeaccess.AccessFlags.VOLATILE;
 import java.util.Set;
 
 import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.CharArray;
+import net.imglib2.img.basictypeaccess.array.DirtyBooleanArray;
 import net.imglib2.img.basictypeaccess.array.DirtyByteArray;
 import net.imglib2.img.basictypeaccess.array.DirtyCharArray;
 import net.imglib2.img.basictypeaccess.array.DirtyDoubleArray;
@@ -53,6 +55,7 @@ import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.img.basictypeaccess.array.IntArray;
 import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileBooleanArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileCharArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileDoubleArray;
@@ -60,6 +63,7 @@ import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileFloatArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileIntArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileLongArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileShortArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileBooleanArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.VolatileByteArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.VolatileCharArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.VolatileDoubleArray;
@@ -115,6 +119,14 @@ public class ArrayDataAccessFactory
 		final boolean volatil = flags.contains( VOLATILE );
 		switch ( primitiveType )
 		{
+		case BOOLEAN:
+			return dirty
+					? ( volatil
+							? ( A ) new DirtyVolatileBooleanArray( 0, true )
+							: ( A ) new DirtyBooleanArray( 0 ) )
+					: ( volatil
+							? ( A ) new VolatileBooleanArray( 0, true )
+							: ( A ) new BooleanArray( 0 ) );
 		case BYTE:
 			return dirty
 					? ( volatil

--- a/src/main/java/net/imglib2/img/basictypeaccess/BooleanAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/BooleanAccess.java
@@ -1,4 +1,4 @@
-/*-
+/*
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
@@ -31,46 +31,17 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.type;
 
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
-import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+package net.imglib2.img.basictypeaccess;
 
 /**
- * Enumeration of Java primitive types which can back {@link NativeType}s.
- * <p>
- * In conjunction with {@link AccessFlags} this describes a specific
- * {@link ArrayDataAccess}. For example, {@code BYTE} with flags {@code DIRTY}
- * and {@code VOLATILE} specifies {@link DirtyVolatileByteArray}.
- * </p>
- *
- * @author Tobias Pietzsch
+ * TODO
+ * 
  * @author Curtis Rueden
  */
-public enum PrimitiveType
+public interface BooleanAccess
 {
-	// NB: In theory, the number of bytes for boolean is implementation
-	// dependent; in practice, it is 1 for popular JVM implementations.
-	BOOLEAN( 1 ),
-	BYTE( Byte.BYTES ),
-	CHAR( Character.BYTES ),
-	SHORT( Short.BYTES ),
-	INT( Integer.BYTES ),
-	LONG( Long.BYTES ),
-	FLOAT( Float.BYTES ),
-	DOUBLE( Double.BYTES ),
-	UNDEFINED( -1 );
+	public boolean getValue( final int index );
 
-	private final int byteCount;
-
-	private PrimitiveType( final int byteCount )
-	{
-		this.byteCount = byteCount;
-	}
-
-	int getByteCount()
-	{
-		return byteCount;
-	}
+	public void setValue( final int index, final boolean value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractBooleanArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractBooleanArray.java
@@ -1,4 +1,4 @@
-/*-
+/*
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
@@ -31,46 +31,49 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.type;
 
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
-import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+package net.imglib2.img.basictypeaccess.array;
+
+import net.imglib2.img.basictypeaccess.BooleanAccess;
 
 /**
- * Enumeration of Java primitive types which can back {@link NativeType}s.
- * <p>
- * In conjunction with {@link AccessFlags} this describes a specific
- * {@link ArrayDataAccess}. For example, {@code BYTE} with flags {@code DIRTY}
- * and {@code VOLATILE} specifies {@link DirtyVolatileByteArray}.
- * </p>
  *
- * @author Tobias Pietzsch
  * @author Curtis Rueden
  */
-public enum PrimitiveType
+public abstract class AbstractBooleanArray< A extends AbstractBooleanArray< A > > implements BooleanAccess, ArrayDataAccess< A >
 {
-	// NB: In theory, the number of bytes for boolean is implementation
-	// dependent; in practice, it is 1 for popular JVM implementations.
-	BOOLEAN( 1 ),
-	BYTE( Byte.BYTES ),
-	CHAR( Character.BYTES ),
-	SHORT( Short.BYTES ),
-	INT( Integer.BYTES ),
-	LONG( Long.BYTES ),
-	FLOAT( Float.BYTES ),
-	DOUBLE( Double.BYTES ),
-	UNDEFINED( -1 );
+	protected boolean[] data;
 
-	private final int byteCount;
-
-	private PrimitiveType( final int byteCount )
+	public AbstractBooleanArray( final int numEntities )
 	{
-		this.byteCount = byteCount;
+		this.data = new boolean[ numEntities ];
 	}
 
-	int getByteCount()
+	public AbstractBooleanArray( final boolean[] data )
 	{
-		return byteCount;
+		this.data = data;
+	}
+
+	@Override
+	public boolean getValue( final int index )
+	{
+		return data[ index ];
+	}
+
+	@Override
+	public void setValue( final int index, final boolean value )
+	{
+		data[ index ] = value;
+	}
+
+	@Override
+	public boolean[] getCurrentStorageArray()
+	{
+		return data;
+	}
+
+	@Override
+	public int getArrayLength() {
+		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/BooleanArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/BooleanArray.java
@@ -1,4 +1,4 @@
-/*-
+/*
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
@@ -31,46 +31,28 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.type;
 
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
-import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+package net.imglib2.img.basictypeaccess.array;
 
 /**
- * Enumeration of Java primitive types which can back {@link NativeType}s.
- * <p>
- * In conjunction with {@link AccessFlags} this describes a specific
- * {@link ArrayDataAccess}. For example, {@code BYTE} with flags {@code DIRTY}
- * and {@code VOLATILE} specifies {@link DirtyVolatileByteArray}.
- * </p>
  *
- * @author Tobias Pietzsch
  * @author Curtis Rueden
  */
-public enum PrimitiveType
+public class BooleanArray extends AbstractBooleanArray< BooleanArray >
 {
-	// NB: In theory, the number of bytes for boolean is implementation
-	// dependent; in practice, it is 1 for popular JVM implementations.
-	BOOLEAN( 1 ),
-	BYTE( Byte.BYTES ),
-	CHAR( Character.BYTES ),
-	SHORT( Short.BYTES ),
-	INT( Integer.BYTES ),
-	LONG( Long.BYTES ),
-	FLOAT( Float.BYTES ),
-	DOUBLE( Double.BYTES ),
-	UNDEFINED( -1 );
-
-	private final int byteCount;
-
-	private PrimitiveType( final int byteCount )
+	public BooleanArray( final int numEntities )
 	{
-		this.byteCount = byteCount;
+		super( numEntities );
 	}
 
-	int getByteCount()
+	public BooleanArray( final boolean[] data )
 	{
-		return byteCount;
+		super( data );
+	}
+
+	@Override
+	public BooleanArray createArray( final int numEntities )
+	{
+		return new BooleanArray( numEntities );
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/DirtyBooleanArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/DirtyBooleanArray.java
@@ -1,4 +1,4 @@
-/*-
+/*
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
@@ -31,46 +31,51 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.type;
 
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
-import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+package net.imglib2.img.basictypeaccess.array;
+
+import net.imglib2.Dirty;
 
 /**
- * Enumeration of Java primitive types which can back {@link NativeType}s.
- * <p>
- * In conjunction with {@link AccessFlags} this describes a specific
- * {@link ArrayDataAccess}. For example, {@code BYTE} with flags {@code DIRTY}
- * and {@code VOLATILE} specifies {@link DirtyVolatileByteArray}.
- * </p>
  *
- * @author Tobias Pietzsch
  * @author Curtis Rueden
  */
-public enum PrimitiveType
+public class DirtyBooleanArray extends AbstractBooleanArray< DirtyBooleanArray > implements Dirty
 {
-	// NB: In theory, the number of bytes for boolean is implementation
-	// dependent; in practice, it is 1 for popular JVM implementations.
-	BOOLEAN( 1 ),
-	BYTE( Byte.BYTES ),
-	CHAR( Character.BYTES ),
-	SHORT( Short.BYTES ),
-	INT( Integer.BYTES ),
-	LONG( Long.BYTES ),
-	FLOAT( Float.BYTES ),
-	DOUBLE( Double.BYTES ),
-	UNDEFINED( -1 );
+	protected boolean dirty = false;
 
-	private final int byteCount;
-
-	private PrimitiveType( final int byteCount )
+	public DirtyBooleanArray( final int numEntities )
 	{
-		this.byteCount = byteCount;
+		super( numEntities );
 	}
 
-	int getByteCount()
+	public DirtyBooleanArray( final boolean[] data )
 	{
-		return byteCount;
+		super( data );
+	}
+
+	@Override
+	public void setValue( final int index, final boolean value )
+	{
+		dirty = true;
+		data[ index ] = value;
+	}
+
+	@Override
+	public DirtyBooleanArray createArray( final int numEntities )
+	{
+		return new DirtyBooleanArray( numEntities );
+	}
+
+	@Override
+	public boolean isDirty()
+	{
+		return dirty;
+	}
+
+	@Override
+	public void setDirty()
+	{
+		dirty = true;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileBooleanAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileBooleanAccess.java
@@ -1,4 +1,4 @@
-/*-
+/*
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
@@ -31,46 +31,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.type;
+package net.imglib2.img.basictypeaccess.volatiles;
 
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
-import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+import net.imglib2.img.basictypeaccess.BooleanAccess;
+
 
 /**
- * Enumeration of Java primitive types which can back {@link NativeType}s.
- * <p>
- * In conjunction with {@link AccessFlags} this describes a specific
- * {@link ArrayDataAccess}. For example, {@code BYTE} with flags {@code DIRTY}
- * and {@code VOLATILE} specifies {@link DirtyVolatileByteArray}.
- * </p>
- *
- * @author Tobias Pietzsch
  * @author Curtis Rueden
  */
-public enum PrimitiveType
-{
-	// NB: In theory, the number of bytes for boolean is implementation
-	// dependent; in practice, it is 1 for popular JVM implementations.
-	BOOLEAN( 1 ),
-	BYTE( Byte.BYTES ),
-	CHAR( Character.BYTES ),
-	SHORT( Short.BYTES ),
-	INT( Integer.BYTES ),
-	LONG( Long.BYTES ),
-	FLOAT( Float.BYTES ),
-	DOUBLE( Double.BYTES ),
-	UNDEFINED( -1 );
-
-	private final int byteCount;
-
-	private PrimitiveType( final int byteCount )
-	{
-		this.byteCount = byteCount;
-	}
-
-	int getByteCount()
-	{
-		return byteCount;
-	}
-}
+public interface VolatileBooleanAccess extends BooleanAccess, VolatileAccess
+{}

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/array/AbstractVolatileBooleanArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/array/AbstractVolatileBooleanArray.java
@@ -31,46 +31,41 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.type;
+package net.imglib2.img.basictypeaccess.volatiles.array;
 
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
-import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+import net.imglib2.img.basictypeaccess.array.AbstractBooleanArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileArrayDataAccess;
 
 /**
- * Enumeration of Java primitive types which can back {@link NativeType}s.
- * <p>
- * In conjunction with {@link AccessFlags} this describes a specific
- * {@link ArrayDataAccess}. For example, {@code BYTE} with flags {@code DIRTY}
- * and {@code VOLATILE} specifies {@link DirtyVolatileByteArray}.
- * </p>
- *
- * @author Tobias Pietzsch
  * @author Curtis Rueden
  */
-public enum PrimitiveType
+public abstract class AbstractVolatileBooleanArray< A extends AbstractVolatileBooleanArray< A > >
+		extends AbstractBooleanArray< A >
+		implements VolatileArrayDataAccess< A >
 {
-	// NB: In theory, the number of bytes for boolean is implementation
-	// dependent; in practice, it is 1 for popular JVM implementations.
-	BOOLEAN( 1 ),
-	BYTE( Byte.BYTES ),
-	CHAR( Character.BYTES ),
-	SHORT( Short.BYTES ),
-	INT( Integer.BYTES ),
-	LONG( Long.BYTES ),
-	FLOAT( Float.BYTES ),
-	DOUBLE( Double.BYTES ),
-	UNDEFINED( -1 );
+	final protected boolean isValid;
 
-	private final int byteCount;
-
-	private PrimitiveType( final int byteCount )
+	public AbstractVolatileBooleanArray( final int numEntities, final boolean isValid )
 	{
-		this.byteCount = byteCount;
+		super( numEntities );
+		this.isValid = isValid;
 	}
 
-	int getByteCount()
+	public AbstractVolatileBooleanArray( final boolean[] data, final boolean isValid )
 	{
-		return byteCount;
+		super( data );
+		this.isValid = isValid;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return isValid;
+	}
+
+	@Override
+	public A createArray( final int numEntities )
+	{
+		return createArray( numEntities, true );
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/array/DirtyVolatileBooleanArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/array/DirtyVolatileBooleanArray.java
@@ -1,4 +1,4 @@
-/*-
+/*
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
@@ -31,46 +31,54 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.type;
+package net.imglib2.img.basictypeaccess.volatiles.array;
 
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
-import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+import net.imglib2.Dirty;
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
 
 /**
- * Enumeration of Java primitive types which can back {@link NativeType}s.
- * <p>
- * In conjunction with {@link AccessFlags} this describes a specific
- * {@link ArrayDataAccess}. For example, {@code BYTE} with flags {@code DIRTY}
- * and {@code VOLATILE} specifies {@link DirtyVolatileByteArray}.
- * </p>
+ * A {@link BooleanArray} with an {@link #isDirty()} and an {@link #isValid()}
+ * flag.
  *
- * @author Tobias Pietzsch
  * @author Curtis Rueden
  */
-public enum PrimitiveType
+public class DirtyVolatileBooleanArray extends AbstractVolatileBooleanArray< DirtyVolatileBooleanArray > implements VolatileBooleanAccess, Dirty
 {
-	// NB: In theory, the number of bytes for boolean is implementation
-	// dependent; in practice, it is 1 for popular JVM implementations.
-	BOOLEAN( 1 ),
-	BYTE( Byte.BYTES ),
-	CHAR( Character.BYTES ),
-	SHORT( Short.BYTES ),
-	INT( Integer.BYTES ),
-	LONG( Long.BYTES ),
-	FLOAT( Float.BYTES ),
-	DOUBLE( Double.BYTES ),
-	UNDEFINED( -1 );
+	protected boolean dirty = false;
 
-	private final int byteCount;
-
-	private PrimitiveType( final int byteCount )
+	public DirtyVolatileBooleanArray( final int numEntities, final boolean isValid )
 	{
-		this.byteCount = byteCount;
+		super( numEntities, isValid );
 	}
 
-	int getByteCount()
+	public DirtyVolatileBooleanArray( final boolean[] data, final boolean isValid )
 	{
-		return byteCount;
+		super( data, isValid );
+	}
+
+	@Override
+	public void setValue( final int index, final boolean value )
+	{
+		dirty = true;
+		data[ index ] = value;
+	}
+
+	@Override
+	public DirtyVolatileBooleanArray createArray( final int numEntities, final boolean isValid )
+	{
+		return new DirtyVolatileBooleanArray( numEntities, isValid );
+	}
+
+	@Override
+	public boolean isDirty()
+	{
+		return dirty;
+	}
+
+	@Override
+	public void setDirty()
+	{
+		dirty = true;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/array/VolatileBooleanArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/array/VolatileBooleanArray.java
@@ -1,4 +1,4 @@
-/*-
+/*
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
@@ -31,46 +31,31 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package net.imglib2.type;
+package net.imglib2.img.basictypeaccess.volatiles.array;
 
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
-import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
 
 /**
- * Enumeration of Java primitive types which can back {@link NativeType}s.
- * <p>
- * In conjunction with {@link AccessFlags} this describes a specific
- * {@link ArrayDataAccess}. For example, {@code BYTE} with flags {@code DIRTY}
- * and {@code VOLATILE} specifies {@link DirtyVolatileByteArray}.
- * </p>
+ * A {@link BooleanArray} with an {@link #isValid()} flag.
  *
- * @author Tobias Pietzsch
  * @author Curtis Rueden
  */
-public enum PrimitiveType
+public class VolatileBooleanArray extends AbstractVolatileBooleanArray< VolatileBooleanArray > implements VolatileBooleanAccess
 {
-	// NB: In theory, the number of bytes for boolean is implementation
-	// dependent; in practice, it is 1 for popular JVM implementations.
-	BOOLEAN( 1 ),
-	BYTE( Byte.BYTES ),
-	CHAR( Character.BYTES ),
-	SHORT( Short.BYTES ),
-	INT( Integer.BYTES ),
-	LONG( Long.BYTES ),
-	FLOAT( Float.BYTES ),
-	DOUBLE( Double.BYTES ),
-	UNDEFINED( -1 );
-
-	private final int byteCount;
-
-	private PrimitiveType( final int byteCount )
+	public VolatileBooleanArray( final int numEntities, final boolean isValid )
 	{
-		this.byteCount = byteCount;
+		super( numEntities, isValid );
 	}
 
-	int getByteCount()
+	public VolatileBooleanArray( final boolean[] data, final boolean isValid )
 	{
-		return byteCount;
+		super( data, isValid );
+	}
+
+	@Override
+	public VolatileBooleanArray createArray( final int numEntities, final boolean isValid )
+	{
+		return new VolatileBooleanArray( numEntities, isValid );
 	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarImgs.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImgs.java
@@ -34,6 +34,7 @@
 
 package net.imglib2.img.planar;
 
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
@@ -42,6 +43,7 @@ import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.type.Type;
 import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.NativeBoolType;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.complex.ComplexDoubleType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
@@ -137,6 +139,15 @@ final public class PlanarImgs
 	final static public PlanarImg< LongType, LongArray > longs( final long... dim )
 	{
 		return ( PlanarImg< LongType, LongArray > ) new PlanarImgFactory<>( new LongType() ).create( dim );
+	}
+
+	/**
+	 * Create an {@link PlanarImg}&lt;{@link NativeBoolType}, {@link BooleanArray}&gt;.
+	 */
+	@SuppressWarnings( "unchecked" )
+	final static public PlanarImg< NativeBoolType, BooleanArray > booleans( final long... dim )
+	{
+		return ( PlanarImg< NativeBoolType, BooleanArray > ) new PlanarImgFactory<>( new NativeBoolType() ).create( dim );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/type/NativeTypeFactory.java
+++ b/src/main/java/net/imglib2/type/NativeTypeFactory.java
@@ -36,6 +36,7 @@ package net.imglib2.type;
 import java.util.function.Function;
 
 import net.imglib2.img.NativeImg;
+import net.imglib2.img.basictypeaccess.BooleanAccess;
 import net.imglib2.img.basictypeaccess.ByteAccess;
 import net.imglib2.img.basictypeaccess.CharAccess;
 import net.imglib2.img.basictypeaccess.DoubleAccess;
@@ -109,6 +110,11 @@ public final class NativeTypeFactory< T extends NativeType< T >, A >
 	public T createLinkedType( final NativeImg< T, ? extends A > img )
 	{
 		return createLinkedType.apply( img );
+	}
+
+	public static < T extends NativeType< T >, A extends BooleanAccess > NativeTypeFactory< T, A > BOOLEAN( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	{
+		return new NativeTypeFactory<>( PrimitiveType.BOOLEAN, createLinkedType );
 	}
 
 	public static < T extends NativeType< T >, A extends ByteAccess > NativeTypeFactory< T, A > BYTE( final Function< NativeImg< T, ? extends A >, T > createLinkedType )

--- a/src/main/java/net/imglib2/type/logic/NativeBoolType.java
+++ b/src/main/java/net/imglib2/type/logic/NativeBoolType.java
@@ -1,0 +1,350 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.type.logic;
+
+import java.math.BigInteger;
+
+import net.imglib2.img.NativeImg;
+import net.imglib2.img.basictypeaccess.BooleanAccess;
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.NativeTypeFactory;
+import net.imglib2.type.numeric.integer.AbstractIntegerType;
+import net.imglib2.util.Fraction;
+
+/**
+ * {@link NativeType} backed by {@code boolean}.
+ *
+ * @author Curtis Rueden
+ */
+public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implements BooleanType< NativeBoolType >, NativeType< NativeBoolType >
+{
+	int i = 0;
+
+	final protected NativeImg< ?, ? extends BooleanAccess > img;
+
+	// the DataAccess that holds the information
+	protected BooleanAccess dataAccess;
+
+	// this is the constructor if you want it to read from an array
+	public NativeBoolType( final NativeImg< ?, ? extends BooleanAccess > boolStorage )
+	{
+		img = boolStorage;
+	}
+
+	// this is the constructor if you want it to be a variable
+	public NativeBoolType( final boolean value )
+	{
+		img = null;
+		dataAccess = new BooleanArray( 1 );
+		set( value );
+	}
+
+	// this is the constructor if you want to specify the dataAccess
+	public NativeBoolType( final BooleanAccess access )
+	{
+		img = null;
+		dataAccess = access;
+	}
+
+	// this is the constructor if you want it to be a variable
+	public NativeBoolType()
+	{
+		this( false );
+	}
+
+	private final NativeTypeFactory< NativeBoolType, BooleanAccess > typeFactory = NativeTypeFactory.BOOLEAN( img -> new NativeBoolType( img ) );
+
+	@Override
+	public NativeTypeFactory< NativeBoolType, BooleanAccess > getNativeTypeFactory()
+	{
+		return typeFactory;
+	}
+
+	@Override
+	public NativeBoolType duplicateTypeOnSameNativeImg()
+	{
+		return new NativeBoolType( img );
+	}
+
+	@Override
+	public Fraction getEntitiesPerPixel()
+	{
+		return new Fraction();
+	}
+
+	@Override
+	public void updateContainer( final Object c )
+	{
+		dataAccess = img.update( c );
+	}
+
+	/**
+	 * Returns the primitive boolean value that is used to store this type.
+	 *
+	 * @return primitive boolean value
+	 */
+	@Override
+	public boolean get()
+	{
+		return dataAccess.getValue( i );
+	}
+
+	/**
+	 * Sets the primitive boolean value that is used to store this type.
+	 */
+	@Override
+	public void set( final boolean f )
+	{
+		dataAccess.setValue( i, f );
+	}
+
+	@Override
+	public void set( final NativeBoolType c ) { set( c.get() ); }
+
+	@Override
+	public void and( final NativeBoolType c ) { set( get() && c.get() ); }
+
+	@Override
+	public void or( final NativeBoolType c ) { set( get() || c.get() ); }
+
+	@Override
+	public void xor( final NativeBoolType c ) { set( get() ^ c.get() ); }
+
+	@Override
+	public void not() { set( !get() ); }
+
+	@Override
+	public void add( final NativeBoolType c )
+	{
+		xor( c );
+	}
+
+	@Override
+	public void div( final NativeBoolType c )
+	{
+		and( c );
+	}
+
+	@Override
+	public void mul( final NativeBoolType c )
+	{
+		and( c );
+	}
+
+	@Override
+	public void sub( final NativeBoolType c )
+	{
+		xor( c );
+	}
+
+	@Override
+	public void mul( final float c )
+	{
+		if ( c >= 0.5f )
+			set( get() && true );
+		else
+			set( false );
+	}
+
+	@Override
+	public void mul( final double c )
+	{
+		if ( c >= 0.5f )
+			set( get() && true );
+		else
+			set( false );
+	}
+
+	@Override
+	public void setOne() { set( true ); }
+
+	@Override
+	public void setZero() { set( false ); }
+
+	@Override
+	public void inc() { not(); }
+
+	@Override
+	public void dec() { not(); }
+
+
+	@Override
+	public String toString()
+	{
+		return "" + get();
+	}
+
+	@Override
+	public void updateIndex( final int index )
+	{
+		i = index;
+	}
+
+	@Override
+	public int getIndex()
+	{
+		return i;
+	}
+
+	@Override
+	public void incIndex()
+	{
+		++i;
+	}
+
+	@Override
+	public void incIndex( final int increment )
+	{
+		i += increment;
+	}
+
+	@Override
+	public void decIndex()
+	{
+		--i;
+	}
+
+	@Override
+	public void decIndex( final int decrement )
+	{
+		i -= decrement;
+	}
+
+	@Override
+	public int getBitsPerPixel()
+	{
+		// NB: The Java Language Specification does not mandate how many
+		// bytes each boolean occupies. But in practice, VMs appear to use
+		// 8 bits per array element, as evidenced by the following code:
+		//
+		//   boolean[] b = new boolean[1024 * 1024 * 1024];
+		//   System.gc();
+		//   long total = Runtime.getRuntime().totalMemory();
+		//   long free = Runtime.getRuntime().freeMemory();
+		//   long bits = 8 * (total - free) / b.length;
+		//   System.out.println("boolean bits = " + bits);
+		//
+		return 8;
+	}
+
+	@Override
+	public boolean valueEquals( final NativeBoolType t )
+	{
+		return get() == t.get();
+	}
+
+	@Override
+	public int hashCode()
+	{
+		// NB: Use the same hash code as java.lang.Boolean#hashCode().
+		return Boolean.hashCode( get() );
+	}
+
+	@Override
+	public int compareTo( final NativeBoolType c )
+	{
+		final boolean b1 = get();
+		final boolean b2 = c.get();
+
+		if ( b1 && !b2 )
+			return 1;
+		if ( !b1 && b2 )
+			return -1;
+		return 0;
+	}
+
+	@Override
+	public NativeBoolType createVariable()
+	{
+		return new NativeBoolType();
+	}
+
+	@Override
+	public NativeBoolType copy()
+	{
+		return new NativeBoolType( get() );
+	}
+
+	@Override
+	public double getMaxValue()
+	{
+		return 1;
+	}
+
+	@Override
+	public double getMinValue()
+	{
+		return 0;
+	}
+
+	@Override
+	public int getInteger()
+	{
+		return get() ? 1 : 0;
+	}
+
+	@Override
+	public long getIntegerLong()
+	{
+		return get() ? 1 : 0;
+	}
+
+	@Override
+	public BigInteger getBigInteger()
+	{
+		return get() ? BigInteger.ONE : BigInteger.ZERO;
+	}
+
+	@Override
+	public void setInteger( int f )
+	{
+		set( f > 0 );
+	}
+
+	@Override
+	public void setInteger( long f )
+	{
+		set( f > 0 );
+	}
+
+	@Override
+	public void setBigInteger( BigInteger b )
+	{
+		set( b.compareTo( BigInteger.ZERO ) > 0 );
+	}
+
+}

--- a/src/test/java/net/imglib2/type/logic/NativeBoolTypeTest.java
+++ b/src/test/java/net/imglib2/type/logic/NativeBoolTypeTest.java
@@ -1,0 +1,138 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+/**
+ * 
+ */
+package net.imglib2.type.logic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests {@link NativeBoolType}.
+ * 
+ * @author Curtis Rueden
+ */
+public class NativeBoolTypeTest {
+
+	static ArrayImg< NativeBoolType, BooleanArray > img;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception
+	{
+		img = ArrayImgs.booleans( 10, 20, 30 );
+	}
+
+	/**
+	 * Test method for {@link net.imglib2.type.logic.NativeBoolType#setOne()}.
+	 */
+	@Test
+	public void testSetOne()
+	{
+		for ( final NativeBoolType t : img )
+			t.setOne();
+		for ( final NativeBoolType t : img )
+			assertTrue( t.get() );
+	}
+
+	/**
+	 * Test method for {@link net.imglib2.type.logic.NativeBoolType#setZero()}.
+	 */
+	@Test
+	public void testSetZero()
+	{
+		for ( final NativeBoolType t : img )
+			t.setZero();
+		for ( final NativeBoolType t : img )
+			assertTrue( !t.get() );
+	}
+
+	/**
+	 * Test method for {@link net.imglib2.type.logic.NativeBoolType#setOne()}.
+	 */
+	@Test
+	public void testSetOneAndZero()
+	{
+		final Random rnd = new Random( 0 );
+
+		for ( final NativeBoolType t : img )
+		{
+			final boolean b = rnd.nextBoolean();
+			t.set( b );
+			assertTrue( t.get() == b );
+		}
+	}
+
+	/**
+	 * Tests that {@link NativeBoolType#getBigInteger()} returns the BigInteger
+	 * representation of a NativeBoolType.
+	 */
+	@Test
+	public void testGetBigInteger()
+	{
+		final NativeBoolType l = new NativeBoolType( false );
+
+		assertEquals( BigInteger.ZERO, l.getBigInteger() );
+	}
+
+	/**
+	 * Tests {@link NativeBoolType#setBigInteger(BigInteger)} and ensures that
+	 * the value returned is within NativeBoolType range.
+	 */
+	@Test
+	public void testSetBigInteger()
+	{
+		final NativeBoolType ul = new NativeBoolType( false );
+
+		assertEquals( ul.get(), false );
+
+		final BigInteger bi = new BigInteger( "AAAAAA3141343BBBBBBBBBBB4134", 16 );
+		ul.setBigInteger( bi );
+
+		assertEquals( ul.get(), true );
+	}
+}


### PR DESCRIPTION
Previously, one could extend the type system to have a `NativeBoolType` (plus `BoolAccess` and `BoolArray`) externally, and use it with `ArrayImg` and/or `PlanarImg`. However, as of ImgLib2 v5, the `NativeTypeFactory` was locked down tightly, as a final class with only a private constructor. Hence, creating a `NativeTypeFactory` that produced `NativeBoolType` instances became impossible.

This branch addresses the issue by introducing the needed classes to work with `boolean` arrays in the same way as other primitive arrays.

For an example of where this is used, see https://github.com/ctrueden/game-of-life.