### PR TITLE
Partition.java does not check the validity of input iterators

### DIFF
--- a/src/main/java/net/imglib2/util/Partition.java
+++ b/src/main/java/net/imglib2/util/Partition.java
@@ -37,6 +37,7 @@ package net.imglib2.util;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.NoSuchElementException;
 
 /**
  * TODO
@@ -1115,6 +1116,9 @@ public class Partition
 	 */
 	public static < T extends Comparable< T > > void partitionSubList( final ListIterator< T > i, final ListIterator< T > j, final int[] permutation )
 	{
+                if (!i.hasNext() || !j.hasPrevious()) {
+                    throw new NoSuchElementException("Invalid iterators for partitioning a sublist.");
+                }
 		final int pivotIndex = j.previousIndex();
 		final int permutationPivot = permutation[ pivotIndex ];
 		final T pivot = j.previous();

--- a/src/test/java/net/imglib2/util/PartitionTest.java
+++ b/src/test/java/net/imglib2/util/PartitionTest.java
@@ -36,12 +36,15 @@ package net.imglib2.util;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.ListIterator;
+import java.util.NoSuchElementException;
 
 import org.junit.Test;
 
@@ -404,6 +407,21 @@ public class PartitionTest
 		for ( int k = 0; k < permutation.length; ++k )
 			assertTrue( values.get( k ).equals( origvalues.get( permutation[ k ] ) ) );
 	}
+
+	@Test
+	public void testPartitionEmptyFloatObjectIteratorPermutation()
+        {
+            final ArrayList< Float > values = new ArrayList< Float >();
+            final ListIterator< Float > iIterator = values.listIterator();
+            final ListIterator< Float > jIterator = values.listIterator( values.size() );
+            final int[] permutation = new int[ values.size() ];
+            try {
+                Partition.partitionSubList( iIterator, jIterator, permutation );
+                fail( "Expected a NoSuchElementException to be thrown" );
+            } catch ( NoSuchElementException noSuchElementException )  {
+                assertEquals( noSuchElementException.getMessage(), "Invalid iterators for partitioning a sublist." );
+            }
+        }
 
 	@Test
 	public void testPartitionFloatObjectIteratorPermutation()


### PR DESCRIPTION
`Partition.java` calls `j.previous()` on `java.util.Iterator j` and `i.next()` on `java.util.Iterator i` 
without checking if there are any elements to iterate over. Because the method is public and the iterators are obtained from inputs, they could be invalid (e.g., an empty list) and lead to an exception. This pull request adds a `hasNext()` and a `hasPrevious()` check.

This violation is present in other parts of this class as well. If this fix is acceptable to you, we can
submit another pull request with fixes for all other cases.
