### PR TITLE
Interval: add default implementations for most methods

### DIFF
--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -48,7 +48,12 @@ public interface Dimensions extends EuclideanSpace
 	 * 
 	 * @param dimensions
 	 */
-	public void dimensions( long[] dimensions );
+	default void dimensions( final long[] dimensions )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			dimensions[ d ] = dimension( d );
+	}
 
 	/**
 	 * Get the number of pixels in a given dimension <em>d</em>.

--- a/src/main/java/net/imglib2/Interval.java
+++ b/src/main/java/net/imglib2/Interval.java
@@ -58,47 +58,134 @@ public interface Interval extends RealInterval, Dimensions
 {
 	/**
 	 * Get the minimum in dimension d.
-	 * 
+	 *
 	 * @param d
 	 *            dimension
 	 * @return minimum in dimension d.
 	 */
-	public long min( final int d );
+	long min( final int d );
 
 	/**
 	 * Write the minimum of each dimension into long[].
-	 * 
+	 *
 	 * @param min
 	 */
-	public void min( long[] min );
+	default void min( final long[] min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min[ d ] = min( d );
+	}
+
 
 	/**
 	 * Sets a {@link Positionable} to the minimum of this {@link Interval}
-	 * 
+	 *
 	 * @param min
 	 */
-	public void min( Positionable min );
+	default void min( final Positionable min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min.setPosition( min( d ), d );
+	}
 
 	/**
 	 * Get the maximum in dimension d.
-	 * 
+	 *
 	 * @param d
 	 *            dimension
 	 * @return maximum in dimension d.
 	 */
-	public long max( final int d );
+	long max( final int d );
 
 	/**
 	 * Write the maximum of each dimension into long[].
-	 * 
+	 *
 	 * @param max
 	 */
-	public void max( long[] max );
+	default void max( final long[] max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max[ d ] = max( d );
+	}
 
 	/**
 	 * Sets a {@link Positionable} to the maximum of this {@link Interval}
-	 * 
+	 *
 	 * @param max
 	 */
-	public void max( Positionable max );
+	default void max( final Positionable max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max.setPosition( max( d ), d );
+	}
+
+	/** Default implementation of {@link RealInterval#realMin(int)}. */
+	@Override
+	default double realMin( final int d )
+	{
+		return min( d );
+	}
+
+	/** Default implementation of {@link RealInterval#realMin(double[])} */
+	@Override
+	default void realMin( final double[] min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min[ d ] = realMin( d );
+	}
+
+	/** Default implementation of {@link RealInterval#realMin(RealPositionable)} */
+	@Override
+	default void realMin( final RealPositionable min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min.setPosition( realMin( d ), d );
+	}
+
+	/** Default implementation of {@link RealInterval#realMax(int)}. */
+	@Override
+	default double realMax( final int d )
+	{
+		return max( d );
+	}
+
+	/** Default implementation of {@link RealInterval#realMax(double[])}. */
+	@Override
+	default void realMax( final double[] max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max[ d ] = realMax( d );
+	}
+
+	/** Default implementation of {@link RealInterval#realMax(RealPositionable)}. */
+	@Override
+	default void realMax( final RealPositionable max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max.setPosition( realMax( d ), d );
+	}
+
+	/** Default implementation of {@link Dimensions#dimensions(long[])}. */
+	@Override
+	default void dimensions( final long[] dimensions )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			dimensions[ d ] = dimension( d );
+	}
+
+	/** Default implementation of {@link Dimensions#dimension(int)}. */
+	@Override
+	default long dimension( int d )
+	{
+		return max( d ) - min( d ) + 1;
+	}
 }

--- a/src/main/java/net/imglib2/Interval.java
+++ b/src/main/java/net/imglib2/Interval.java
@@ -138,7 +138,7 @@ public interface Interval extends RealInterval, Dimensions
 
 	/** Default implementation of {@link Dimensions#dimension(int)}. */
 	@Override
-	default long dimension( int d )
+	default long dimension( final int d )
 	{
 		return max( d ) - min( d ) + 1;
 	}

--- a/src/main/java/net/imglib2/Interval.java
+++ b/src/main/java/net/imglib2/Interval.java
@@ -77,7 +77,6 @@ public interface Interval extends RealInterval, Dimensions
 			min[ d ] = min( d );
 	}
 
-
 	/**
 	 * Sets a {@link Positionable} to the minimum of this {@link Interval}
 	 *
@@ -130,56 +129,11 @@ public interface Interval extends RealInterval, Dimensions
 		return min( d );
 	}
 
-	/** Default implementation of {@link RealInterval#realMin(double[])} */
-	@Override
-	default void realMin( final double[] min )
-	{
-		final int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			min[ d ] = realMin( d );
-	}
-
-	/** Default implementation of {@link RealInterval#realMin(RealPositionable)} */
-	@Override
-	default void realMin( final RealPositionable min )
-	{
-		final int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			min.setPosition( realMin( d ), d );
-	}
-
 	/** Default implementation of {@link RealInterval#realMax(int)}. */
 	@Override
 	default double realMax( final int d )
 	{
 		return max( d );
-	}
-
-	/** Default implementation of {@link RealInterval#realMax(double[])}. */
-	@Override
-	default void realMax( final double[] max )
-	{
-		final int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			max[ d ] = realMax( d );
-	}
-
-	/** Default implementation of {@link RealInterval#realMax(RealPositionable)}. */
-	@Override
-	default void realMax( final RealPositionable max )
-	{
-		final int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			max.setPosition( realMax( d ), d );
-	}
-
-	/** Default implementation of {@link Dimensions#dimensions(long[])}. */
-	@Override
-	default void dimensions( final long[] dimensions )
-	{
-		final int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			dimensions[ d ] = dimension( d );
 	}
 
 	/** Default implementation of {@link Dimensions#dimension(int)}. */

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -52,9 +52,9 @@ public interface Localizable extends RealLocalizable
 	 * @param position
 	 *            receives current position
 	 */
-	default void localize( int[] position )
+	default void localize( final int[] position )
 	{
-		int n = numDimensions();
+		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
 			position[ d ] = getIntPosition( d );
 	}
@@ -65,9 +65,9 @@ public interface Localizable extends RealLocalizable
 	 * @param position
 	 *            receives current position
 	 */
-	default void localize( long[] position )
+	default void localize( final long[] position )
 	{
-		int n = numDimensions();
+		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
 			position[ d ] = getIntPosition( d );
 	}
@@ -79,7 +79,7 @@ public interface Localizable extends RealLocalizable
 	 *            dimension
 	 * @return dimension of current position
 	 */
-	default int getIntPosition( int d )
+	default int getIntPosition( final int d )
 	{
 		return (int) getLongPosition( d );
 	}
@@ -94,13 +94,13 @@ public interface Localizable extends RealLocalizable
 	public long getLongPosition( int d );
 
 	@Override
-	default float getFloatPosition( int d )
+	default float getFloatPosition( final int d )
 	{
 		return getLongPosition( d );
 	}
 
 	@Override
-	default double getDoublePosition( int d )
+	default double getDoublePosition( final int d )
 	{
 		return getLongPosition( d );
 	}

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -48,11 +48,16 @@ public interface Localizable extends RealLocalizable
 {
 	/**
 	 * Write the current position into the passed array.
-	 * 
+	 *
 	 * @param position
 	 *            receives current position
 	 */
-	public void localize( int[] position );
+	default void localize( int[] position )
+	{
+		int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			position[ d ] = getIntPosition( d );
+	}
 
 	/**
 	 * Write the current position into the passed array.
@@ -60,16 +65,24 @@ public interface Localizable extends RealLocalizable
 	 * @param position
 	 *            receives current position
 	 */
-	public void localize( long[] position );
+	default void localize( long[] position )
+	{
+		int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			position[ d ] = getIntPosition( d );
+	}
 
 	/**
 	 * Return the current position in a given dimension.
-	 * 
+	 *
 	 * @param d
 	 *            dimension
 	 * @return dimension of current position
 	 */
-	public int getIntPosition( int d );
+	default int getIntPosition( int d )
+	{
+		return (int) getLongPosition( d );
+	}
 
 	/**
 	 * Return the current position in a given dimension.
@@ -79,4 +92,16 @@ public interface Localizable extends RealLocalizable
 	 * @return dimension of current position
 	 */
 	public long getLongPosition( int d );
+
+	@Override
+	default float getFloatPosition( int d )
+	{
+		return getLongPosition( d );
+	}
+
+	@Override
+	default double getDoublePosition( int d )
+	{
+		return getLongPosition( d );
+	}
 }

--- a/src/main/java/net/imglib2/RealInterval.java
+++ b/src/main/java/net/imglib2/RealInterval.java
@@ -67,14 +67,24 @@ public interface RealInterval extends EuclideanSpace
 	 * 
 	 * @param min
 	 */
-	public void realMin( double[] min );
+	default void realMin( final double[] min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min[ d ] = realMin( d );
+	}
 
 	/**
 	 * Sets a {@link RealPositionable} to the minimum of this {@link Interval}
 	 * 
 	 * @param min
 	 */
-	public void realMin( RealPositionable min );
+	default void realMin( final RealPositionable min )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			min.setPosition( realMin( d ), d );
+	}
 
 	/**
 	 * Get the maximum in dimension d.
@@ -90,12 +100,22 @@ public interface RealInterval extends EuclideanSpace
 	 * 
 	 * @param max
 	 */
-	public void realMax( double[] max );
+	default void realMax( final double[] max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max[ d ] = realMax( d );
+	}
 
 	/**
 	 * Sets a {@link RealPositionable} to the maximum of this {@link Interval}
 	 * 
 	 * @param max
 	 */
-	public void realMax( RealPositionable max );
+	default void realMax( final RealPositionable max )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			max.setPosition( realMax( d ), d );
+	}
 }

--- a/src/main/java/net/imglib2/RealLocalizable.java
+++ b/src/main/java/net/imglib2/RealLocalizable.java
@@ -50,9 +50,9 @@ public interface RealLocalizable extends EuclideanSpace
 	 * @param position
 	 *            receives current position
 	 */
-	default void localize( float[] position )
+	default void localize( final float[] position )
 	{
-		int n = numDimensions();
+		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
 			position[ d ] = getFloatPosition( d );
 	}
@@ -63,9 +63,9 @@ public interface RealLocalizable extends EuclideanSpace
 	 * @param position
 	 *            receives current position
 	 */
-	default void localize( double[] position )
+	default void localize( final double[] position )
 	{
-		int n = numDimensions();
+		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
 			position[ d ] = getDoublePosition( d );
 	}
@@ -77,7 +77,7 @@ public interface RealLocalizable extends EuclideanSpace
 	 *            dimension
 	 * @return dimension of current position
 	 */
-	default float getFloatPosition( int d )
+	default float getFloatPosition( final int d )
 	{
 		return ( float ) getDoublePosition( d );
 	}

--- a/src/test/java/net/imglib2/DimensionsTest.java
+++ b/src/test/java/net/imglib2/DimensionsTest.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests {@link Dimensions}.
+ *
+ * @author Matthias Arzt
+ */
+public class DimensionsTest
+{
+	private final Dimensions dimensions = new Dimensions()
+	{
+		@Override
+		public long dimension( int d )
+		{
+			return 42 + d;
+		}
+
+		@Override
+		public int numDimensions()
+		{
+			return 3;
+		}
+	};
+
+	/**
+	 * Tests {@link Dimensions#dimensions(long[])}.
+	 */
+	@Test
+	public void testDimensionsWithLongs()
+	{
+		long[] result = new long[ 3 ];
+		dimensions.dimensions( result );
+		assertArrayEquals( new long[] { 42, 43, 44 }, result );
+	}
+}

--- a/src/test/java/net/imglib2/IntervalTest.java
+++ b/src/test/java/net/imglib2/IntervalTest.java
@@ -1,0 +1,142 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests default methods of the interface {@link Interval}.
+ *
+ * @author Matthias Arzt
+ */
+public class IntervalTest
+{
+
+	private final Interval interval = new Interval()
+	{
+
+		@Override
+		public long min( int d )
+		{
+			return 3;
+		}
+
+		@Override
+		public long max( int d )
+		{
+			return 7;
+		}
+
+		@Override
+		public int numDimensions()
+		{
+			return 1;
+		}
+	};
+
+	/**
+	 * Tests {@link Interval#min(long[])}.
+	 */
+	@Test
+	public void testMinWithLongs()
+	{
+		long[] result = new long[ 1 ];
+		interval.min( result );
+		assertArrayEquals( new long[] { 3 }, result );
+	}
+
+	/**
+	 * Tests {@link Interval#min(Positionable)}.
+	 */
+	@Test
+	public void testMinWithPositionable()
+	{
+		Point result = new Point( 1 );
+		interval.min( result );
+		assertEquals( 3, result.getLongPosition( 0 ) );
+	}
+
+	/**
+	 * Tests {@link Interval#max(long[])}.
+	 */
+	@Test
+	public void testMaxWithLongs()
+	{
+		long[] result = new long[ 1 ];
+		interval.max( result );
+		assertArrayEquals( new long[] { 7 }, result );
+	}
+
+	/**
+	 * Tests {@link Interval#max(Positionable)}.
+	 */
+	@Test
+	public void testMaxWithPositionable()
+	{
+		Point result = new Point( 1 );
+		interval.max( result );
+		assertEquals( 7, result.getLongPosition( 0 ) );
+	}
+
+	/**
+	 * Tests {@link Interval#realMin(int)}.
+	 */
+	@Test
+	public void testRealMin()
+	{
+		assertEquals( 3.0, interval.realMin( 0 ), 0.0 );
+	}
+
+	/**
+	 * Tests {@link Interval#realMax(int)}.
+	 */
+	@Test
+	public void testRealMax()
+	{
+		assertEquals( 7.0, interval.realMax( 0 ), 0.0 );
+	}
+
+	/**
+	 * Tests {@link Interval#dimension(int)}.
+	 */
+	@Test
+	public void testDimension()
+	{
+		assertEquals( 5, interval.dimension( 0 ) );
+	}
+}

--- a/src/test/java/net/imglib2/LocalizableTest.java
+++ b/src/test/java/net/imglib2/LocalizableTest.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,60 +34,71 @@
 
 package net.imglib2;
 
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 /**
- * The {@link RealLocalizable} interface can localize itself in an n-dimensional
- * real space.
- * 
- * 
- * @author Stephan Preibisch
- * @author Stephan Saalfeld
+ * Tests {@link Localizable}.
+ *
+ * @author Matthias Arzt
  */
-public interface RealLocalizable extends EuclideanSpace
+public class LocalizableTest
 {
-	/**
-	 * Write the current position into the passed array.
-	 * 
-	 * @param position
-	 *            receives current position
-	 */
-	default void localize( float[] position )
+
+	private final Localizable localizable = new Localizable()
 	{
-		int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			position[ d ] = getFloatPosition( d );
+		@Override
+		public long getLongPosition( int d )
+		{
+			return 42 + d;
+		}
+
+		@Override
+		public int numDimensions()
+		{
+			return 3;
+		}
+	};
+
+	@Test
+	public void testGetIntPosition()
+	{
+		assertEquals( 44, localizable.getIntPosition( 2 ) );
+	}
+
+	@Test
+	public void testGetDoublePosition()
+	{
+		assertEquals( 44.0, localizable.getDoublePosition( 2 ), 0.0 );
+	}
+
+	@Test
+	public void testGetFloatPosition()
+	{
+		assertEquals( 44.0f, localizable.getFloatPosition( 2 ), 0.0f );
 	}
 
 	/**
-	 * Write the current position into the passed array.
-	 *
-	 * @param position
-	 *            receives current position
+	 * Tests {@link Localizable#localize(long[])}.
 	 */
-	default void localize( double[] position )
+	@Test
+	public void testLocalizeWithLongs()
 	{
-		int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			position[ d ] = getDoublePosition( d );
+		long[] result = new long[ localizable.numDimensions() ];
+		localizable.localize( result );
+		assertArrayEquals( new long[] { 42, 43, 44 }, result );
 	}
 
 	/**
-	 * Return the current position in a given dimension.
-	 * 
-	 * @param d
-	 *            dimension
-	 * @return dimension of current position
+	 * Tests {@link Localizable#localize(int[])}.
 	 */
-	default float getFloatPosition( int d )
+	@Test
+	public void testLocalizeWithInts()
 	{
-		return ( float ) getDoublePosition( d );
+		int[] result = new int[ localizable.numDimensions() ];
+		localizable.localize( result );
+		assertArrayEquals( new int[] { 42, 43, 44 }, result );
 	}
-
-	/**
-	 * Return the current position in a given dimension.
-	 * 
-	 * @param d
-	 *            dimension
-	 * @return dimension of current position
-	 */
-	public double getDoublePosition( int d );
 }

--- a/src/test/java/net/imglib2/RealIntervalTest.java
+++ b/src/test/java/net/imglib2/RealIntervalTest.java
@@ -1,0 +1,114 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests {@link RealInterval}.
+ *
+ * @author Matthias Arzt
+ */
+public class RealIntervalTest
+{
+
+	private final RealInterval interval = new RealInterval()
+	{
+
+		@Override
+		public double realMin( int d )
+		{
+			return 1.5 + d;
+		}
+
+		@Override
+		public double realMax( int d )
+		{
+			return 7.3 + d;
+		}
+
+		@Override
+		public int numDimensions()
+		{
+			return 2;
+		}
+	};
+
+	/**
+	 * Tests {@link Interval#realMin(double[])}.
+	 */
+	@Test
+	public void testRealMinWithDoubles()
+	{
+		double[] result = new double[ 2 ];
+		interval.realMin( result );
+		assertArrayEquals( new double[] { 1.5, 2.5 }, result, 0.0 );
+	}
+
+	/**
+	 * Tests {@link Interval#realMax(double[])}.
+	 */
+	@Test
+	public void testRealMaxWithDoubles()
+	{
+		double[] result = new double[ 2 ];
+		interval.realMax( result );
+		assertArrayEquals( new double[] { 7.3, 8.3 }, result, 0.0 );
+	}
+
+	/**
+	 * Tests {@link Interval#realMin(RealPositionable)}.
+	 */
+	@Test
+	public void testRealMinWithPositionable()
+	{
+		double[] result = new double[ 2 ];
+		interval.realMin( RealPoint.wrap( result ) );
+		assertArrayEquals( new double[] { 1.5, 2.5 }, result, 0.0 );
+	}
+
+	/**
+	 * Tests {@link Interval#realMax(double[])}.
+	 */
+	@Test
+	public void testRealMaxWithPositionable()
+	{
+		double[] result = new double[ 2 ];
+		interval.realMax( RealPoint.wrap( result ) );
+		assertArrayEquals( new double[] { 7.3, 8.3 }, result, 0.0 );
+	}
+}

--- a/src/test/java/net/imglib2/RealLocalizableTest.java
+++ b/src/test/java/net/imglib2/RealLocalizableTest.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,60 +34,59 @@
 
 package net.imglib2;
 
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 /**
- * The {@link RealLocalizable} interface can localize itself in an n-dimensional
- * real space.
- * 
- * 
- * @author Stephan Preibisch
- * @author Stephan Saalfeld
+ * Tests {@link RealLocalizable}.
+ *
+ * @author Mathias Arzt
  */
-public interface RealLocalizable extends EuclideanSpace
+public class RealLocalizableTest
 {
-	/**
-	 * Write the current position into the passed array.
-	 * 
-	 * @param position
-	 *            receives current position
-	 */
-	default void localize( float[] position )
+	private final RealLocalizable localizable = new RealLocalizable()
 	{
-		int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			position[ d ] = getFloatPosition( d );
+
+		@Override
+		public double getDoublePosition( int d )
+		{
+			return 4.2 + d;
+		}
+
+		@Override
+		public int numDimensions()
+		{
+			return 2;
+		}
+	};
+
+	@Test
+	public void testGetFloatPosition()
+	{
+		assertEquals( 5.2f, localizable.getFloatPosition( 1 ), 0 );
 	}
 
 	/**
-	 * Write the current position into the passed array.
-	 *
-	 * @param position
-	 *            receives current position
+	 * Tests {@link RealLocalizable#localize(double[])}.
 	 */
-	default void localize( double[] position )
+	@Test
+	public void testLocalizeWithDoubles()
 	{
-		int n = numDimensions();
-		for ( int d = 0; d < n; d++ )
-			position[ d ] = getDoublePosition( d );
+		double[] result = new double[ localizable.numDimensions() ];
+		localizable.localize( result );
+		assertArrayEquals( new double[] { 4.2, 5.2 }, result, 0 );
 	}
 
 	/**
-	 * Return the current position in a given dimension.
-	 * 
-	 * @param d
-	 *            dimension
-	 * @return dimension of current position
+	 * Tests {@link RealLocalizable#localize(float[])}.
 	 */
-	default float getFloatPosition( int d )
+	@Test
+	public void testLocalizeWithFloats()
 	{
-		return ( float ) getDoublePosition( d );
+		float[] result = new float[ localizable.numDimensions() ];
+		localizable.localize( result );
+		assertArrayEquals( new float[] { 4.2f, 5.2f }, result, 0 );
 	}
-
-	/**
-	 * Return the current position in a given dimension.
-	 * 
-	 * @param d
-	 *            dimension
-	 * @return dimension of current position
-	 */
-	public double getDoublePosition( int d );
 }


### PR DESCRIPTION
Most methods in the interface `Interval` can have a default implementation. 
These default implementations will prevent a lot of bugs and code duplication.
Implementing an Interval becomes as easy as overloading three methods:
```java
public class SimpleInterval implements Interval
{
	private final long[] min;
	private final long[] max;

	public SimpleInterval( long[] min, long[] max )
	{
		assert min.length == max.length;
		this.min = min;
		this.max = max;
	}

	@Override
	public long min( int d )
	{
		return min[ d ];
	}

	@Override
	public long max( int d )
	{
		return max[ d ];
	}

	@Override
	public int numDimensions()
	{
		return min.length;
	}
}
```