### PR TITLE
ImgUtil.copy RandomAccessibleInterval to an IterableInterval, multithreaded

### DIFF
--- a/src/main/java/net/imglib2/util/ImgUtil.java
+++ b/src/main/java/net/imglib2/util/ImgUtil.java
@@ -35,8 +35,9 @@
 package net.imglib2.util;
 
 import net.imglib2.Cursor;
-import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.IntegerType;
@@ -312,34 +313,12 @@ public class ImgUtil
 	}
 	
 	/**
-	 * Copy one {@link Img} into another.
-	 * If both have the same iteration order, the copy proceeds with two {@link Cursor}.
-	 * If they differ in iteration order, then they are copied with a {@link RandomAccess} approach.
-	 * 
-	 * @param src
-	 * @param dest
-	 * 
+	 * Copy one image into another, multi-threaded.
 	 */
-	public static < T extends Type< T >> void copy( final Img< T > src, final Img< T > dest )
+	public static < T extends Type< T >> void copy( final RandomAccessibleInterval< T > source, final RandomAccessibleInterval< T > destination )
 	{
-		if ( src.iterationOrder() == dest.iterationOrder() )
-		{
-			final Cursor< T > c1 = src.cursor(),
-							  c2 = dest.cursor();
-			while ( c1.hasNext() )
-				c2.next().set( c1.next() );
-		}
-		else
-		{
-			final Cursor< T > c = src.cursor();
-			final RandomAccess< T > r = dest.randomAccess();
-			
-			while ( c.hasNext() )
-			{
-				c.fwd();
-				r.setPosition( c );
-				r.get().set( c.get() );
-			}
-		}
+		LoopBuilder.setImages(source, destination)
+				.multiThreaded()
+				.forEachPixel( (i,o) -> o.set(i) );
 	}
 }

--- a/src/test/java/net/imglib2/util/ImgUtilTest.java
+++ b/src/test/java/net/imglib2/util/ImgUtilTest.java
@@ -42,8 +42,11 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 
 import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.test.ImgLib2Assert;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
@@ -365,6 +368,15 @@ public class ImgUtilTest
 			ImgUtil.copy( img, output, offsets[ i ], strides[ i ] );
 			assertArrayEquals( expected[ i ], output );
 		}
+	}
+	
+	@Test
+	public void testCopyRAItoRAI()
+	{
+		RandomAccessibleInterval<IntType> source = ArrayImgs.ints(new int[]{1, 2, 3, 4, 5, 6}, 2, 3);
+		RandomAccessibleInterval<IntType> destination = ArrayImgs.ints(2, 3);
+		ImgUtil.copy( source, destination );
+		ImgLib2Assert.assertImageEquals( source, destination );
 	}
 
 }


### PR DESCRIPTION
New utility method ImgUtil.copy(RandomAccessibleInterval, IterableInterval, int) for multi-threaded copying with `int` threads.

Addresses the issue of copying "images" that are actually transformed views using linear interpolators and others, which can be costly and, from a scripting framework, it is not entirely trivial to partition a RandomAccessibleInterval for multi-threaded processing.
While it could be done via Views.interval, it is simpler to use a utility method to do it all.