### PR TITLE
Add copy helper methods for accesses

### DIFF
--- a/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
@@ -1,0 +1,136 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.basictypeaccess;
+
+/**
+ * Utility and helper methods for accesses ({@link ByteAccess} etc).
+ *
+ * @author Philipp Hanslovsky
+ */
+public interface Accesses
+{
+
+	public static void copy( final ByteAccess source, final ByteAccess target, final int size )
+	{
+		copy( source, target, 0, size );
+	}
+
+	public static void copy( final ByteAccess source, final ByteAccess target, final int start, final int stop )
+	{
+		for ( int index = start; index < stop; ++index )
+		{
+			target.setValue( index, source.getValue( index ) );
+		}
+	}
+
+	public static void copy( final CharAccess source, final CharAccess target, final int size )
+	{
+		copy( source, target, 0, size );
+	}
+
+	public static void copy( final CharAccess source, final CharAccess target, final int start, final int stop )
+	{
+		for ( int index = start; index < stop; ++index )
+		{
+			target.setValue( index, source.getValue( index ) );
+		}
+	}
+
+	public static void copy( final DoubleAccess source, final DoubleAccess target, final int size )
+	{
+		copy( source, target, 0, size );
+	}
+
+	public static void copy( final DoubleAccess source, final DoubleAccess target, final int start, final int stop )
+	{
+		for ( int index = start; index < stop; ++index )
+		{
+			target.setValue( index, source.getValue( index ) );
+		}
+	}
+
+	public static void copy( final FloatAccess source, final FloatAccess target, final int size )
+	{
+		copy( source, target, 0, size );
+	}
+
+	public static void copy( final FloatAccess source, final FloatAccess target, final int start, final int stop )
+	{
+		for ( int index = start; index < stop; ++index )
+		{
+			target.setValue( index, source.getValue( index ) );
+		}
+	}
+
+	public static void copy( final IntAccess source, final IntAccess target, final int size )
+	{
+		copy( source, target, 0, size );
+	}
+
+	public static void copy( final IntAccess source, final IntAccess target, final int start, final int stop )
+	{
+		for ( int index = start; index < stop; ++index )
+		{
+			target.setValue( index, source.getValue( index ) );
+		}
+	}
+
+	public static void copy( final LongAccess source, final LongAccess target, final int size )
+	{
+		copy( source, target, 0, size );
+	}
+
+	public static void copy( final LongAccess source, final LongAccess target, final int start, final int stop )
+	{
+		for ( int index = start; index < stop; ++index )
+		{
+			target.setValue( index, source.getValue( index ) );
+		}
+	}
+
+	public static void copy( final ShortAccess source, final ShortAccess target, final int size )
+	{
+		copy( source, target, 0, size );
+	}
+
+	public static void copy( final ShortAccess source, final ShortAccess target, final int start, final int stop )
+	{
+		for ( int index = start; index < stop; ++index )
+		{
+			target.setValue( index, source.getValue( index ) );
+		}
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
@@ -42,94 +42,409 @@ package net.imglib2.img.basictypeaccess;
 public interface Accesses
 {
 
-	public static void copy( final ByteAccess source, final ByteAccess target, final int size )
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final ByteAccess src,
+			final int srcPos,
+			final ByteAccess dest,
+			final int destPos,
+			final int length )
 	{
-		copy( source, target, 0, size );
-	}
 
-	public static void copy( final ByteAccess source, final ByteAccess target, final int start, final int stop )
-	{
-		for ( int index = start; index < stop; ++index )
+		if ( src == dest )
 		{
-			target.setValue( index, source.getValue( index ) );
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 		}
 	}
 
-	public static void copy( final CharAccess source, final CharAccess target, final int size )
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final CharAccess src,
+			final int srcPos,
+			final CharAccess dest,
+			final int destPos,
+			final int length )
 	{
-		copy( source, target, 0, size );
-	}
 
-	public static void copy( final CharAccess source, final CharAccess target, final int start, final int stop )
-	{
-		for ( int index = start; index < stop; ++index )
+		if ( src == dest )
 		{
-			target.setValue( index, source.getValue( index ) );
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 		}
 	}
 
-	public static void copy( final DoubleAccess source, final DoubleAccess target, final int size )
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final DoubleAccess src,
+			final int srcPos,
+			final DoubleAccess dest,
+			final int destPos,
+			final int length )
 	{
-		copy( source, target, 0, size );
-	}
 
-	public static void copy( final DoubleAccess source, final DoubleAccess target, final int start, final int stop )
-	{
-		for ( int index = start; index < stop; ++index )
+		if ( src == dest )
 		{
-			target.setValue( index, source.getValue( index ) );
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 		}
 	}
 
-	public static void copy( final FloatAccess source, final FloatAccess target, final int size )
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final FloatAccess src,
+			final int srcPos,
+			final FloatAccess dest,
+			final int destPos,
+			final int length )
 	{
-		copy( source, target, 0, size );
-	}
 
-	public static void copy( final FloatAccess source, final FloatAccess target, final int start, final int stop )
-	{
-		for ( int index = start; index < stop; ++index )
+		if ( src == dest )
 		{
-			target.setValue( index, source.getValue( index ) );
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 		}
 	}
 
-	public static void copy( final IntAccess source, final IntAccess target, final int size )
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final IntAccess src,
+			final int srcPos,
+			final IntAccess dest,
+			final int destPos,
+			final int length )
 	{
-		copy( source, target, 0, size );
-	}
 
-	public static void copy( final IntAccess source, final IntAccess target, final int start, final int stop )
-	{
-		for ( int index = start; index < stop; ++index )
+		if ( src == dest )
 		{
-			target.setValue( index, source.getValue( index ) );
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 		}
 	}
 
-	public static void copy( final LongAccess source, final LongAccess target, final int size )
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final LongAccess src,
+			final int srcPos,
+			final LongAccess dest,
+			final int destPos,
+			final int length )
 	{
-		copy( source, target, 0, size );
-	}
 
-	public static void copy( final LongAccess source, final LongAccess target, final int start, final int stop )
-	{
-		for ( int index = start; index < stop; ++index )
+		if ( src == dest )
 		{
-			target.setValue( index, source.getValue( index ) );
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 		}
 	}
 
-	public static void copy( final ShortAccess source, final ShortAccess target, final int size )
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final ShortAccess src,
+			final int srcPos,
+			final ShortAccess dest,
+			final int destPos,
+			final int length )
 	{
-		copy( source, target, 0, size );
-	}
 
-	public static void copy( final ShortAccess source, final ShortAccess target, final int start, final int stop )
-	{
-		for ( int index = start; index < stop; ++index )
+		if ( src == dest )
 		{
-			target.setValue( index, source.getValue( index ) );
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 		}
 	}
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
@@ -52,6 +52,18 @@ import net.imglib2.type.numeric.real.FloatType;
 public class Accesses
 {
 
+	private static final Function< ByteAccess, ByteType> BYTE_FACTORY = ByteType::new;
+
+	private static final Function< ShortAccess, ShortType> SHORT_FACTORY =  ShortType::new;
+
+	private static final Function< IntAccess, IntType> INT_FACTORY =  IntType::new;
+
+	private static final Function< LongAccess, LongType> LONG_FACTORY =  LongType::new;
+
+	private static final Function< DoubleAccess, DoubleType> DOUBLE_FACTORY =  DoubleType::new;
+
+	private static final Function< FloatAccess, FloatType> FLOAT_FACTORY =  FloatType::new;
+
 	private Accesses() {}
 
 	/**
@@ -95,6 +107,12 @@ public class Accesses
 			final int length )
 	{
 		Function typeFactory = getTypeFactory( src );
+
+		if ( !typeFactory.equals( getTypeFactory( dest ) ) )
+			throw new IllegalArgumentException( "src and dest types are not compatible: "
+					+ src.getClass().getName() + " "
+					+ dest.getClass().getName() );
+
 		copy( src, srcPos, dest, destPos, length, typeFactory );
 	}
 
@@ -134,17 +152,17 @@ public class Accesses
 
 	private static < A > Function<A, ? extends NativeType< ? > > getTypeFactory( A a ) {
 		if ( a instanceof ByteAccess )
-			return ( Function< A, ByteType> ) access -> new ByteType( ( ByteAccess ) access );
+			return ( Function< A, ByteType> ) BYTE_FACTORY;
 		if ( a instanceof ShortAccess )
-			return ( Function< A, ShortType> ) access -> new ShortType( ( ShortAccess ) access );
+			return ( Function< A, ShortType> ) SHORT_FACTORY;
 		if ( a instanceof IntAccess )
-			return ( Function< A, IntType> ) access -> new IntType( ( IntAccess ) access );
+			return ( Function< A, IntType> ) INT_FACTORY;
 		if ( a instanceof LongAccess )
-			return ( Function< A, LongType> ) access -> new LongType( ( LongAccess ) access );
+			return ( Function< A, LongType> ) LONG_FACTORY;
 		if ( a instanceof DoubleAccess )
-			return ( Function< A, DoubleType> ) access -> new DoubleType( ( DoubleAccess ) access );
+			return ( Function< A, DoubleType> ) DOUBLE_FACTORY;
 		if ( a instanceof FloatAccess )
-			return( Function< A, FloatType> ) access -> new FloatType( ( FloatAccess ) access );
+			return( Function< A, FloatType> ) FLOAT_FACTORY;
 
 		throw new IllegalArgumentException( "Access is not supported: " + a.getClass().getName() );
 	}

--- a/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
@@ -39,9 +39,10 @@ package net.imglib2.img.basictypeaccess;
  *
  * @author Philipp Hanslovsky
  */
-public interface Accesses
+public class Accesses
 {
 
+	private Accesses() {}
 	/**
 	 *
 	 * Following {@link System#arraycopy}, copies {@code length} elements from

--- a/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
@@ -90,8 +90,8 @@ public interface Accesses
 				{
 					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 				}
+				return;
 			}
-			return;
 		}
 
 		for ( int index = 0; index < length; ++index )
@@ -148,8 +148,8 @@ public interface Accesses
 				{
 					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 				}
+				return;
 			}
-			return;
 		}
 
 		for ( int index = 0; index < length; ++index )
@@ -206,8 +206,8 @@ public interface Accesses
 				{
 					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 				}
+				return;
 			}
-			return;
 		}
 
 		for ( int index = 0; index < length; ++index )
@@ -264,8 +264,8 @@ public interface Accesses
 				{
 					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 				}
+				return;
 			}
-			return;
 		}
 
 		for ( int index = 0; index < length; ++index )
@@ -322,8 +322,8 @@ public interface Accesses
 				{
 					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 				}
+				return;
 			}
-			return;
 		}
 
 		for ( int index = 0; index < length; ++index )
@@ -380,8 +380,8 @@ public interface Accesses
 				{
 					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 				}
+				return;
 			}
-			return;
 		}
 
 		for ( int index = 0; index < length; ++index )
@@ -438,8 +438,8 @@ public interface Accesses
 				{
 					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
 				}
+				return;
 			}
-			return;
 		}
 
 		for ( int index = 0; index < length; ++index )

--- a/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
@@ -215,4 +215,158 @@ public class AccessesTest
 
 	}
 
+	@Test
+	public void testByteSourceSameAsTarget()
+	{
+		final ByteArray source = new ByteArray( numEntities );
+		for ( int i = 0; i < numEntities; ++i )
+		{
+			source.setValue( i, ( byte ) i );
+		}
+		final byte[] sourceCopy = source.getCurrentStorageArray().clone();
+
+		Accesses.copy( source, 0, source, 0, numEntities );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
+		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
+		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+	}
+
+	@Test
+	public void testCharSourceSameAsTarget()
+	{
+		final CharArray source = new CharArray( numEntities );
+		for ( int i = 0; i < numEntities; ++i )
+		{
+			source.setValue( i, ( char ) i );
+		}
+		final char[] sourceCopy = source.getCurrentStorageArray().clone();
+
+		Accesses.copy( source, 0, source, 0, numEntities );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
+		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
+		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+	}
+
+	@Test
+	public void testShortSourceSameAsTarget()
+	{
+		final ShortArray source = new ShortArray( numEntities );
+		for ( int i = 0; i < numEntities; ++i )
+		{
+			source.setValue( i, ( short ) i );
+		}
+		final short[] sourceCopy = source.getCurrentStorageArray().clone();
+
+		Accesses.copy( source, 0, source, 0, numEntities );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
+		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
+		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+	}
+
+	@Test
+	public void testIntSourceSameAsTarget()
+	{
+		final IntArray source = new IntArray( numEntities );
+		for ( int i = 0; i < numEntities; ++i )
+		{
+			source.setValue( i, ( byte ) i );
+		}
+		final int[] sourceCopy = source.getCurrentStorageArray().clone();
+
+		Accesses.copy( source, 0, source, 0, numEntities );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
+		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
+		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+	}
+
+	@Test
+	public void testLongSourceSameAsTarget()
+	{
+		final LongArray source = new LongArray( numEntities );
+		for ( int i = 0; i < numEntities; ++i )
+		{
+			source.setValue( i, ( byte ) i );
+		}
+		final long[] sourceCopy = source.getCurrentStorageArray().clone();
+
+		Accesses.copy( source, 0, source, 0, numEntities );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
+		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+
+		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
+		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+	}
+
+	@Test
+	public void testFloatSourceSameAsTarget()
+	{
+		final FloatArray source = new FloatArray( numEntities );
+		for ( int i = 0; i < numEntities; ++i )
+		{
+			source.setValue( i, ( byte ) i );
+		}
+		final float[] sourceCopy = source.getCurrentStorageArray().clone();
+
+		Accesses.copy( source, 0, source, 0, numEntities );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0f );
+
+		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
+		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0f );
+
+		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
+		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0f );
+	}
+
+	@Test
+	public void testDoubleSourceSameAsTarget()
+	{
+		final DoubleArray source = new DoubleArray( numEntities );
+		for ( int i = 0; i < numEntities; ++i )
+		{
+			source.setValue( i, ( byte ) i );
+		}
+		final double[] sourceCopy = source.getCurrentStorageArray().clone();
+
+		Accesses.copy( source, 0, source, 0, numEntities );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0 );
+
+		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
+		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0 );
+
+		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
+		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
+		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0 );
+	}
+
 }

--- a/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
@@ -62,13 +62,13 @@ public class AccessesTest
 
 		{
 			final ByteArray target = new ByteArray( numEntities );
-			Accesses.copy( source, target, numEntities );
+			Accesses.copy( source, 0, target, 0, numEntities );
 			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
 		}
 
 		{
 			final ByteArray target = new ByteArray( numEntities );
-			Accesses.copy( source, target, start, stop );
+			Accesses.copy( source, start, target, start, stop - start );
 			for ( int i = 0; i < numEntities; ++i )
 			{
 				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
@@ -85,13 +85,13 @@ public class AccessesTest
 
 		{
 			final CharArray target = new CharArray( numEntities );
-			Accesses.copy( source, target, numEntities );
+			Accesses.copy( source, 0, target, 0, numEntities );
 			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
 		}
 
 		{
 			final CharArray target = new CharArray( numEntities );
-			Accesses.copy( source, target, start, stop );
+			Accesses.copy( source, start, target, start, stop - start );
 			for ( int i = 0; i < numEntities; ++i )
 			{
 				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
@@ -108,13 +108,13 @@ public class AccessesTest
 
 		{
 			final DoubleArray target = new DoubleArray( numEntities );
-			Accesses.copy( source, target, numEntities );
+			Accesses.copy( source, 0, target, 0, numEntities );
 			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray(), 0.0 );
 		}
 
 		{
 			final DoubleArray target = new DoubleArray( numEntities );
-			Accesses.copy( source, target, start, stop );
+			Accesses.copy( source, start, target, start, stop - start );
 			for ( int i = 0; i < numEntities; ++i )
 			{
 				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ), 0.0 );
@@ -131,13 +131,13 @@ public class AccessesTest
 
 		{
 			final FloatArray target = new FloatArray( numEntities );
-			Accesses.copy( source, target, numEntities );
+			Accesses.copy( source, 0, target, 0, numEntities );
 			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray(), 0.0f );
 		}
 
 		{
 			final FloatArray target = new FloatArray( numEntities );
-			Accesses.copy( source, target, start, stop );
+			Accesses.copy( source, start, target, start, stop - start );
 			for ( int i = 0; i < numEntities; ++i )
 			{
 				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ), 0.0f );
@@ -154,13 +154,13 @@ public class AccessesTest
 
 		{
 			final IntArray target = new IntArray( numEntities );
-			Accesses.copy( source, target, numEntities );
+			Accesses.copy( source, 0, target, 0, numEntities );
 			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
 		}
 
 		{
 			final IntArray target = new IntArray( numEntities );
-			Accesses.copy( source, target, start, stop );
+			Accesses.copy( source, start, target, start, stop - start );
 			for ( int i = 0; i < numEntities; ++i )
 			{
 				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
@@ -177,13 +177,13 @@ public class AccessesTest
 
 		{
 			final LongArray target = new LongArray( numEntities );
-			Accesses.copy( source, target, numEntities );
+			Accesses.copy( source, 0, target, 0, numEntities );
 			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
 		}
 
 		{
 			final LongArray target = new LongArray( numEntities );
-			Accesses.copy( source, target, start, stop );
+			Accesses.copy( source, start, target, start, stop - start );
 			for ( int i = 0; i < numEntities; ++i )
 			{
 				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
@@ -200,13 +200,13 @@ public class AccessesTest
 
 		{
 			final ShortArray target = new ShortArray( numEntities );
-			Accesses.copy( source, target, numEntities );
+			Accesses.copy( source, 0, target, 0, numEntities );
 			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
 		}
 
 		{
 			final ShortArray target = new ShortArray( numEntities );
-			Accesses.copy( source, target, start, stop );
+			Accesses.copy( source, start, target, start, stop - start );
 			for ( int i = 0; i < numEntities; ++i )
 			{
 				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );

--- a/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
@@ -48,330 +48,98 @@ import net.imglib2.img.basictypeaccess.array.ShortArray;
 public class AccessesTest
 {
 
-	private final int numEntities = 10;
-
-	private final int start = 3;
-
-	private final int stop = 6;
-
 	@Test
 	public void testByte()
 	{
-
-		final ByteArray source = new ByteArray( numEntities );
-
-		{
-			final ByteArray target = new ByteArray( numEntities );
-			Accesses.copy( source, 0, target, 0, numEntities );
-			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
-		}
-
-		{
-			final ByteArray target = new ByteArray( numEntities );
-			Accesses.copy( source, start, target, start, stop - start );
-			for ( int i = 0; i < numEntities; ++i )
-			{
-				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
-			}
-		}
-
+		final ByteArray source = new ByteArray( new byte[] { 1, 2, 3, 4, 5 } );
+		final ByteArray target = new ByteArray( new byte[] { -1, -2, -3, -4, -5 } );
+		Accesses.copy( source, 1, target, 3, 2 );
+		Assert.assertArrayEquals( new byte[] { -1, -2, -3, 2, 3 }, target.getCurrentStorageArray() );
 	}
 
 	@Test( expected = IllegalArgumentException.class )
 	public void testChar()
 	{
-
-		final CharArray source = new CharArray( numEntities );
-
-		{
-			final CharArray target = new CharArray( numEntities );
-			Accesses.copy( source, 0, target, 0, numEntities );
-			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
-		}
-
-		{
-			final CharArray target = new CharArray( numEntities );
-			Accesses.copy( source, start, target, start, stop - start );
-			for ( int i = 0; i < numEntities; ++i )
-			{
-				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
-			}
-		}
-
+		final CharArray source = new CharArray( new char[] { 'a', 'b', 'c', 'd', 'e' } );
+		final CharArray target = new CharArray( new char[] { 'f', 'g', 'h', 'i', 'j' } );
+		Accesses.copy( source, 1, target, 3, 2 );
+		Assert.assertArrayEquals( new char[] { 'f', 'g', 'h', 'b', 'c' }, target.getCurrentStorageArray() );
 	}
 
 	@Test
 	public void testDouble()
 	{
-
-		final DoubleArray source = new DoubleArray( numEntities );
-
-		{
-			final DoubleArray target = new DoubleArray( numEntities );
-			Accesses.copy( source, 0, target, 0, numEntities );
-			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray(), 0.0 );
-		}
-
-		{
-			final DoubleArray target = new DoubleArray( numEntities );
-			Accesses.copy( source, start, target, start, stop - start );
-			for ( int i = 0; i < numEntities; ++i )
-			{
-				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ), 0.0 );
-			}
-		}
-
+		final DoubleArray source = new DoubleArray( new double[] { 1, 2, 3, 4, 5 } );
+		final DoubleArray target = new DoubleArray( new double[] { -1, -2, -3, -4, -5 } );
+		Accesses.copy( source, 1, target, 3, 2 );
+		Assert.assertArrayEquals( new double[] { -1, -2, -3, 2, 3 }, target.getCurrentStorageArray(), 0.0 );
 	}
 
 	@Test
 	public void testFloat()
 	{
-
-		final FloatArray source = new FloatArray( numEntities );
-
-		{
-			final FloatArray target = new FloatArray( numEntities );
-			Accesses.copy( source, 0, target, 0, numEntities );
-			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray(), 0.0f );
-		}
-
-		{
-			final FloatArray target = new FloatArray( numEntities );
-			Accesses.copy( source, start, target, start, stop - start );
-			for ( int i = 0; i < numEntities; ++i )
-			{
-				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ), 0.0f );
-			}
-		}
-
+		final FloatArray source = new FloatArray( new float[] { 1, 2, 3, 4, 5 } );
+		final FloatArray target = new FloatArray( new float[] { -1, -2, -3, -4, -5 } );
+		Accesses.copy( source, 1, target, 3, 2 );
+		Assert.assertArrayEquals( new float[] { -1, -2, -3, 2, 3 }, target.getCurrentStorageArray(), 0.0f );
 	}
 
 	@Test
 	public void testInt()
 	{
-
-		final IntArray source = new IntArray( numEntities );
-
-		{
-			final IntArray target = new IntArray( numEntities );
-			Accesses.copy( source, 0, target, 0, numEntities );
-			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
-		}
-
-		{
-			final IntArray target = new IntArray( numEntities );
-			Accesses.copy( source, start, target, start, stop - start );
-			for ( int i = 0; i < numEntities; ++i )
-			{
-				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
-			}
-		}
-
+		final IntArray source = new IntArray( new int[] { 1, 2, 3, 4, 5 } );
+		final IntArray target = new IntArray( new int[] { -1, -2, -3, -4, -5 } );
+		Accesses.copy( source, 1, target, 3, 2 );
+		Assert.assertArrayEquals( new int[] { -1, -2, -3, 2, 3 }, target.getCurrentStorageArray() );
 	}
 
 	@Test
 	public void testLong()
 	{
-
-		final LongArray source = new LongArray( numEntities );
-
-		{
-			final LongArray target = new LongArray( numEntities );
-			Accesses.copy( source, 0, target, 0, numEntities );
-			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
-		}
-
-		{
-			final LongArray target = new LongArray( numEntities );
-			Accesses.copy( source, start, target, start, stop - start );
-			for ( int i = 0; i < numEntities; ++i )
-			{
-				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
-			}
-		}
-
+		final LongArray source = new LongArray( new long[] { 1, 2, 3, 4, 5 } );
+		final LongArray target = new LongArray( new long[] { -1, -2, -3, -4, -5 } );
+		Accesses.copy( source, 1, target, 3, 2 );
+		Assert.assertArrayEquals( new long[] { -1, -2, -3, 2, 3 }, target.getCurrentStorageArray() );
 	}
 
 	@Test
 	public void testShort()
 	{
-
-		final ShortArray source = new ShortArray( numEntities );
-
-		{
-			final ShortArray target = new ShortArray( numEntities );
-			Accesses.copy( source, 0, target, 0, numEntities );
-			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
-		}
-
-		{
-			final ShortArray target = new ShortArray( numEntities );
-			Accesses.copy( source, start, target, start, stop - start );
-			for ( int i = 0; i < numEntities; ++i )
-			{
-				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
-			}
-		}
-
+		final ShortArray source = new ShortArray( new short[] { 1, 2, 3, 4, 5 } );
+		final ShortArray target = new ShortArray( new short[] { -1, -2, -3, -4, -5 } );
+		Accesses.copy( source, 1, target, 3, 2 );
+		Assert.assertArrayEquals( new short[] { -1, -2, -3, 2, 3 }, target.getCurrentStorageArray() );
 	}
 
 	@Test
-	public void testByteSourceSameAsTarget()
+	public void testCopyInPlace()
 	{
-		final ByteArray source = new ByteArray( numEntities );
-		for ( int i = 0; i < numEntities; ++i )
-		{
-			source.setValue( i, ( byte ) i );
-		}
-		final byte[] sourceCopy = source.getCurrentStorageArray().clone();
-
-		Accesses.copy( source, 0, source, 0, numEntities );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
-		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
-		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-	}
-
-	@Test( expected = IllegalArgumentException.class )
-	public void testCharSourceSameAsTarget()
-	{
-		final CharArray source = new CharArray( numEntities );
-		for ( int i = 0; i < numEntities; ++i )
-		{
-			source.setValue( i, ( char ) i );
-		}
-		final char[] sourceCopy = source.getCurrentStorageArray().clone();
-
-		Accesses.copy( source, 0, source, 0, numEntities );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
-		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
-		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+		byte[] expected = { 1, 2, 3, 4, 5 };
+		final ByteArray access = new ByteArray( expected.clone() );
+		Accesses.copy( access, 0, access, 0, access.getArrayLength() );
+		Assert.assertArrayEquals( expected, access.getCurrentStorageArray() );
 	}
 
 	@Test
-	public void testShortSourceSameAsTarget()
+	public void testCopyInPlaceWithOffset()
 	{
-		final ShortArray source = new ShortArray( numEntities );
-		for ( int i = 0; i < numEntities; ++i )
-		{
-			source.setValue( i, ( short ) i );
-		}
-		final short[] sourceCopy = source.getCurrentStorageArray().clone();
-
-		Accesses.copy( source, 0, source, 0, numEntities );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
-		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
-		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
+		final ByteArray access = new ByteArray( new byte[] { 1, 2, 3, 4, 5 } );
+		Accesses.copy( access, 1, access, 2, 2 );
+		Assert.assertArrayEquals( new byte[] { 1, 2, 2, 3, 5 }, access.getCurrentStorageArray() );
 	}
 
 	@Test
-	public void testIntSourceSameAsTarget()
+	public void testCopyInPlaceWithNegativeOffset()
 	{
-		final IntArray source = new IntArray( numEntities );
-		for ( int i = 0; i < numEntities; ++i )
-		{
-			source.setValue( i, ( byte ) i );
-		}
-		final int[] sourceCopy = source.getCurrentStorageArray().clone();
-
-		Accesses.copy( source, 0, source, 0, numEntities );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
-		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
-		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-	}
-
-	@Test
-	public void testLongSourceSameAsTarget()
-	{
-		final LongArray source = new LongArray( numEntities );
-		for ( int i = 0; i < numEntities; ++i )
-		{
-			source.setValue( i, ( byte ) i );
-		}
-		final long[] sourceCopy = source.getCurrentStorageArray().clone();
-
-		Accesses.copy( source, 0, source, 0, numEntities );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
-		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-
-		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
-		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
-	}
-
-	@Test
-	public void testFloatSourceSameAsTarget()
-	{
-		final FloatArray source = new FloatArray( numEntities );
-		for ( int i = 0; i < numEntities; ++i )
-		{
-			source.setValue( i, ( byte ) i );
-		}
-		final float[] sourceCopy = source.getCurrentStorageArray().clone();
-
-		Accesses.copy( source, 0, source, 0, numEntities );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0f );
-
-		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
-		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0f );
-
-		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
-		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0f );
-	}
-
-	@Test
-	public void testDoubleSourceSameAsTarget()
-	{
-		final DoubleArray source = new DoubleArray( numEntities );
-		for ( int i = 0; i < numEntities; ++i )
-		{
-			source.setValue( i, ( byte ) i );
-		}
-		final double[] sourceCopy = source.getCurrentStorageArray().clone();
-
-		Accesses.copy( source, 0, source, 0, numEntities );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0 );
-
-		System.arraycopy( sourceCopy, 0, sourceCopy, numEntities / 2, numEntities / 2 );
-		Accesses.copy( source, 0, source, numEntities / 2, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0 );
-
-		System.arraycopy( sourceCopy, numEntities / 4, sourceCopy, 0, numEntities / 2 );
-		Accesses.copy( source, numEntities / 4, source, 0, numEntities / 2 );
-		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0 );
+		final ByteArray access = new ByteArray( new byte[] { 1, 2, 3, 4, 5 } );
+		Accesses.copy( access, 2, access, 1, 2 );
+		Assert.assertArrayEquals( new byte[] { 1, 3, 4, 4, 5 }, access.getCurrentStorageArray() );
 	}
 
 	@Test( expected = IllegalArgumentException.class )
 	public void testLongSourceByteTargetFail()
 	{
+		int numEntities = 5;
 		final LongArray source = new LongArray( numEntities );
 		final ByteArray target = new ByteArray( numEntities );
 		Accesses.copy( source, 0, target, 0, numEntities );
@@ -380,35 +148,16 @@ public class AccessesTest
 	@Test
 	public void testByteWithDifferentAccesses()
 	{
-
-		final SomeByteAccess source = new SomeByteAccess( numEntities );
-
-		{
-			final ByteArray target = new ByteArray( numEntities );
-			Accesses.copy( source, 0, target, 0, numEntities );
-			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
-		}
-
-		{
-			final ByteArray target = new ByteArray( numEntities );
-			Accesses.copy( source, start, target, start, stop - start );
-			for ( int i = 0; i < numEntities; ++i )
-			{
-				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
-			}
-		}
-
+		final ByteArray source = new ByteArray( new byte[] { 1, 2, 3, 4, 5 } );
+		final SomeByteAccess target = new SomeByteAccess( new byte[] { -1, -2, -3, -4, -5 } );
+		Accesses.copy( source, 1, target, 3, 2 );
+		Assert.assertArrayEquals( new byte[] { -1, -2, -3, 2, 3 }, target.getCurrentStorageArray() );
 	}
 
 	private static final class SomeByteAccess implements ByteAccess
 	{
 
 		private final byte[] data;
-
-		private SomeByteAccess( int numEntities )
-		{
-			this( new byte[ numEntities ] );
-		}
 
 		private SomeByteAccess( byte[] data )
 		{

--- a/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
@@ -369,4 +369,60 @@ public class AccessesTest
 		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0 );
 	}
 
+	@Test
+	public void testByteWithDifferentAccesses()
+	{
+
+		final SomeByteAccess source = new SomeByteAccess( numEntities );
+
+		{
+			final ByteArray target = new ByteArray( numEntities );
+			Accesses.copy( source, 0, target, 0, numEntities );
+			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
+		}
+
+		{
+			final ByteArray target = new ByteArray( numEntities );
+			Accesses.copy( source, start, target, start, stop - start );
+			for ( int i = 0; i < numEntities; ++i )
+			{
+				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
+			}
+		}
+
+	}
+
+	private static final class SomeByteAccess implements ByteAccess
+	{
+
+		private final byte[] data;
+
+		private SomeByteAccess( int numEntities )
+		{
+			this( new byte[ numEntities ] );
+		}
+
+		private SomeByteAccess( byte[] data )
+		{
+			this.data = data;
+		}
+
+		public byte[] getCurrentStorageArray()
+		{
+			return this.data;
+		}
+
+		@Override
+		public byte getValue( int index )
+		{
+			return data[ index ];
+		}
+
+		@Override
+		public void setValue(int index, byte value)
+		{
+			data[ index ] = value;
+		}
+	}
+
 }

--- a/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
@@ -1,0 +1,218 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.basictypeaccess;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.CharArray;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+
+public class AccessesTest
+{
+
+	private final int numEntities = 10;
+
+	private final int start = 3;
+
+	private final int stop = 6;
+
+	@Test
+	public void testByte()
+	{
+
+		final ByteArray source = new ByteArray( numEntities );
+
+		{
+			final ByteArray target = new ByteArray( numEntities );
+			Accesses.copy( source, target, numEntities );
+			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
+		}
+
+		{
+			final ByteArray target = new ByteArray( numEntities );
+			Accesses.copy( source, target, start, stop );
+			for ( int i = 0; i < numEntities; ++i )
+			{
+				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
+			}
+		}
+
+	}
+
+	@Test
+	public void testChar()
+	{
+
+		final CharArray source = new CharArray( numEntities );
+
+		{
+			final CharArray target = new CharArray( numEntities );
+			Accesses.copy( source, target, numEntities );
+			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
+		}
+
+		{
+			final CharArray target = new CharArray( numEntities );
+			Accesses.copy( source, target, start, stop );
+			for ( int i = 0; i < numEntities; ++i )
+			{
+				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
+			}
+		}
+
+	}
+
+	@Test
+	public void testDouble()
+	{
+
+		final DoubleArray source = new DoubleArray( numEntities );
+
+		{
+			final DoubleArray target = new DoubleArray( numEntities );
+			Accesses.copy( source, target, numEntities );
+			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray(), 0.0 );
+		}
+
+		{
+			final DoubleArray target = new DoubleArray( numEntities );
+			Accesses.copy( source, target, start, stop );
+			for ( int i = 0; i < numEntities; ++i )
+			{
+				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ), 0.0 );
+			}
+		}
+
+	}
+
+	@Test
+	public void testFloat()
+	{
+
+		final FloatArray source = new FloatArray( numEntities );
+
+		{
+			final FloatArray target = new FloatArray( numEntities );
+			Accesses.copy( source, target, numEntities );
+			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray(), 0.0f );
+		}
+
+		{
+			final FloatArray target = new FloatArray( numEntities );
+			Accesses.copy( source, target, start, stop );
+			for ( int i = 0; i < numEntities; ++i )
+			{
+				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ), 0.0f );
+			}
+		}
+
+	}
+
+	@Test
+	public void testInt()
+	{
+
+		final IntArray source = new IntArray( numEntities );
+
+		{
+			final IntArray target = new IntArray( numEntities );
+			Accesses.copy( source, target, numEntities );
+			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
+		}
+
+		{
+			final IntArray target = new IntArray( numEntities );
+			Accesses.copy( source, target, start, stop );
+			for ( int i = 0; i < numEntities; ++i )
+			{
+				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
+			}
+		}
+
+	}
+
+	@Test
+	public void testLong()
+	{
+
+		final LongArray source = new LongArray( numEntities );
+
+		{
+			final LongArray target = new LongArray( numEntities );
+			Accesses.copy( source, target, numEntities );
+			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
+		}
+
+		{
+			final LongArray target = new LongArray( numEntities );
+			Accesses.copy( source, target, start, stop );
+			for ( int i = 0; i < numEntities; ++i )
+			{
+				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
+			}
+		}
+
+	}
+
+	@Test
+	public void testShort()
+	{
+
+		final ShortArray source = new ShortArray( numEntities );
+
+		{
+			final ShortArray target = new ShortArray( numEntities );
+			Accesses.copy( source, target, numEntities );
+			Assert.assertArrayEquals( source.getCurrentStorageArray(), target.getCurrentStorageArray() );
+		}
+
+		{
+			final ShortArray target = new ShortArray( numEntities );
+			Accesses.copy( source, target, start, stop );
+			for ( int i = 0; i < numEntities; ++i )
+			{
+				Assert.assertEquals( i < start || i >= stop ? 0 : source.getValue( i ), target.getValue( i ) );
+			}
+		}
+
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
@@ -369,6 +369,14 @@ public class AccessesTest
 		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray(), 0.0 );
 	}
 
+	@Test( expected = IllegalArgumentException.class )
+	public void testLongSourceByteTargetFail()
+	{
+		final LongArray source = new LongArray( numEntities );
+		final ByteArray target = new ByteArray( numEntities );
+		Accesses.copy( source, 0, target, 0, numEntities );
+	}
+
 	@Test
 	public void testByteWithDifferentAccesses()
 	{

--- a/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/AccessesTest.java
@@ -77,7 +77,7 @@ public class AccessesTest
 
 	}
 
-	@Test
+	@Test( expected = IllegalArgumentException.class )
 	public void testChar()
 	{
 
@@ -237,7 +237,7 @@ public class AccessesTest
 		Assert.assertArrayEquals( sourceCopy, source.getCurrentStorageArray() );
 	}
 
-	@Test
+	@Test( expected = IllegalArgumentException.class )
 	public void testCharSourceSameAsTarget()
 	{
 		final CharArray source = new CharArray( numEntities );


### PR DESCRIPTION
This is useful for me in the imglyb context, copying from contiguous `numpy.ndarray` to imglib2 `ArrayDataAccess`.