### PR TITLE
UnsignedLongType: fix getRealDouble and getRealFloat

### DIFF
--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
@@ -52,6 +52,9 @@ import net.imglib2.util.Util;
  */
 public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 {
+
+	private static final double MAX_VALUE_PLUS_ONE = Math.pow( 2, 64 ); // not precise, because double is not sufficient
+
 	// this is the constructor if you want it to read from an array
 	public UnsignedLongType( final NativeImg< ?, ? extends LongAccess > img )
 	{
@@ -282,7 +285,7 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 	@Override
 	public double getMaxValue()
 	{
-		return Math.pow( 2, 64 ) - 1;
+		return MAX_VALUE_PLUS_ONE - 1;
 	} // imprecise
 
 	/**
@@ -338,4 +341,19 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 	{
 		return new UnsignedLongType( get() );
 	}
+
+	@Override
+	public float getRealFloat()
+	{
+		long l = get();
+		return l >= 0 ? l : ((float) MAX_VALUE_PLUS_ONE + l);
+	}
+
+	@Override
+	public double getRealDouble()
+	{
+		long l = get();
+		return l >= 0 ? l : (MAX_VALUE_PLUS_ONE + l);
+	}
+
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
@@ -177,4 +177,23 @@ public class UnsignedLongTypeTest {
 
 		assertEquals( ul.get(), bi.longValue() );
 	}
+
+	@Test
+	public void testGetMaxValue() {
+		assertEquals( (double) Long.MAX_VALUE - (double) Long.MIN_VALUE, new UnsignedLongType().getMaxValue(), 0.0 );
+	}
+
+	@Test
+	public void testGetRealDouble() {
+
+		final UnsignedLongType ul = new UnsignedLongType( -1 );
+		assertEquals( ul.getMaxValue(), ul.getRealDouble(), 0.0 );
+	}
+
+	@Test
+	public void testGetRealFloat() {
+
+		final UnsignedLongType ul = new UnsignedLongType( -1 );
+		assertEquals( (float) ul.getMaxValue(), ul.getRealFloat(), 0.0f );
+	}
 }


### PR DESCRIPTION
The methods getRealDouble and getRealFloat now return correct values,
even if a positive unsigned long value is represented by a negative
long value.