### PR TITLE
Asserts And Radomized Images for JUnit Tests with ImgLib2

### DIFF
--- a/src/main/java/net/imglib2/test/ImgLib2Assert.java
+++ b/src/main/java/net/imglib2/test/ImgLib2Assert.java
@@ -1,0 +1,140 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.test;
+
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.operators.ValueEquals;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Pair;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+import java.util.Arrays;
+import java.util.StringJoiner;
+import java.util.function.BiPredicate;
+
+public class ImgLib2Assert
+{
+	private ImgLib2Assert()
+	{
+		// prevent from instantiation
+	}
+
+	/**
+	 * Throws an AssertionError, if the content or intervals of the two images differ.
+	 * Comparision is done pixel wise using {@link ValueEquals#valueEquals(Object)}.
+	 */
+	public static < A extends ValueEquals< B >, B >
+	void assertImageEquals( final RandomAccessibleInterval< ? extends A > actual, final RandomAccessibleInterval< ? extends B > expected )
+	{
+		assertImageEquals( actual, expected, ValueEquals::valueEquals );
+	}
+
+	/**
+	 * Throws an AssertionError, if the content or intervals of the two images differ.
+	 * Comparision is done pixel wise. Two pixels are considered equal, if the values
+	 * returned by {@link RealType#getRealDouble()} differ by less than "tolerance".
+	 */
+	public static void assertImageEqualsRealType( final RandomAccessibleInterval< ? extends RealType< ? > > actual, final RandomAccessibleInterval< ? extends RealType< ? > > expected, double tolerance )
+	{
+		assertImageEquals( actual, expected, ( a, e ) -> Math.abs( a.getRealDouble() - e.getRealDouble() ) <= tolerance );
+	}
+
+	/**
+	 * Throws an AssertionError, if the content or intervals of the two images differ.
+	 * Comparision is done pixel wise. Two pixels are considered equal, if the values
+	 * returned by {@link IntegerType#getIntegerLong()} are equal.
+	 */
+	public static void assertImageEqualsIntegerType( final RandomAccessibleInterval< ? extends IntegerType< ? > > actual, final RandomAccessibleInterval< ? extends IntegerType< ? > > expected )
+	{
+		assertImageEquals( actual, expected, ( a, e ) -> a.getIntegerLong() == e.getIntegerLong() );
+	}
+
+	/**
+	 * Throws an AssertionError, if the content or intervals of the two images differ.
+	 * Comparision is done pixel wise. Two pixels are considered equal, if the give
+	 * predicate returns true.
+	 */
+	public static < A, B >
+	void assertImageEquals( final RandomAccessibleInterval< ? extends A > a, final RandomAccessibleInterval< ? extends B > b, BiPredicate< A, B > equals )
+	{
+		assertIntervalEquals( a, b );
+		IntervalView< ? extends Pair< ? extends A, ? extends B > > pairs = Views.interval( Views.pair( a, b ), b );
+		Cursor< ? extends Pair< ? extends A, ? extends B > > cursor = pairs.cursor();
+		while ( cursor.hasNext() )
+		{
+			Pair< ? extends A, ? extends B > p = cursor.next();
+			if ( !equals.test( p.getA(), p.getB() ) )
+				fail( "Pixel values differ on coordinate " +
+						positionToString( cursor ) + ", expected: "
+						+ p.getA() + " actual: " + p.getB() );
+		}
+	}
+
+	/**
+	 * Throws an AssertionError, if the two Intervals differ.
+	 */
+	public static void assertIntervalEquals( Interval a, Interval b )
+	{
+		if ( !Intervals.equals( a, b ) )
+			fail( "Intervals are different, expected: " + intervalToString( a ) + ", actual: " + intervalToString( b ) );
+	}
+
+	// -- Helper methods --
+
+	private static String positionToString( Localizable localizable )
+	{
+		StringJoiner joiner = new StringJoiner( ", " );
+		for ( int i = 0, n = localizable.numDimensions(); i < n; i++ )
+			joiner.add( String.valueOf( localizable.getIntPosition( i ) ) );
+		return "(" + joiner + ")";
+	}
+
+	static String intervalToString( Interval a )
+	{
+		return "{min=" + Arrays.toString( Intervals.minAsLongArray( a ) ) +
+				", max=" + Arrays.toString( Intervals.maxAsLongArray( a ) ) + "}";
+	}
+
+	private static void fail( String message )
+	{
+		throw new AssertionError( message );
+	}
+}

--- a/src/main/java/net/imglib2/test/RandomImgs.java
+++ b/src/main/java/net/imglib2/test/RandomImgs.java
@@ -1,0 +1,135 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.test;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.AbstractIntegerBitType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import java.util.Random;
+import java.util.function.Consumer;
+
+public class RandomImgs
+{
+
+	private final Random random;
+
+	public static RandomImgs seed( int seed )
+	{
+		return new RandomImgs( seed );
+	}
+
+	private RandomImgs( int seed )
+	{
+		this.random = new Random( seed );
+	}
+
+	/**
+	 * Creates an image with randomized content.
+	 * @param type Pixel type
+	 * @param interval Interval
+	 */
+	public < T extends NativeType< T > > RandomAccessibleInterval< T > nextImage( final T type, Interval interval )
+	{
+		long[] sizes = Intervals.dimensionsAsLongArray( interval );
+		long[] min = Intervals.minAsLongArray( interval );
+		return Views.translate( nextImage( type, sizes ), min );
+	}
+
+	/**
+	 * Creates an image with randomized content
+	 * @param type Pixel type
+	 * @param dims Dimensions
+	 */
+	public < T extends NativeType< T > > Img< T > nextImage( final T type, final long... dims )
+	{
+		final Img< T > result = new ArrayImgFactory<>( type ).create( dims );
+		return randomize( result );
+	}
+
+	/**
+	 * Randomizes the content of the given image.
+	 * @return Reference to the given image
+	 */
+	public < I extends RandomAccessibleInterval< T >, T >
+	I randomize( final I image )
+	{
+		final T type = Util.getTypeFromInterval( image );
+		Views.iterable( image ).forEach( randomSetter( type ) );
+		return image;
+	}
+
+	private < T > Consumer< T > randomSetter( final T type )
+	{
+		if ( ( type instanceof UnsignedByteType )
+				|| ( type instanceof ByteType )
+				|| ( type instanceof ShortType )
+				|| ( type instanceof UnsignedShortType )
+				|| ( type instanceof IntType ) )
+			return b -> ( ( IntegerType< ? > ) b ).setInteger( random.nextInt() );
+		if ( ( type instanceof UnsignedLongType )
+				|| ( type instanceof UnsignedIntType )
+				|| ( type instanceof AbstractIntegerBitType )
+				|| ( type instanceof UnsignedVariableBitLengthType )
+				|| ( type instanceof LongType ) )
+			return b -> ( ( IntegerType< ? > ) b ).setInteger( random.nextLong() );
+		if ( type instanceof ARGBType )
+			return b -> ( ( ARGBType ) b ).set( random.nextInt() );
+		if ( type instanceof FloatType )
+			return b -> ( ( FloatType ) b ).setReal( random.nextFloat() );
+		if ( type instanceof DoubleType )
+			return b -> ( ( DoubleType ) b ).setReal( random.nextDouble() );
+		throw new UnsupportedOperationException( "Randomization of type: " + type.getClass() + " is not supported." );
+	}
+}

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -45,6 +45,7 @@ import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealRandomAccess;
 import net.imglib2.RealRandomAccessible;
+import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgFactory;
@@ -52,11 +53,13 @@ import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.img.list.ListImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.operators.ValueEquals;
 import net.imglib2.view.Views;
 
 import java.util.List;
 import java.util.function.BiPredicate;
+import java.util.stream.StreamSupport;
 
 /**
  * A collection of general-purpose utility methods for working with ImgLib2 data
@@ -1002,5 +1005,31 @@ public class Util
 		for ( int i = 0; i < a.length; ++i )
 			if ( b[ i ] > a[ i ] )
 				a[ i ] = b[ i ];
+	}
+
+	/**
+	 * Returns the content of {@code Iterable<RealType>} as array of doubles.
+	 */
+	public static double[] asDoubleArray( Iterable< ? extends RealType< ? > > iterable )
+	{
+		return StreamSupport.stream( iterable.spliterator(), false ).mapToDouble( RealType::getRealDouble ).toArray();
+	}
+
+	/**
+	 * Returns the pixels of an RandomAccessibleInterval of RealType as array of doubles.
+	 * The pixels are sorted in flat iteration order.
+	 */
+	public static double[] asDoubleArray( RandomAccessibleInterval< ? extends RealType< ? > > rai )
+	{
+		return asDoubleArray( Views.flatIterable( rai ) );
+	}
+
+	/**
+	 * Returns the pixels of an image of RealType as array of doubles.
+	 * The pixels are sorted in flat iteration order.
+	 */
+	public static double[] asDoubleArray( Img< ? extends RealType< ? > > image )
+	{
+		return asDoubleArray( ( RandomAccessibleInterval< ? extends RealType< ? > > ) image );
 	}
 }

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -34,8 +34,6 @@
 
 package net.imglib2.util;
 
-import java.util.List;
-
 import net.imglib2.Dimensions;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
@@ -54,6 +52,11 @@ import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.img.list.ListImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
+import net.imglib2.type.operators.ValueEquals;
+import net.imglib2.view.Views;
+
+import java.util.List;
+import java.util.function.BiPredicate;
 
 /**
  * A collection of general-purpose utility methods for working with ImgLib2 data
@@ -950,6 +953,28 @@ public class Util
 			if ( l1.getDoublePosition( d ) != l2.getDoublePosition( d ) )
 				return false;
 		}
+		return true;
+	}
+
+	/**
+	 * Checks if both images have equal intervals and content.
+	 */
+	public static < T extends ValueEquals< U >, U > boolean imagesEqual( final RandomAccessibleInterval< ? extends T > a, final RandomAccessibleInterval< ? extends U > b )
+	{
+		return imagesEqual( a, b, ValueEquals::valueEquals );
+	}
+
+	/**
+	 * Checks if both images have equal intervals and content.
+	 * A predicate must be given to check if two pixels are equal.
+	 */
+	public static < T, U > boolean imagesEqual( final RandomAccessibleInterval< ? extends T > a, final RandomAccessibleInterval< ? extends U > b, BiPredicate< T, U > pixelEquals )
+	{
+		if ( !Intervals.equals( a, b ) )
+			return false;
+		for ( Pair< ? extends T, ? extends U > pair : Views.interval( Views.pair( a, b ), b ) )
+			if ( !pixelEquals.test( pair.getA(), pair.getB() ) )
+				return false;
 		return true;
 	}
 

--- a/src/test/java/net/imglib2/test/ImgLib2AssertTest.java
+++ b/src/test/java/net/imglib2/test/ImgLib2AssertTest.java
@@ -1,0 +1,153 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.test;
+
+import net.imglib2.Interval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Intervals;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImgLib2AssertTest
+{
+	@Test
+	public void testIntervalToString()
+	{
+		Interval interval = Intervals.createMinMax( 1, 2, 3, 4 );
+		String restult = ImgLib2Assert.intervalToString( interval );
+		assertEquals( "{min=[1, 2], max=[3, 4]}", restult );
+	}
+
+	@Test
+	public void testAssertIntervalsEquals()
+	{
+		Interval a = Intervals.createMinMax( 1, 2, 3, 4 );
+		Interval b = Intervals.createMinMax( 1, 2, 3, 4 );
+		ImgLib2Assert.assertIntervalEquals( a, b );
+	}
+
+	@Test( expected = AssertionError.class )
+	public void testAssertIntervalsEquals_Fail()
+	{
+		Interval a = Intervals.createMinMax( 1, 2, 3, 4 );
+		Interval b = Intervals.createMinMax( 1, 3, 3, 4 );
+		ImgLib2Assert.assertIntervalEquals( a, b );
+	}
+
+	// test assertImagesEquals with Predicate
+
+	@Test
+	public void testAssertImageEqualsWithPredicate()
+	{
+		ImgLib2Assert.assertImageEquals( img( 3 ), img( 5 ), ( a, e ) -> (a.getInteger() == 3) && (e.getInteger() == 5) );
+	}
+
+	@Test( expected = AssertionError.class )
+	public void testAssertImageEqualsWithPredicate_Fail()
+	{
+		ImgLib2Assert.assertImageEquals( img( 0 ), img( 0 ), ( a, e ) -> false );
+	}
+
+	@Test( expected = AssertionError.class )
+	public void testAssertImageEqualsWithPredicate_FailForInterval()
+	{
+		ImgLib2Assert.assertImageEquals( img( 1 ), ArrayImgs.ints( 1, 1 ), ( a, e ) -> true );
+	}
+
+	// test assertImagesEquals
+
+	@Test
+	public void testAssertImageEquals()
+	{
+		ImgLib2Assert.assertImageEquals( img( 1 ), img( 1 ) );
+	}
+
+	@Test( expected = AssertionError.class )
+	public void testAssertImageEquals_Fail()
+	{
+		ImgLib2Assert.assertImageEquals( img( 1 ), img( 2 ) );
+	}
+
+	// test method assertImageEqualsIntegerType
+
+	@Test
+	public void testAssertImageEqualsIntegerType()
+	{
+		ImgLib2Assert.assertImageEqualsIntegerType( img( 42 ), img( 42L ) );
+	}
+
+	@Test( expected = AssertionError.class )
+	public void testAssertImageEqualsIntegerType_Fail()
+	{
+		ImgLib2Assert.assertImageEqualsIntegerType( img( Integer.MAX_VALUE ), img( Long.MAX_VALUE ) );
+	}
+
+	// test method assertImageEqualsRealType
+
+	@Test
+	public void testAssertImageEqualsRealType()
+	{
+		ImgLib2Assert.assertImageEqualsRealType( img( 42.0 ), img( 42.5 ), 0.5 );
+	}
+
+	@Test( expected = AssertionError.class )
+	public void testAssertImageEqualsRealType_Fail()
+	{
+		ImgLib2Assert.assertImageEqualsRealType( img( 42.0 ), img( 42.5 ), 0.1 );
+	}
+
+	// Helper methods
+
+	private Img< IntType > img( int pixel )
+	{
+		return ArrayImgs.ints( new int[] { pixel }, 1 );
+	}
+
+	private Img< LongType > img( long pixel )
+	{
+		return ArrayImgs.longs( new long[] { pixel }, 1 );
+	}
+
+	private Img< DoubleType > img( double pixel )
+	{
+		return ArrayImgs.doubles( new double[] { pixel }, 1 );
+	}
+
+}

--- a/src/test/java/net/imglib2/test/RandomImgsTest.java
+++ b/src/test/java/net/imglib2/test/RandomImgsTest.java
@@ -1,0 +1,194 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.test;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converters;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.function.DoubleBinaryOperator;
+
+import static net.imglib2.test.ImgLib2Assert.assertImageEquals;
+import static net.imglib2.test.ImgLib2Assert.assertIntervalEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RandomImgsTest
+{
+	@Test
+	public void testRandomImage()
+	{
+		int expected = new Random( 42 ).nextInt();
+		Img< IntType > image = RandomImgs.seed( 42 ).nextImage( new IntType(), 1 );
+		assertImageEquals( ArrayImgs.ints( new int[] { expected }, 1 ), image );
+	}
+
+	@Test
+	public void testRandomImageDimensions()
+	{
+		long[] dims = { 4, 6, 7 };
+		Img< IntType > image = RandomImgs.seed( 42 ).nextImage( new IntType(), dims );
+		assertArrayEquals( dims, Intervals.dimensionsAsLongArray( image ) );
+	}
+
+	@Test
+	public void testRandomImageInterval()
+	{
+		Interval interval = Intervals.createMinSize( 2, 5, 7, 3, 4, 5 );
+		RandomAccessibleInterval< IntType > image = RandomImgs.seed( 42 ).nextImage( new IntType(), interval );
+		assertIntervalEquals( interval, image );
+	}
+
+	@Test
+	public void testRandomize()
+	{
+		int expected = new Random( 42 ).nextInt();
+		Img< IntType > image = RandomImgs.seed( 42 ).randomize( ArrayImgs.ints( new int[ 1 ], 1 ) );
+		assertImageEquals( ArrayImgs.ints( new int[]{ expected }, 1 ), image );
+	}
+
+	@Test
+	public void testRandomImageIntergerTypes()
+	{
+		createAndTestIntegerTypeImage( new ByteType() );
+		createAndTestIntegerTypeImage( new ShortType() );
+		createAndTestIntegerTypeImage( new IntType() );
+		createAndTestIntegerTypeImage( new LongType() );
+		createAndTestIntegerTypeImage( new UnsignedByteType() );
+		createAndTestIntegerTypeImage( new UnsignedShortType() );
+		createAndTestIntegerTypeImage( new UnsignedIntType() );
+		//testRealType( new UnsignedLongType() ); // NB: UnsignedLongType#getRealDouble needs to be fixed
+		createAndTestIntegerTypeImage( new Unsigned2BitType() );
+		createAndTestIntegerTypeImage( new Unsigned4BitType() );
+		createAndTestIntegerTypeImage( new Unsigned12BitType() );
+		createAndTestIntegerTypeImage( new UnsignedVariableBitLengthType( 5 ) );
+	}
+
+	@Test
+	public void testARGBType()
+	{
+		Img< ARGBType > image = RandomImgs.seed( 42 ).nextImage( new ARGBType(), 10, 10 );
+		testIsRandomImageIntegerType( Converters.argbChannel( image, 0 ) );
+		testIsRandomImageIntegerType( Converters.argbChannel( image, 1 ) );
+		testIsRandomImageIntegerType( Converters.argbChannel( image, 2 ) );
+		testIsRandomImageIntegerType( Converters.argbChannel( image, 3 ) );
+	}
+
+	private < T extends IntegerType< T > & NativeType< T > > void createAndTestIntegerTypeImage( T type )
+	{
+		Img< T > image = RandomImgs.seed( 42 ).nextImage( type, 10, 10 );
+		testIsRandomImageIntegerType( image );
+	}
+
+	private < T extends IntegerType< T > & NativeType< T > > void testIsRandomImageIntegerType( RandomAccessibleInterval< T > image )
+	{
+		T type = Util.getTypeFromInterval( image );
+		double min = type.getMinValue();
+		double max = type.getMaxValue();
+		double actualMin = fold( Double.POSITIVE_INFINITY, Math::min, Views.iterable( image ) );
+		double actualMax = fold( Double.NEGATIVE_INFINITY, Math::max, Views.iterable( image ) );
+		// NB: Test, if the actual maximal value is close enough to the types getMaxValue().
+		String msg1 = "Actual max is to low, type: " + type.getClass().getSimpleName() + " max: " + max + " actual max: " + actualMax;
+		assertTrue( msg1, min * 0.2 + max * 0.8 < actualMax );
+		// NB: Test, if the actual minimal value is close enough to the types getMinValue().
+		String msg2 = "Actual min is to high, type: " + type.getClass().getSimpleName() + " min: " + min + " actual min: " + actualMin;
+		assertTrue( msg2, min * 0.8 + max * 0.2 > actualMin );
+	}
+
+	@Test
+	public void testRandomImageRealTypes()
+	{
+		createAndTestRealTypeImage( new FloatType() );
+		createAndTestRealTypeImage( new DoubleType() );
+	}
+
+	private < T extends NativeType< T > & RealType< T > > void createAndTestRealTypeImage( T type )
+	{
+		Img< ? extends RealType< ? > > image = RandomImgs.seed( 42 ).nextImage( type, 10, 10 );
+		testUniformDistribution( image );
+	}
+
+	private void testUniformDistribution( Img< ? extends RealType< ? > > image )
+	{
+		assertEquals( 0.5, mean( image ), 0.1 );
+		assertEquals( 1.0 / 12.0, variance( image ), 0.1 );
+	}
+
+	private double mean( Img< ? extends RealType< ? > > image )
+	{
+		double sum = fold( 0, ( acc, value ) -> acc + value, image );
+		return sum / Intervals.numElements( image );
+	}
+
+	private double variance( Img< ? extends RealType< ? > > image )
+	{
+		double mean = mean( image );
+		double sum_squared = fold( 0, ( acc, value ) -> acc + Math.pow( value - mean, 2 ), image );
+		return sum_squared / Intervals.numElements( image );
+	}
+
+	private double fold( final double neutral, final DoubleBinaryOperator operation, final Iterable< ? extends RealType< ? > > image )
+	{
+		double accumulator = neutral;
+		for ( RealType< ? > values : image )
+			accumulator = operation.applyAsDouble( accumulator, values.getRealDouble() );
+		return accumulator;
+	}
+}

--- a/src/test/java/net/imglib2/util/UtilTest.java
+++ b/src/test/java/net/imglib2/util/UtilTest.java
@@ -34,10 +34,6 @@
 
 package net.imglib2.util;
 
-import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import net.imglib2.FinalInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
@@ -49,13 +45,17 @@ import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.img.list.ListImgFactory;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.logic.BoolType;
-
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.real.DoubleType;
 import org.junit.Test;
 
 import java.util.function.BiPredicate;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class UtilTest
 {
@@ -177,5 +177,14 @@ public class UtilTest
 	private Img<DoubleType > doublesImage( double... pixels )
 	{
 		return ArrayImgs.doubles( pixels, pixels.length );
+	}
+
+	@Test
+	public void testAsDoubleArray()
+	{
+		double[] expected = { 1, 2, 3, 4 };
+		Img< DoubleType > img = ArrayImgs.doubles( expected, 2, 2 );
+		double[] result = Util.asDoubleArray( img );
+		assertArrayEquals( expected, result, 0.0 );
 	}
 }

--- a/src/test/java/net/imglib2/util/UtilTest.java
+++ b/src/test/java/net/imglib2/util/UtilTest.java
@@ -34,20 +34,28 @@
 
 package net.imglib2.util;
 
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import net.imglib2.FinalInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
+import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.img.list.ListImgFactory;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.logic.BoolType;
 
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.real.DoubleType;
 import org.junit.Test;
+
+import java.util.function.BiPredicate;
 
 public class UtilTest
 {
@@ -142,5 +150,32 @@ public class UtilTest
 
 		final ImgFactory< BoolType > boolFactory = Util.getSuitableImgFactory( new FinalInterval( 10, 10 ), new BoolType() );
 		assertTrue( boolFactory instanceof ListImgFactory );
+	}
+
+	@Test
+	public void testImagesEqual() {
+		assertTrue( Util.imagesEqual( intsImage(1,2,3), intsImage(1,2,3) ) );
+		assertFalse( Util.imagesEqual( intsImage(1), intsImage(1,2,3) ) );
+		assertFalse( Util.imagesEqual( intsImage(1,2,3), intsImage(1,4,3) ) );
+		assertTrue( Util.imagesEqual( doublesImage(1,2,3), doublesImage(1,2,3) ) );
+		assertFalse( Util.imagesEqual( doublesImage(1,2,3), doublesImage(1,4,3) ) );
+	}
+
+	@Test
+	public void testImagesEqualWithPredicate() {
+		BiPredicate< RealType<?>, RealType<?> > predicate = ( a, b ) -> a.getRealDouble() == b.getRealDouble();
+		assertTrue( Util.imagesEqual( intsImage(1,2,3), doublesImage(1,2,3), predicate ) );
+		assertFalse( Util.imagesEqual( intsImage(1), doublesImage(1,2,3), predicate ) );
+		assertFalse( Util.imagesEqual( intsImage(1,2,3), doublesImage(1,4,3), predicate ) );
+	}
+
+	private Img< IntType > intsImage( int... pixels )
+	{
+		return ArrayImgs.ints( pixels, pixels.length );
+	}
+
+	private Img<DoubleType > doublesImage( double... pixels )
+	{
+		return ArrayImgs.doubles( pixels, pixels.length );
 	}
 }


### PR DESCRIPTION
When writing unit tests that involved ImgLib2, I often find it to hard:
* To check if two images are equal.
* To generate a randomized image as input for my unit test.

This PR adds this needed functionality.