### PR TITLE
ClassCopier: Use the classloader of the class that is copied

### DIFF
--- a/src/main/java/net/imglib2/loops/ClassCopier.java
+++ b/src/main/java/net/imglib2/loops/ClassCopier.java
@@ -67,7 +67,7 @@ class ClassCopier< T >
 	public Class< ? extends T > copy()
 	{
 		@SuppressWarnings( "unchecked" )
-		final Class< ? extends T > copy = ( Class< ? extends T > ) new ClassCopyLoader().bytesToClass( original.getName(), bytes );
+		final Class< ? extends T > copy = ( Class< ? extends T > ) new ClassCopyLoader( original.getClassLoader() ).bytesToClass( original.getName(), bytes );
 		return copy;
 	}
 
@@ -89,6 +89,11 @@ class ClassCopier< T >
 
 	private static class ClassCopyLoader extends ClassLoader
 	{
+
+		public ClassCopyLoader( ClassLoader parent )
+		{
+			super( parent );
+		}
 
 		private Class< ? > bytesToClass( final String className, final byte[] bytes )
 		{


### PR DESCRIPTION
Previously the system classloader was used as parent of the internal classloader, which can create problems in environments with multiple classloaders (e.g. OSGi).