### PR TITLE
Let LoopBuilder Support Up To Six Images

### DIFF
--- a/src/main/java/net/imglib2/loops/LoopBuilder.java
+++ b/src/main/java/net/imglib2/loops/LoopBuilder.java
@@ -112,6 +112,21 @@ public class LoopBuilder< T >
 		return new LoopBuilder<>( a, b, c );
 	}
 
+	public static < A, B, C, D > LoopBuilder< FourConsumer< A, B, C, D > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d )
+	{
+		return new LoopBuilder<>( a, b, c, d );
+	}
+
+	public static < A, B, C, D, E > LoopBuilder< FiveConsumer< A, B, C, D, E > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e )
+	{
+		return new LoopBuilder<>( a, b, c, d, e );
+	}
+
+	public static < A, B, C, D, E, F > LoopBuilder< SixConsumer< A, B, C, D, E, F > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f )
+	{
+		return new LoopBuilder<>( a, b, c, d, e, f );
+	}
+
 	public void forEachPixel( final T action )
 	{
 		Objects.requireNonNull( action );
@@ -132,13 +147,31 @@ public class LoopBuilder< T >
 		void accept( A a, B b, C c );
 	}
 
+	public interface FourConsumer< A, B, C, D >
+	{
+		void accept( A a, B b, C c, D d );
+	}
+
+	public interface FiveConsumer< A, B, C, D, E >
+	{
+		void accept( A a, B b, C c, D d, E e );
+	}
+
+	public interface SixConsumer< A, B, C, D, E, F >
+	{
+		void accept( A a, B b, C c, D d, E e, F f );
+	}
+
 	private static class RunnableFactory
 	{
 
 		private static final List< ClassCopyProvider< Runnable > > factories = Arrays.asList(
 				new ClassCopyProvider<>( ConsumerRunnable.class, Runnable.class ),
 				new ClassCopyProvider<>( BiConsumerRunnable.class, Runnable.class ),
-				new ClassCopyProvider<>( TriConsumerRunnable.class, Runnable.class ) );
+				new ClassCopyProvider<>( TriConsumerRunnable.class, Runnable.class ),
+				new ClassCopyProvider<>( FourConsumerRunnable.class, Runnable.class ),
+				new ClassCopyProvider<>( FiveConsumerRunnable.class, Runnable.class ),
+				new ClassCopyProvider<>( SixConsumerRunnable.class, Runnable.class ));
 
 		/**
 		 * For example.: Given a BiConsumer and two Samplers:
@@ -254,6 +287,102 @@ public class LoopBuilder< T >
 			public void run()
 			{
 				action.accept( samplerA.get(), samplerB.get(), samplerC.get() );
+			}
+		}
+
+		public static class FourConsumerRunnable< A, B, C, D > implements Runnable
+		{
+
+			private final FourConsumer< A, B, C, D > action;
+
+			private final Sampler< A > samplerA;
+
+			private final Sampler< B > samplerB;
+
+			private final Sampler< C > samplerC;
+
+			private final Sampler< D > samplerD;
+
+			public FourConsumerRunnable( final FourConsumer< A, B, C, D > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD )
+			{
+				this.action = action;
+				this.samplerA = samplerA;
+				this.samplerB = samplerB;
+				this.samplerC = samplerC;
+				this.samplerD = samplerD;
+			}
+
+			@Override
+			public void run()
+			{
+				action.accept( samplerA.get(), samplerB.get(), samplerC.get(), samplerD.get() );
+			}
+		}
+
+		public static class FiveConsumerRunnable< A, B, C, D, E > implements Runnable
+		{
+
+			private final FiveConsumer< A, B, C, D, E > action;
+
+			private final Sampler< A > samplerA;
+
+			private final Sampler< B > samplerB;
+
+			private final Sampler< C > samplerC;
+
+			private final Sampler< D > samplerD;
+
+			private final Sampler< E > samplerE;
+
+			public FiveConsumerRunnable( final FiveConsumer< A, B, C, D, E > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, Sampler< E > samplerE )
+			{
+				this.action = action;
+				this.samplerA = samplerA;
+				this.samplerB = samplerB;
+				this.samplerC = samplerC;
+				this.samplerD = samplerD;
+				this.samplerE = samplerE;
+			}
+
+			@Override
+			public void run()
+			{
+				action.accept( samplerA.get(), samplerB.get(), samplerC.get(), samplerD.get(), samplerE.get() );
+			}
+		}
+
+		public static class SixConsumerRunnable< A, B, C, D, E, F > implements Runnable
+		{
+
+			private final SixConsumer< A, B, C, D, E, F > action;
+
+			private final Sampler< A > samplerA;
+
+			private final Sampler< B > samplerB;
+
+			private final Sampler< C > samplerC;
+
+			private final Sampler< D > samplerD;
+
+			private final Sampler< E > samplerE;
+
+			private final Sampler< F > samplerF;
+
+			public SixConsumerRunnable( final SixConsumer< A, B, C, D, E, F > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, final Sampler< E > samplerE, final Sampler< F > samplerF )
+			{
+				this.action = action;
+				this.samplerA = samplerA;
+				this.samplerB = samplerB;
+				this.samplerC = samplerC;
+				this.samplerD = samplerD;
+				this.samplerE = samplerE;
+				this.samplerF = samplerF;
+			}
+
+			@Override
+			public void run()
+			{
+				action.accept( samplerA.get(), samplerB.get(), samplerC.get(), samplerD.get(), samplerE.get(), samplerF.get() );
 			}
 		}
 	}

--- a/src/main/java/net/imglib2/loops/SyncedPositionables.java
+++ b/src/main/java/net/imglib2/loops/SyncedPositionables.java
@@ -84,9 +84,18 @@ public final class SyncedPositionables
 			return new Forwarder2( positionables );
 		case 3:
 			return new Forwarder3( positionables );
+		case 4:
+			return new Forwarder4( positionables );
+		case 5:
+			return new Forwarder5( positionables );
 		default:
 			return new GeneralForwarder( positionables );
 		}
+	}
+
+	public static Positionable createSlow( final List< ? extends Positionable > positionables )
+	{
+		return new GeneralForwarder( positionables );
 	}
 
 	public static Positionable create( final Positionable... positionables )
@@ -245,7 +254,74 @@ public final class SyncedPositionables
 		}
 	}
 
-	private static class GeneralForwarder implements Forwarder
+	private static class Forwarder4 implements Forwarder
+	{
+
+		private final Positionable a, b, c, d;
+
+		public Forwarder4( final List< ? extends Positionable > values )
+		{
+			this.a = values.get( 0 );
+			this.b = values.get( 1 );
+			this.c = values.get( 2 );
+			this.d = values.get( 3 );
+		}
+
+		@Override
+		public void fwd( final int d )
+		{
+			this.a.fwd( d );
+			this.b.fwd( d );
+			this.c.fwd( d );
+			this.d.fwd( d );
+		}
+
+		@Override
+		public void move( final long offset, final int d )
+		{
+			this.a.move( offset, d );
+			this.b.move( offset, d );
+			this.c.move( offset, d );
+			this.d.move( offset, d );
+		}
+	}
+
+	private static class Forwarder5 implements Forwarder
+	{
+
+		private final Positionable a, b, c, d, e;
+
+		public Forwarder5( final List< ? extends Positionable > values )
+		{
+			this.a = values.get( 0 );
+			this.b = values.get( 1 );
+			this.c = values.get( 2 );
+			this.d = values.get( 3 );
+			this.e = values.get( 4 );
+		}
+
+		@Override
+		public void fwd( final int d )
+		{
+			this.a.fwd( d );
+			this.b.fwd( d );
+			this.c.fwd( d );
+			this.d.fwd( d );
+			this.e.fwd( d );
+		}
+
+		@Override
+		public void move( final long offset, final int d )
+		{
+			this.a.move( offset, d );
+			this.b.move( offset, d );
+			this.c.move( offset, d );
+			this.d.move( offset, d );
+			this.e.move( offset, d );
+		}
+	}
+
+	static class GeneralForwarder implements Forwarder
 	{
 
 		private final Positionable[] values;

--- a/src/test/java/net/imglib2/loops/LoopBuilderTest.java
+++ b/src/test/java/net/imglib2/loops/LoopBuilderTest.java
@@ -33,9 +33,13 @@
  */
 package net.imglib2.loops;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
 
@@ -81,5 +85,50 @@ public class LoopBuilderTest
 		final Cursor< IntType > s = Views.iterable( sum ).cursor();
 		while ( s.hasNext() )
 			assertEquals( s.next().get(), a.next().get() + b.next().get() );
+	}
+
+	@Test
+	public void testFourConsumer() {
+		List< Img< IntType > > images = createNImages( 4 );
+		LoopBuilder.setImages( images.get( 0 ), images.get( 1 ), images.get( 2 ), images.get( 3 ) )
+				.forEachPixel( ( a, b, c, d ) -> setIncreasing(a, b, c, d) );
+		assertIncreasing( images );
+	}
+
+	@Test
+	public void testFiveConsumer() {
+		List< Img< IntType > > images = createNImages( 5 );
+		LoopBuilder.setImages( images.get( 0 ), images.get( 1 ), images.get( 2 ), images.get( 3 ), images.get( 4 ) )
+				.forEachPixel( ( a, b, c, d, e ) -> setIncreasing(a, b, c, d, e) );
+		assertIncreasing( images );
+	}
+
+	@Test
+	public void testSixConsumer() {
+		List< Img< IntType > > images = createNImages( 6 );
+		LoopBuilder.setImages( images.get( 0 ), images.get( 1 ), images.get( 2 ), images.get( 3 ), images.get( 4 ), images.get( 5 ) )
+				.forEachPixel( ( a, b, c, d, e, f ) -> setIncreasing(a, b, c, d, e, f) );
+		assertIncreasing( images );
+	}
+
+	private List< Img< IntType > > createNImages(int n)
+	{
+		return IntStream.range( 0, n )
+					.mapToObj( ignore -> ArrayImgs.ints( 1 ) ).collect( Collectors.toList());
+	}
+
+	private void assertIncreasing( List< Img< IntType > > images )
+	{
+		for ( int i = 0; i < images.size(); i++ )
+		{
+			Img< IntType > image = images.get( i );
+			assertEquals( i, image.firstElement().get() );
+		}
+	}
+
+	private void setIncreasing( IntType... types )
+	{
+		for ( int i = 0; i < types.length; i++ )
+			types[i].setInteger( i );
 	}
 }

--- a/src/test/java/net/imglib2/loops/SyncedPositionablesBenchmark.java
+++ b/src/test/java/net/imglib2/loops/SyncedPositionablesBenchmark.java
@@ -1,0 +1,75 @@
+package net.imglib2.loops;
+
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.IntType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.List;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@State( Scope.Benchmark )
+public class SyncedPositionablesBenchmark
+{
+	private long[] dims = { 100, 100, 100 };
+
+	private List< Img< IntType > > array = sixTimes(() -> ArrayImgs.ints( dims ));
+
+	private < T > List< T > sixTimes( Supplier< T > supplier )
+	{
+		return IntStream.range( 0, 6 ).mapToObj( ignore -> supplier.get() ).collect( Collectors.toList());
+	}
+
+	@Benchmark
+	public void benchmark2() {
+		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ) )
+				.forEachPixel( (a, r) -> r.setReal( a.getRealDouble() ) );
+	}
+
+	@Benchmark
+	public void benchmark3() {
+		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ) )
+				.forEachPixel( (a, b, r) -> r.setReal( a.getRealDouble() + b.getRealDouble() ) );
+	}
+
+	@Benchmark
+	public void benchmark4() {
+		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ), array.get( 3 ) )
+				.forEachPixel( (a, b, c, r) -> r.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() ) );
+	}
+
+	@Benchmark
+	public void benchmark5() {
+		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ), array.get( 3 ), array.get( 4) )
+				.forEachPixel( (a, b, c, d, r) -> r.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() + d.getRealDouble() ) );
+	}
+
+	@Benchmark
+	public void benchmark6() {
+		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ), array.get( 3 ), array.get( 4 ), array.get( 5) )
+				.forEachPixel( (a, b, c, d, e, r) -> r.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() + d.getRealDouble() + e.getRealDouble() ) );
+	}
+
+	public static void main( final String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( SyncedPositionables.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 10 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}


### PR DESCRIPTION
I think it's time to support more than three images in LoopBuilder
as the topic came up in the ImageJ forum:
http://forum.imagej.net/t/imglib2-any-way-to-apply-a-math-operation-to-three-randomaccessibleinterval-and-store-the-result-in-a-fourth-without-an-explicit-loop/12079
