### PR TITLE
Add methods to test equality of (Real)Localizables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>imglib2</artifactId>
-	<version>5.3.1-SNAPSHOT</version>
+	<version>5.4.0-SNAPSHOT</version>
 
 	<name>ImgLib2 Core Library</name>
 	<description>A multidimensional, type-agnostic image processing library.</description>

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -55,7 +55,8 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
 
 /**
- * TODO
+ * A collection of general-purpose utility methods for working with ImgLib2 data
+ * structures.
  * 
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -39,6 +39,7 @@ import java.util.List;
 import net.imglib2.Dimensions;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
+import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
@@ -60,6 +61,7 @@ import net.imglib2.type.Type;
  * 
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
+ * @author Curtis Rueden
  */
 public class Util
 {
@@ -891,6 +893,63 @@ public class Util
 				return false;
 		}
 
+		return true;
+	}
+
+	/**
+	 * Determines whether the two {@link Localizable} objects have the same
+	 * position, with {@code long} precision.
+	 * <p>
+	 * At first glance, this method may appear to be unnecessary, since there is
+	 * also {@link #locationsEqual(RealLocalizable, RealLocalizable)}, which is
+	 * more general. The difference is that this method compares the positions
+	 * using {@link Localizable#getLongPosition(int)}, which has higher
+	 * precision in integer space than
+	 * {@link RealLocalizable#getDoublePosition(int)} does, which is what the
+	 * {@link #locationsEqual(RealLocalizable, RealLocalizable)} method uses.
+	 * </p>
+	 * 
+	 * @param l1
+	 *            The first {@link Localizable}.
+	 * @param l2
+	 *            The second {@link Localizable}.
+	 * @return True iff the positions are the same, including dimensionality.
+	 * @see Localizable#getLongPosition(int)
+	 */
+	public static boolean locationsEqual( final Localizable l1, final Localizable l2 )
+	{
+		final int numDims = l1.numDimensions();
+		if ( l2.numDimensions() != numDims )
+			return false;
+		for ( int d = 0; d < numDims; d++ )
+		{
+			if ( l1.getLongPosition( d ) != l2.getLongPosition( d ) )
+				return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Determines whether the two {@link RealLocalizable} objects have the same
+	 * position, with {@code double} precision.
+	 * 
+	 * @param l1
+	 *            The first {@link RealLocalizable}.
+	 * @param l2
+	 *            The second {@link RealLocalizable}.
+	 * @return True iff the positions are the same, including dimensionality.
+	 * @see RealLocalizable#getDoublePosition(int)
+	 */
+	public static boolean locationsEqual( final RealLocalizable l1, final RealLocalizable l2 )
+	{
+		final int numDims = l1.numDimensions();
+		if ( l2.numDimensions() != numDims )
+			return false;
+		for ( int d = 0; d < numDims; d++ )
+		{
+			if ( l1.getDoublePosition( d ) != l2.getDoublePosition( d ) )
+				return false;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
The equals method of individual Localizable and RealLocalizable implementations may impose different or additional requirements beyond merely equality of position. These utility methods offer a consistent way to verify that two such objects have the same position. They will be used in imglib2-roi; see imglib/imglib2-roi#35.