### PR TITLE
Add ConstantUtils.constantRandomAccessibleInterval without explicitly passing number of dimensions

### DIFF
--- a/src/main/java/net/imglib2/util/ConstantUtils.java
+++ b/src/main/java/net/imglib2/util/ConstantUtils.java
@@ -99,9 +99,10 @@ public class ConstantUtils
 
 	public static < T > RandomAccessibleInterval< T > constantRandomAccessibleInterval( final T constant, final Interval interval )
 	{
-		return constantRandomAccessibleInterval( constant, interval.numDimensions(), interval );
+		return Views.interval( constantRandomAccessible( constant, interval.numDimensions() ), interval );
 	}
 
+	@Deprecated
 	public static < T > RandomAccessibleInterval< T > constantRandomAccessibleInterval( final T constant, final int numDimensions, final Interval interval )
 	{
 		return Views.interval( constantRandomAccessible( constant, numDimensions ), interval );

--- a/src/main/java/net/imglib2/util/ConstantUtils.java
+++ b/src/main/java/net/imglib2/util/ConstantUtils.java
@@ -97,6 +97,11 @@ public class ConstantUtils
 		};
 	}
 
+	public static < T > RandomAccessibleInterval< T > constantRandomAccessibleInterval( final T constant, final Interval interval )
+	{
+		return constantRandomAccessibleInterval( constant, interval.numDimensions(), interval );
+	}
+
 	public static < T > RandomAccessibleInterval< T > constantRandomAccessibleInterval( final T constant, final int numDimensions, final Interval interval )
 	{
 		return Views.interval( constantRandomAccessible( constant, numDimensions ), interval );

--- a/src/test/java/net/imglib2/util/ConstantUtilsTest.java
+++ b/src/test/java/net/imglib2/util/ConstantUtilsTest.java
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.util;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.RealRandomAccessible;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.view.Views;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+public class ConstantUtilsTest
+{
+
+	@Test
+	public void constantRandomAccessible()
+	{
+		final int nDim = 5;
+		final int numPositions = 10;
+		final Random rng = new Random( 100 );
+		final IntType constVal = new IntType( 123 );
+		final RandomAccessible< IntType > randomAccessible = ConstantUtils.constantRandomAccessible( constVal, nDim );
+		final RandomAccess< IntType > access = randomAccessible.randomAccess();
+		for ( int i = 0; i < numPositions; ++i )
+		{
+			for ( int d = 0; d < nDim; ++d )
+				access.setPosition( rng.nextLong(), d );
+
+			Assert.assertTrue( constVal.valueEquals( access.get() ) );
+		}
+	}
+
+	@Test
+	public void constantRandomAccessibleInterval()
+	{
+		final int nDim = 5;
+		final Random rng = new Random( 100 );
+		final long[] dims = LongStream.generate( () -> rng.nextInt( 5 ) + 1 ).limit( nDim ).toArray();
+		final IntType constVal = new IntType( 123 );
+		final RandomAccessibleInterval< IntType > randomAccessibleInterval = ConstantUtils.constantRandomAccessibleInterval( constVal, new FinalInterval( dims ) );
+
+		Assert.assertArrayEquals( dims, Intervals.dimensionsAsLongArray( randomAccessibleInterval ) );
+		Assert.assertArrayEquals( new long[ nDim ], Intervals.minAsLongArray( randomAccessibleInterval ) );
+
+		Views.iterable( randomAccessibleInterval ).forEach( p -> Assert.assertTrue( constVal.valueEquals( constVal ) ) );
+	}
+
+	@Test
+	public void constantRealRandomAccessible()
+	{
+		final int nDim = 5;
+		final int numPositions = 10;
+		final Random rng = new Random( 100 );
+		final IntType constVal = new IntType( 123 );
+		final RealRandomAccessible< IntType > randomAccessible = ConstantUtils.constantRealRandomAccessible( constVal, nDim );
+		final RealRandomAccess< IntType > access = randomAccessible.realRandomAccess();
+		for ( int i = 0; i < numPositions; ++i )
+		{
+			for ( int d = 0; d < nDim; ++d )
+				access.setPosition( rng.nextDouble(), d );
+
+			Assert.assertTrue( constVal.valueEquals( access.get() ) );
+		}
+	}
+}

--- a/src/test/java/net/imglib2/util/IntervalIndexerTest.java
+++ b/src/test/java/net/imglib2/util/IntervalIndexerTest.java
@@ -80,7 +80,6 @@ public class IntervalIndexerTest
 			}
 			final RandomAccessibleInterval< DoubleType > interval = ConstantUtils.constantRandomAccessibleInterval(
 					new DoubleType(),
-					dim.length,
 					new FinalInterval( min, max ) );
 			testIndexToPosition( interval );
 			testPositionToIndex( interval );

--- a/src/test/java/net/imglib2/view/SubsampleIntervalViewTest.java
+++ b/src/test/java/net/imglib2/view/SubsampleIntervalViewTest.java
@@ -127,7 +127,7 @@ public class SubsampleIntervalViewTest
 		SubsampleIntervalView< FloatType > subInterval;
 
 		RandomAccessibleInterval< FloatType > randAccessInterval = ConstantUtils.constantRandomAccessibleInterval(
-				new FloatType( 1f ), 5, interval );
+				new FloatType( 1f ), interval );
 
 		for ( long[] shift : testShifts )
 		{


### PR DESCRIPTION
The explicitly passed parameter numDimensions is not required as this can be deducted from the provided interval.