### PR TITLE
Extract MixedTransform creation and Interval manipulation methods from Views

### DIFF
--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -414,7 +414,7 @@ public class Intervals
 	public static FinalInterval moveAxis( final Interval interval, final int fromAxis, final int toAxis )
 	{
 		final int n = interval.numDimensions();
-		final Mixed t = MixedTransforms.getMoveAxisTransform( fromAxis, toAxis, n );
+		final Mixed t = MixedTransforms.moveAxis( fromAxis, toAxis, n );
 		final int[] newAxisIndices = new int[ n ];
 		t.getComponentMapping( newAxisIndices );
 

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -276,6 +276,59 @@ public class Intervals
 	}
 
 	/**
+	 * Offset an interval in one dimension.
+	 * 
+	 * Create a {@link FinalInterval} , which is the input interval shifted by -o
+	 * in dimension d.
+	 * 
+	 * @param interval
+	 *            the input interval
+	 * @param o
+	 *            by how many pixels to shift the interval
+	 * @param d
+	 *            in which dimension
+	 * @return offsetted interval
+	 */
+	public static FinalInterval offset( final Interval interval, final long o, final int d )
+	{
+		final int n = interval.numDimensions();
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		interval.min( min );
+		interval.max( max );
+		min[ d ] += o;
+		max[ d ] += o;
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Offset an interval.
+	 *
+	 * Create a {@link FinalInterval} , which is the input interval shifted by
+	 * {@code -offset}.
+	 *
+	 * @param interval
+	 *            the input interval
+	 * @param offset
+	 *            by how many pixels to shift the interval
+	 * @return offsetted interval
+	 */
+	public static FinalInterval offset( final Interval interval, final long... offset )
+	{
+		final int n = interval.numDimensions();
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		interval.min( min );
+		interval.max( max );
+		for ( int d = 0; d < n; ++d )
+		{
+			min[ d ] -= offset[ d ];
+			max[ d ] -= offset[ d ];
+		}
+		return new FinalInterval( min, max );
+	}
+
+	/**
 	 * Compute the intersection of two intervals.
 	 * 
 	 * Create a {@link FinalInterval} , which is the intersection of the input

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -42,6 +42,8 @@ import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
+import net.imglib2.transform.integer.Mixed;
+import net.imglib2.view.MixedTransforms;
 
 /**
  * Convenience methods for manipulating {@link Interval Intervals}.
@@ -324,6 +326,156 @@ public class Intervals
 		{
 			min[ d ] -= offset[ d ];
 			max[ d ] -= offset[ d ];
+		}
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Create new interval by adding a dimension to the source
+	 * {@link Interval}. The {@link Interval} boundaries in the
+	 * additional dimension are set to the specified values.
+	 *
+	 * The additional dimension is the last dimension. 
+	 *
+	 * @param interval
+	 *            the original interval
+	 * @param minOfNewDim
+	 *            Interval min in the additional dimension.
+	 * @param maxOfNewDim
+	 *            Interval max in the additional dimension.
+	 */
+	public static FinalInterval addDimension( final Interval interval, final long minOfNewDim, final long maxOfNewDim ) {
+		final int m = interval.numDimensions();
+		final long[] min = new long[ m + 1 ];
+		final long[] max = new long[ m + 1 ];
+		for ( int d = 0; d < m; ++d )
+		{
+			min[ d ] = interval.min( d );
+			max[ d ] = interval.max( d );
+		}
+		min[ m ] = minOfNewDim;
+		max[ m ] = maxOfNewDim;
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Invert the bounds on the d-axis of the given interval
+	 *
+	 * @param interval
+	 *            the source
+	 * @param d
+	 *            the axis to invert
+	 */
+	public static FinalInterval invertAxis( final Interval interval, final int d ) {
+		final int n = interval.numDimensions();
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		interval.min( min );
+		interval.max( max );
+		final long tmp = min[ d ];
+		min[ d ] = -max[ d ];
+		max[ d ] = -tmp;
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Take a (n-1)-dimensional slice of a n-dimensional interval, dropping the
+	 * d axis.
+	 */
+	public static FinalInterval hyperSlice( final Interval interval, final int d )
+	{
+		final int m = interval.numDimensions();
+		final int n = m - 1;
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		for ( int e = 0; e < m; ++e )
+		{
+			if ( e < d )
+			{
+				min[ e ] = interval.min( e );
+				max[ e ] = interval.max( e );
+			}
+			else if ( e > d )
+			{
+				min[ e - 1 ] = interval.min( e );
+				max[ e - 1 ] = interval.max( e );
+			}
+		}
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Create an interval with permuted axes. The {@code fromAxis} is moved to {@code toAxis}, while the
+	 * order of the other axes is preserved.
+	 *
+	 * If fromAxis=2 and toAxis=4, and axis order of {@code interval} was XYCZT, then
+	 * an interval with axis order XYZTC would be created.
+	 */
+	public static FinalInterval moveAxis( final Interval interval, final int fromAxis, final int toAxis )
+	{
+		final int n = interval.numDimensions();
+		final Mixed t = MixedTransforms.getMoveAxisTransform( fromAxis, toAxis, n );
+		final int[] newAxisIndices = new int[ n ];
+		t.getComponentMapping( newAxisIndices );
+
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		for (int d = 0; d < n; d++) {
+			min[ newAxisIndices[ d ] ] = interval.min( d );
+			max[ newAxisIndices[ d ] ] = interval.max( d );
+		}
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Create an interval with permuted axes. fromAxis and toAxis are swapped.
+	 *
+	 * If fromAxis=0 and toAxis=2, this means that the X-axis of the source interval
+	 * is mapped to the Z-Axis of the permuted interval and vice versa. For a XYZ
+	 * source, a ZYX interval would be created.
+	 */
+	public static FinalInterval permuteAxes( final Interval interval, final int fromAxis, final int toAxis )
+	{
+		final int n = interval.numDimensions();
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		interval.min( min );
+		interval.max( max );
+		final long fromMinNew = min[ toAxis ];
+		final long fromMaxNew = max[ toAxis ];
+		min[ toAxis ] = min[ fromAxis ];
+		max[ toAxis ] = max[ fromAxis ];
+		min[ fromAxis ] = fromMinNew;
+		max[ fromAxis ] = fromMaxNew;
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Create an interval that is rotated by 90 degrees. The rotation is specified by
+	 * the fromAxis and toAxis arguments.
+	 *
+	 * If fromAxis=0 and toAxis=1, this means that the X-axis of the source interval
+	 * is mapped to the Y-Axis of the rotated interval. That is, it corresponds to a
+	 * 90 degree clock-wise rotation of the source interval in the XY plane.
+	 *
+	 * fromAxis=1 and toAxis=0 corresponds to a counter-clock-wise rotation in
+	 * the XY plane.
+	 */
+	public static FinalInterval rotate( final Interval interval, final int fromAxis, final int toAxis ) 
+	{
+		final int n = interval.numDimensions();
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		interval.min( min );
+		interval.max( max );
+		if ( fromAxis != toAxis )
+		{
+			final long fromMinNew = -max[ toAxis ];
+			final long fromMaxNew = -min[ toAxis ];
+			min[ toAxis ] = min[ fromAxis ];
+			max[ toAxis ] = max[ fromAxis ];
+			min[ fromAxis ] = fromMinNew;
+			max[ fromAxis ] = fromMaxNew;
 		}
 		return new FinalInterval( min, max );
 	}

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -278,59 +278,6 @@ public class Intervals
 	}
 
 	/**
-	 * Offset an interval in one dimension.
-	 * 
-	 * Create a {@link FinalInterval} , which is the input interval shifted by -o
-	 * in dimension d.
-	 * 
-	 * @param interval
-	 *            the input interval
-	 * @param o
-	 *            by how many pixels to shift the interval
-	 * @param d
-	 *            in which dimension
-	 * @return offsetted interval
-	 */
-	public static FinalInterval offset( final Interval interval, final long o, final int d )
-	{
-		final int n = interval.numDimensions();
-		final long[] min = new long[ n ];
-		final long[] max = new long[ n ];
-		interval.min( min );
-		interval.max( max );
-		min[ d ] += o;
-		max[ d ] += o;
-		return new FinalInterval( min, max );
-	}
-
-	/**
-	 * Offset an interval.
-	 *
-	 * Create a {@link FinalInterval} , which is the input interval shifted by
-	 * {@code -offset}.
-	 *
-	 * @param interval
-	 *            the input interval
-	 * @param offset
-	 *            by how many pixels to shift the interval
-	 * @return offsetted interval
-	 */
-	public static FinalInterval offset( final Interval interval, final long... offset )
-	{
-		final int n = interval.numDimensions();
-		final long[] min = new long[ n ];
-		final long[] max = new long[ n ];
-		interval.min( min );
-		interval.max( max );
-		for ( int d = 0; d < n; ++d )
-		{
-			min[ d ] -= offset[ d ];
-			max[ d ] -= offset[ d ];
-		}
-		return new FinalInterval( min, max );
-	}
-
-	/**
 	 * Create new interval by adding a dimension to the source
 	 * {@link Interval}. The {@link Interval} boundaries in the
 	 * additional dimension are set to the specified values.

--- a/src/main/java/net/imglib2/view/MixedTransforms.java
+++ b/src/main/java/net/imglib2/view/MixedTransforms.java
@@ -1,3 +1,36 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.view;
 
 import java.util.ArrayList;

--- a/src/main/java/net/imglib2/view/MixedTransforms.java
+++ b/src/main/java/net/imglib2/view/MixedTransforms.java
@@ -12,7 +12,7 @@ import net.imglib2.transform.integer.MixedTransform;
  * Utility methods to create mixed transforms for common operations. Used by {@link Views}.
  * 
  * @author Tobias Pietzsch
- * @author Carsten Haubold, KNIME GmbH
+ * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
  */
 public class MixedTransforms
 {
@@ -21,7 +21,7 @@ public class MixedTransforms
 	 * is specified by two axis indices, such that the {@code fromAxis} is
 	 * rotated to the {@code toAxis}.
 	 *
-	 * For example: {@code getRotationTransform(0, 1, 3)} creates a transform
+	 * For example: {@code rotate(0, 1, 3)} creates a transform
 	 * that rotates the X axis (of a XYZ space) to the Y axis. Applying the
 	 * transform to <em>(1,2,3)</em> yields <em>(2,-1,3)</em>.
 	 *
@@ -34,7 +34,7 @@ public class MixedTransforms
 	 * @return a transform that rotates the {@code fromAxis} to the
 	 *         {@code toAxis}.
 	 */
-	public static Mixed getRotationTransform( final int fromAxis, final int toAxis, final int n )
+	public static Mixed rotate( final int fromAxis, final int toAxis, final int n )
 	{
 		if ( fromAxis == toAxis )
 			return new MixedTransform(n, n);
@@ -78,7 +78,7 @@ public class MixedTransforms
 	 * @param n
 	 * @return
 	 */
-	public static Mixed getPermuteTransform( final int fromAxis, final int toAxis, final int n )
+	public static Mixed permute( final int fromAxis, final int toAxis, final int n )
 	{
 		if ( fromAxis == toAxis )
 			return new MixedTransform(n, n);
@@ -102,7 +102,7 @@ public class MixedTransforms
 	 * @param m
 	 * @return
 	 */
-	public static MixedTransform getHyperSliceTransform( final int d, final long pos, final int m )
+	public static MixedTransform hyperSlice( final int d, final long pos, final int m )
 	{
 		final int n = m - 1;
 		final MixedTransform t = new MixedTransform( n, m );
@@ -144,7 +144,7 @@ public class MixedTransforms
 	 *            in the source view becomes <em>(x + translation)</em> in the
 	 *            resulting view.
 	 */
-	public static MixedTransform getTranslationTransform( final long... translation )
+	public static MixedTransform translate( final long... translation )
 	{
 		final int n = translation.length;
 		final MixedTransform t = new MixedTransform( n, n );
@@ -161,7 +161,7 @@ public class MixedTransforms
 	 *            origin of resulting view.
 	 * @return transformation
 	 */
-	public static MixedTransform getOffsetTransform(final long... offset )
+	public static MixedTransform offset(final long... offset )
 	{
 		final int n = offset.length;
 		final MixedTransform t = new MixedTransform( n, n );
@@ -176,7 +176,7 @@ public class MixedTransforms
 	 * If fromAxis=2 and toAxis=4, and axis order of image is XYCZT, then
 	 * a view to the image with axis order XYZTC would be created.
 	 */
-	public static MixedTransform getMoveAxisTransform(final int fromAxis, final int toAxis, final int n) {
+	public static MixedTransform moveAxis(final int fromAxis, final int toAxis, final int n) {
 		if ( fromAxis == toAxis )
 			return new MixedTransform(n, n);
 
@@ -202,11 +202,11 @@ public class MixedTransforms
 	 *            the source.
 	 * @return transformation
 	 */
-	public static MixedTransform getZeroMinTransform( final Interval interval ) {
+	public static MixedTransform zeroMin( final Interval interval ) {
 		final int n = interval.numDimensions();
 		final long[] offset = new long[ n ];
 		interval.min( offset );
-		return MixedTransforms.getOffsetTransform(offset);
+		return MixedTransforms.offset(offset);
 	}
 
 	/**
@@ -214,7 +214,7 @@ public class MixedTransforms
 	 * @param currentNumDims
 	 * @return 
 	 */
-	public static MixedTransform getAddDimensionTransform( final int currentNumDims ) {
+	public static MixedTransform addDimension( final int currentNumDims ) {
 		final int newNumDims = currentNumDims + 1;
 		return new MixedTransform(newNumDims, currentNumDims);
 	}
@@ -225,7 +225,7 @@ public class MixedTransforms
 	 * @param n
 	 * @return
 	 */
-	public static MixedTransform getInvertAxisTransform( final int d , final int n ) {
+	public static MixedTransform invertAxis( final int d , final int n ) {
 		final boolean[] inv = new boolean[ n ];
 		inv[ d ] = true;
 		final MixedTransform t = new MixedTransform( n, n );

--- a/src/main/java/net/imglib2/view/MixedTransforms.java
+++ b/src/main/java/net/imglib2/view/MixedTransforms.java
@@ -1,0 +1,235 @@
+package net.imglib2.view;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import net.imglib2.Interval;
+import net.imglib2.transform.integer.Mixed;
+import net.imglib2.transform.integer.MixedTransform;
+
+/**
+ * Utility methods to create mixed transforms for common operations. Used by {@link Views}.
+ * 
+ * @author Tobias Pietzsch
+ * @author Carsten Haubold, KNIME GmbH
+ */
+public class MixedTransforms
+{
+	/**
+	 * Create a {@link MixedTransform} that rotates by 90 degrees. The rotation
+	 * is specified by two axis indices, such that the {@code fromAxis} is
+	 * rotated to the {@code toAxis}.
+	 *
+	 * For example: {@code getRotationTransform(0, 1, 3)} creates a transform
+	 * that rotates the X axis (of a XYZ space) to the Y axis. Applying the
+	 * transform to <em>(1,2,3)</em> yields <em>(2,-1,3)</em>.
+	 *
+	 * @param fromAxis
+	 *            axis index.
+	 * @param toAxis
+	 *            axis index.
+	 * @param n
+	 *            number of dimensions of the space.
+	 * @return a transform that rotates the {@code fromAxis} to the
+	 *         {@code toAxis}.
+	 */
+	public static Mixed getRotationTransform( final int fromAxis, final int toAxis, final int n )
+	{
+		if ( fromAxis == toAxis )
+			return new MixedTransform(n, n);
+
+		final MixedTransform t = new MixedTransform( n, n );
+		if ( fromAxis != toAxis )
+		{
+			final int[] component = new int[ n ];
+			final boolean[] inv = new boolean[ n ];
+			for ( int e = 0; e < n; ++e )
+			{
+				if ( e == toAxis )
+				{
+					component[ e ] = fromAxis;
+					inv[ e ] = true;
+				}
+				else if ( e == fromAxis )
+				{
+					component[ e ] = toAxis;
+				}
+				else
+				{
+					component[ e ] = e;
+				}
+			}
+			t.setComponentMapping( component );
+			t.setComponentInversion( inv );
+		}
+		return t;
+	}
+
+	/**
+	 * Create a transformation that permutes axes. fromAxis and toAxis are swapped.
+	 *
+	 * If fromAxis=0 and toAxis=2, this means that the X-axis of the source view
+	 * is mapped to the Z-Axis of the permuted view and vice versa. For a XYZ
+	 * source, a ZYX view would be created.
+	 * 
+	 * @param fromAxis
+	 * @param toAxis
+	 * @param n
+	 * @return
+	 */
+	public static Mixed getPermuteTransform( final int fromAxis, final int toAxis, final int n )
+	{
+		if ( fromAxis == toAxis )
+			return new MixedTransform(n, n);
+
+		final int[] component = new int[ n ];
+		for ( int e = 0; e < n; ++e )
+			component[ e ] = e;
+		component[ fromAxis ] = toAxis;
+		component[ toAxis ] = fromAxis;
+		final MixedTransform t = new MixedTransform( n, n );
+		t.setComponentMapping( component );
+		return t;
+	}
+
+	/**
+	 * Create a transform that takes a (n-1)-dimensional slice of a n-dimensional view, fixing
+	 * d-component of coordinates to pos.
+	 *
+	 * @param d
+	 * @param pos
+	 * @param m
+	 * @return
+	 */
+	public static MixedTransform getHyperSliceTransform( final int d, final long pos, final int m )
+	{
+		final int n = m - 1;
+		final MixedTransform t = new MixedTransform( n, m );
+		final long[] translation = new long[ m ];
+		translation[ d ] = pos;
+		final boolean[] zero = new boolean[ m ];
+		final int[] component = new int[ m ];
+		for ( int e = 0; e < m; ++e )
+		{
+			if ( e < d )
+			{
+				zero[ e ] = false;
+				component[ e ] = e;
+			}
+			else if ( e > d )
+			{
+				zero[ e ] = false;
+				component[ e ] = e - 1;
+			}
+			else
+			{
+				zero[ e ] = true;
+				component[ e ] = 0;
+			}
+		}
+		t.setTranslation( translation );
+		t.setComponentZero( zero );
+		t.setComponentMapping( component );
+		return t;
+	}
+
+	/**
+	 * Create a {@link MixedTransform} that describes the translation vector. When applied to a View, each pixel
+	 * <em>x</em> in the source view has coordinates <em>(x + translation)</em>
+	 * in the resulting view.
+	 *
+	 * @param translation
+	 *            translation vector of the source view. The pixel at <em>x</em>
+	 *            in the source view becomes <em>(x + translation)</em> in the
+	 *            resulting view.
+	 */
+	public static MixedTransform getTranslationTransform( final long... translation )
+	{
+		final int n = translation.length;
+		final MixedTransform t = new MixedTransform( n, n );
+		t.setInverseTranslation( translation );
+		return t;
+	}
+
+	/**
+	 * Return a transformation such that a pixel at offset in a randomAccessible is at the origin
+	 * in the resulting view. This is equivalent to translating by -offset.
+	 * 
+	 * @param offset
+	 *            offset of the source view. The pixel at offset becomes the
+	 *            origin of resulting view.
+	 * @return transformation
+	 */
+	public static MixedTransform getOffsetTransform(final long... offset )
+	{
+		final int n = offset.length;
+		final MixedTransform t = new MixedTransform( n, n );
+		t.setTranslation( offset );
+		return t;
+	}
+
+	/**
+	 * Create a transformation that moves an axis. fromAxis is moved to toAxis. While the
+	 * order of the other axes is preserved.
+	 *
+	 * If fromAxis=2 and toAxis=4, and axis order of image is XYCZT, then
+	 * a view to the image with axis order XYZTC would be created.
+	 */
+	public static MixedTransform getMoveAxisTransform(final int fromAxis, final int toAxis, final int n) {
+		if ( fromAxis == toAxis )
+			return new MixedTransform(n, n);
+
+		List<Integer> axisIndices = new ArrayList<>();
+		IntStream.rangeClosed(0, n - 1).forEach(axisIndices::add);
+		axisIndices.remove(fromAxis);
+		axisIndices.add(toAxis, fromAxis);
+
+		int components[] = new int[n];
+		for(int i = 0; i < n; i++) {
+			components[axisIndices.get(i)] = i;
+		}
+
+		final MixedTransform t = new MixedTransform(n, n);
+		t.setComponentMapping(components);
+		return t;
+	}
+
+	/**
+	 * Create a transformation that moves the min coordinate of the given interval to the origin
+	 *
+	 * @param interval
+	 *            the source.
+	 * @return transformation
+	 */
+	public static MixedTransform getZeroMinTransform( final Interval interval ) {
+		final int n = interval.numDimensions();
+		final long[] offset = new long[ n ];
+		interval.min( offset );
+		return MixedTransforms.getOffsetTransform(offset);
+	}
+
+	/**
+	 * Create a transformation that adds a new dimension at the end
+	 * @param currentNumDims
+	 * @return 
+	 */
+	public static MixedTransform getAddDimensionTransform( final int currentNumDims ) {
+		final int newNumDims = currentNumDims + 1;
+		return new MixedTransform(newNumDims, currentNumDims);
+	}
+
+	/**
+	 * Create a transform that inverts the d'th axis of an n-dimensional space.
+	 * @param d
+	 * @param n
+	 * @return
+	 */
+	public static MixedTransform getInvertAxisTransform( final int d , final int n ) {
+		final boolean[] inv = new boolean[ n ];
+		inv[ d ] = true;
+		final MixedTransform t = new MixedTransform( n, n );
+		t.setComponentInversion( inv );
+		return t;
+	}
+}

--- a/src/main/java/net/imglib2/view/MixedTransforms.java
+++ b/src/main/java/net/imglib2/view/MixedTransforms.java
@@ -34,6 +34,7 @@
 package net.imglib2.view;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -186,23 +187,6 @@ public class MixedTransforms
 	}
 
 	/**
-	 * Return a transformation such that a pixel at offset in a randomAccessible is at the origin
-	 * in the resulting view. This is equivalent to translating by -offset.
-	 * 
-	 * @param offset
-	 *            offset of the source view. The pixel at offset becomes the
-	 *            origin of resulting view.
-	 * @return transformation
-	 */
-	public static MixedTransform offset(final long... offset )
-	{
-		final int n = offset.length;
-		final MixedTransform t = new MixedTransform( n, n );
-		t.setTranslation( offset );
-		return t;
-	}
-
-	/**
 	 * Create a transformation that moves an axis. fromAxis is moved to toAxis. While the
 	 * order of the other axes is preserved.
 	 *
@@ -239,7 +223,8 @@ public class MixedTransforms
 		final int n = interval.numDimensions();
 		final long[] offset = new long[ n ];
 		interval.min( offset );
-		return MixedTransforms.offset(offset);
+		final long[] translation = Arrays.stream(offset).map(o -> -o).toArray();
+		return MixedTransforms.translate(translation);
 	}
 
 	/**

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -59,7 +59,7 @@ import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
 import net.imglib2.outofbounds.OutOfBoundsPeriodicFactory;
 import net.imglib2.outofbounds.OutOfBoundsRandomValueFactory;
 import net.imglib2.transform.integer.BoundingBox;
-import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.transform.integer.Mixed;
 import net.imglib2.transform.integer.permutation.AbstractPermutationTransform;
 import net.imglib2.transform.integer.permutation.PermutationTransform;
 import net.imglib2.transform.integer.permutation.SingleDimensionPermutationTransform;
@@ -487,7 +487,7 @@ public class Views
 	public static < T > RandomAccessibleInterval< T > moveAxis( final RandomAccessibleInterval< T > image, final int fromAxis, final int toAxis )
 	{
 		final int n = image.numDimensions();
-		final MixedTransform t = MixedTransforms.getMoveAxisTransform(fromAxis, toAxis, n);
+		final Mixed t = MixedTransforms.getMoveAxisTransform(fromAxis, toAxis, n);
 		final int[] newAxisIndices = new int[n];
 		t.getComponentMapping(newAxisIndices);
 
@@ -515,7 +515,7 @@ public class Views
 	 */
 	public static < T > MixedTransformView< T > translate( final RandomAccessible< T > randomAccessible, final long... translation )
 	{
-		final MixedTransform t = MixedTransforms.getTranslationTransform(translation);
+		final Mixed t = MixedTransforms.getTranslationTransform(translation);
 		return new MixedTransformView<>( randomAccessible, t );
 	}
 
@@ -550,7 +550,7 @@ public class Views
 	 */
 	public static < T > MixedTransformView< T > offset( final RandomAccessible< T > randomAccessible, final long... offset )
 	{
-		final MixedTransform t = MixedTransforms.getOffsetTransform(offset);
+		final Mixed t = MixedTransforms.getOffsetTransform(offset);
 		return new MixedTransformView<>( randomAccessible, t );
 	}
 
@@ -566,18 +566,10 @@ public class Views
 	 */
 	public static < T > IntervalView< T > offset( final RandomAccessibleInterval< T > interval, final long... offset )
 	{
-		final int n = interval.numDimensions();
-		final long[] min = new long[ n ];
-		final long[] max = new long[ n ];
-		interval.min( min );
-		interval.max( max );
-		for ( int d = 0; d < n; ++d )
-		{
-			min[ d ] -= offset[ d ];
-			max[ d ] -= offset[ d ];
+		final Mixed t = MixedTransforms.getOffsetTransform(offset);
+		final Interval newInterval = Intervals.offset(interval, offset);
+		return Views.interval(new MixedTransformView<>( (RandomAccessible<T>)interval, t ), newInterval);
 		}
-		return Views.interval( Views.offset( ( RandomAccessible< T > ) interval, offset ), min, max );
-	}
 
 	/**
 	 * Translate the source such that the upper left corner is at the origin
@@ -588,15 +580,11 @@ public class Views
 	 */
 	public static < T > IntervalView< T > zeroMin( final RandomAccessibleInterval< T > interval )
 	{
-		final int n = interval.numDimensions();
-		final long[] min = new long[ n ];
-		final long[] max = new long[ n ];
-		final long[] offset = new long[ n ];
-		interval.min( offset );
-		interval.max( max );
-		for ( int d = 0; d < n; ++d )
-			max[ d ] -= offset[ d ];
-		return Views.interval( new MixedTransformView<>( interval, MixedTransforms.getZeroMinTransform(interval) ), min, max );
+		final Mixed t = MixedTransforms.getZeroMinTransform(interval);
+		final long[] offset = new long[interval.numDimensions()];
+		interval.min(offset);
+		final Interval newInterval = Intervals.offset(interval, offset);
+		return Views.interval( new MixedTransformView<>( interval, t), newInterval );
 	}
 
 	/**
@@ -606,7 +594,7 @@ public class Views
 	public static < T > MixedTransformView< T > hyperSlice( final RandomAccessible< T > view, final int d, final long pos )
 	{
 		final int m = view.numDimensions();
-		final MixedTransform t = MixedTransforms.getHyperSliceTransform(d, pos, m);
+		final Mixed t = MixedTransforms.getHyperSliceTransform(d, pos, m);
 		return new MixedTransformView<>( view, t );
 	}
 

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -514,8 +514,8 @@ public class Views
 	 */
 	public static < T > MixedTransformView< T > offset( final RandomAccessible< T > randomAccessible, final long... offset )
 	{
-		final Mixed t = MixedTransforms.offset(offset);
-		return new MixedTransformView<>( randomAccessible, t );
+		final long[] translation = Arrays.stream(offset).map(o -> -o).toArray();
+		return Views.translate(randomAccessible, translation);
 	}
 
 	/**
@@ -530,10 +530,9 @@ public class Views
 	 */
 	public static < T > IntervalView< T > offset( final RandomAccessibleInterval< T > interval, final long... offset )
 	{
-		final Mixed t = MixedTransforms.offset(offset);
-		final Interval newInterval = Intervals.offset(interval, offset);
-		return Views.interval(new MixedTransformView<>( (RandomAccessible<T>)interval, t ), newInterval);
-		}
+		final long[] translation = Arrays.stream(offset).map(o -> -o).toArray();
+		return Views.translate(interval, translation);
+	}
 
 	/**
 	 * Translate the source such that the upper left corner is at the origin
@@ -547,7 +546,8 @@ public class Views
 		final Mixed t = MixedTransforms.zeroMin(interval);
 		final long[] offset = new long[interval.numDimensions()];
 		interval.min(offset);
-		final Interval newInterval = Intervals.offset(interval, offset);
+		final long[] translation = Arrays.stream(offset).map(o -> -o).toArray();
+		final Interval newInterval = Intervals.translate(interval, translation);
 		return Views.interval( new MixedTransformView<>( interval, t), newInterval );
 	}
 

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -395,7 +395,7 @@ public class Views
 	public static < T > MixedTransformView< T > rotate( final RandomAccessible< T > randomAccessible, final int fromAxis, final int toAxis )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, MixedTransforms.getRotationTransform(fromAxis, toAxis, n) );
+		return new MixedTransformView<>( randomAccessible, MixedTransforms.rotate( fromAxis, toAxis, n ) );
 	}
 
 	/**
@@ -424,7 +424,7 @@ public class Views
 	public static < T > MixedTransformView< T > permute( final RandomAccessible< T > randomAccessible, final int fromAxis, final int toAxis )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, MixedTransforms.getPermuteTransform(fromAxis, toAxis, n) );
+		return new MixedTransformView<>( randomAccessible, MixedTransforms.permute(fromAxis, toAxis, n) );
 	}
 
 	/**
@@ -448,7 +448,7 @@ public class Views
 	 */
 	public static < T > RandomAccessible< T > moveAxis( final RandomAccessible< T > image, final int fromAxis, final int toAxis )
 	{
-		return new MixedTransformView<>( image, MixedTransforms.getMoveAxisTransform( fromAxis, toAxis, image.numDimensions() ) );
+		return new MixedTransformView<>( image, MixedTransforms.moveAxis( fromAxis, toAxis, image.numDimensions() ) );
 	}
 
 	/**
@@ -461,7 +461,7 @@ public class Views
 	public static < T > RandomAccessibleInterval< T > moveAxis( final RandomAccessibleInterval< T > image, final int fromAxis, final int toAxis )
 	{
 		final int n = image.numDimensions();
-		final Mixed t = MixedTransforms.getMoveAxisTransform( fromAxis, toAxis, n );
+		final Mixed t = MixedTransforms.moveAxis( fromAxis, toAxis, n );
 		return Views.interval( new MixedTransformView<>( image, t ), Intervals.moveAxis( image, fromAxis, toAxis ) );
 	}
 
@@ -479,7 +479,7 @@ public class Views
 	 */
 	public static < T > MixedTransformView< T > translate( final RandomAccessible< T > randomAccessible, final long... translation )
 	{
-		final Mixed t = MixedTransforms.getTranslationTransform( translation );
+		final Mixed t = MixedTransforms.translate( translation );
 		return new MixedTransformView<>( randomAccessible, t );
 	}
 
@@ -514,7 +514,7 @@ public class Views
 	 */
 	public static < T > MixedTransformView< T > offset( final RandomAccessible< T > randomAccessible, final long... offset )
 	{
-		final Mixed t = MixedTransforms.getOffsetTransform(offset);
+		final Mixed t = MixedTransforms.offset(offset);
 		return new MixedTransformView<>( randomAccessible, t );
 	}
 
@@ -530,7 +530,7 @@ public class Views
 	 */
 	public static < T > IntervalView< T > offset( final RandomAccessibleInterval< T > interval, final long... offset )
 	{
-		final Mixed t = MixedTransforms.getOffsetTransform(offset);
+		final Mixed t = MixedTransforms.offset(offset);
 		final Interval newInterval = Intervals.offset(interval, offset);
 		return Views.interval(new MixedTransformView<>( (RandomAccessible<T>)interval, t ), newInterval);
 		}
@@ -544,7 +544,7 @@ public class Views
 	 */
 	public static < T > IntervalView< T > zeroMin( final RandomAccessibleInterval< T > interval )
 	{
-		final Mixed t = MixedTransforms.getZeroMinTransform(interval);
+		final Mixed t = MixedTransforms.zeroMin(interval);
 		final long[] offset = new long[interval.numDimensions()];
 		interval.min(offset);
 		final Interval newInterval = Intervals.offset(interval, offset);
@@ -558,7 +558,7 @@ public class Views
 	public static < T > MixedTransformView< T > hyperSlice( final RandomAccessible< T > view, final int d, final long pos )
 	{
 		final int m = view.numDimensions();
-		final Mixed t = MixedTransforms.getHyperSliceTransform(d, pos, m);
+		final Mixed t = MixedTransforms.hyperSlice(d, pos, m);
 		return new MixedTransformView<>( view, t );
 	}
 
@@ -586,7 +586,7 @@ public class Views
 	{
 		final int m = randomAccessible.numDimensions();
 		
-		return new MixedTransformView<>( randomAccessible, MixedTransforms.getAddDimensionTransform(m) );
+		return new MixedTransformView<>( randomAccessible, MixedTransforms.addDimension(m) );
 	}
 
 	/**
@@ -621,7 +621,7 @@ public class Views
 	public static < T > MixedTransformView< T > invertAxis( final RandomAccessible< T > randomAccessible, final int d )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, MixedTransforms.getInvertAxisTransform( d, n ) );
+		return new MixedTransformView<>( randomAccessible, MixedTransforms.invertAxis( d, n ) );
 	}
 
 	/**

--- a/src/test/java/net/imglib2/util/IntervalsTest.java
+++ b/src/test/java/net/imglib2/util/IntervalsTest.java
@@ -1,0 +1,133 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.util;
+
+import org.junit.Test;
+
+import net.imglib2.Interval;
+import net.imglib2.test.ImgLib2Assert;
+
+public class IntervalsTest 
+{
+    @Test
+    public void testTranslateDim() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.translate( input, 10, 0 );
+		final Interval expected = Intervals.createMinMax( 11, 2, 3, 15, 7, 9 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+
+    @Test
+    public void testTranslateUsesCorrectOverload() {
+        final Interval input = Intervals.createMinMax( 1, 2, 5, 7 );
+        // when the number of axes equals 2, then both translate() methods are applicable. 
+        // Which one is used?
+		final Interval result = Intervals.translate( input, 10, (long)1 );
+		final Interval expected = Intervals.createMinMax( 11, 3, 15, 8 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+
+    @Test
+    public void testTranslateDimNegative() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.translate( input, -10, 2 );
+		final Interval expected = Intervals.createMinMax( 1, 2, -7, 5, 7, -1 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+
+    @Test
+    public void testTranslate() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.translate( input, 10, 9, 8 );
+		final Interval expected = Intervals.createMinMax( 11, 11, 11, 15, 16, 17 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+
+    @Test
+    public void testTranslateNegative() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.translate( input, -10, -11, -12 );
+		final Interval expected = Intervals.createMinMax( -9, -9, -9, -5, -4, -3 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+
+    @Test
+	public void testRotate() {
+		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.rotate( input, 1, 0 );
+		final Interval expected = Intervals.createMinMax( 2, -5, 3, 7, -1, 9 );
+		ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+    
+    @Test
+	public void testAddDimension() {
+		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.addDimension( input, 4, 11 );
+		final Interval expected = Intervals.createMinMax( 1, 2, 3, 4, 5, 7, 9, 11 );
+		ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+    
+    @Test
+	public void testInvertAxis() {
+		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.invertAxis( input, 1 );
+		final Interval expected = Intervals.createMinMax( 1, -7, 3, 5, -2, 9 );
+		ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+    
+    @Test
+	public void testMoveAxis() {
+		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.moveAxis( input, 0, 2 );
+		final Interval expected = Intervals.createMinMax( 2, 3, 1, 7, 9, 5 );
+		ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+    
+    @Test
+	public void testPermuteAxis() {
+		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.permuteAxes( input, 0, 2 );
+		final Interval expected = Intervals.createMinMax( 3, 2, 1, 9, 7, 5 );
+		ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
+    
+    @Test
+	public void testHyperSlice() {
+		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+		final Interval result = Intervals.hyperSlice( input, 2 );
+		final Interval expected = Intervals.createMinMax( 1, 2, 5, 7 );
+		ImgLib2Assert.assertIntervalEquals( expected, result );
+	}
+}

--- a/src/test/java/net/imglib2/util/IntervalsTest.java
+++ b/src/test/java/net/imglib2/util/IntervalsTest.java
@@ -44,8 +44,8 @@ public class IntervalsTest
     @Test
     public void testTranslateDim() {
         final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.translate( input, 10, 0 );
-		final Interval expected = Intervals.createMinMax( 11, 2, 3, 15, 7, 9 );
+        final Interval result = Intervals.translate( input, 10, 0 );
+        final Interval expected = Intervals.createMinMax( 11, 2, 3, 15, 7, 9 );
         ImgLib2Assert.assertIntervalEquals( expected, result );
     }
 
@@ -54,80 +54,80 @@ public class IntervalsTest
         final Interval input = Intervals.createMinMax( 1, 2, 5, 7 );
         // when the number of axes equals 2, then both translate() methods are applicable. 
         // Which one is used?
-		final Interval result = Intervals.translate( input, 10, (long)1 );
-		final Interval expected = Intervals.createMinMax( 11, 3, 15, 8 );
+        final Interval result = Intervals.translate( input, 10, (long)1 );
+        final Interval expected = Intervals.createMinMax( 11, 3, 15, 8 );
         ImgLib2Assert.assertIntervalEquals( expected, result );
     }
 
     @Test
     public void testTranslateDimNegative() {
         final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.translate( input, -10, 2 );
-		final Interval expected = Intervals.createMinMax( 1, 2, -7, 5, 7, -1 );
+        final Interval result = Intervals.translate( input, -10, 2 );
+        final Interval expected = Intervals.createMinMax( 1, 2, -7, 5, 7, -1 );
         ImgLib2Assert.assertIntervalEquals( expected, result );
     }
 
     @Test
     public void testTranslate() {
         final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.translate( input, 10, 9, 8 );
-		final Interval expected = Intervals.createMinMax( 11, 11, 11, 15, 16, 17 );
+        final Interval result = Intervals.translate( input, 10, 9, 8 );
+        final Interval expected = Intervals.createMinMax( 11, 11, 11, 15, 16, 17 );
         ImgLib2Assert.assertIntervalEquals( expected, result );
     }
 
     @Test
     public void testTranslateNegative() {
         final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.translate( input, -10, -11, -12 );
-		final Interval expected = Intervals.createMinMax( -9, -9, -9, -5, -4, -3 );
+        final Interval result = Intervals.translate( input, -10, -11, -12 );
+        final Interval expected = Intervals.createMinMax( -9, -9, -9, -5, -4, -3 );
         ImgLib2Assert.assertIntervalEquals( expected, result );
     }
 
     @Test
-	public void testRotate() {
-		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.rotate( input, 1, 0 );
-		final Interval expected = Intervals.createMinMax( 2, -5, 3, 7, -1, 9 );
-		ImgLib2Assert.assertIntervalEquals( expected, result );
+    public void testRotate() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+        final Interval result = Intervals.rotate( input, 1, 0 );
+        final Interval expected = Intervals.createMinMax( 2, -5, 3, 7, -1, 9 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
     }
     
     @Test
-	public void testAddDimension() {
-		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.addDimension( input, 4, 11 );
-		final Interval expected = Intervals.createMinMax( 1, 2, 3, 4, 5, 7, 9, 11 );
-		ImgLib2Assert.assertIntervalEquals( expected, result );
+    public void testAddDimension() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+        final Interval result = Intervals.addDimension( input, 4, 11 );
+        final Interval expected = Intervals.createMinMax( 1, 2, 3, 4, 5, 7, 9, 11 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
     }
     
     @Test
-	public void testInvertAxis() {
-		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.invertAxis( input, 1 );
-		final Interval expected = Intervals.createMinMax( 1, -7, 3, 5, -2, 9 );
-		ImgLib2Assert.assertIntervalEquals( expected, result );
+    public void testInvertAxis() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+        final Interval result = Intervals.invertAxis( input, 1 );
+        final Interval expected = Intervals.createMinMax( 1, -7, 3, 5, -2, 9 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
     }
     
     @Test
-	public void testMoveAxis() {
-		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.moveAxis( input, 0, 2 );
-		final Interval expected = Intervals.createMinMax( 2, 3, 1, 7, 9, 5 );
-		ImgLib2Assert.assertIntervalEquals( expected, result );
+    public void testMoveAxis() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+        final Interval result = Intervals.moveAxis( input, 0, 2 );
+        final Interval expected = Intervals.createMinMax( 2, 3, 1, 7, 9, 5 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
     }
     
     @Test
-	public void testPermuteAxis() {
-		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.permuteAxes( input, 0, 2 );
-		final Interval expected = Intervals.createMinMax( 3, 2, 1, 9, 7, 5 );
-		ImgLib2Assert.assertIntervalEquals( expected, result );
+    public void testPermuteAxis() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+        final Interval result = Intervals.permuteAxes( input, 0, 2 );
+        final Interval expected = Intervals.createMinMax( 3, 2, 1, 9, 7, 5 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
     }
     
     @Test
-	public void testHyperSlice() {
-		final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Interval result = Intervals.hyperSlice( input, 2 );
-		final Interval expected = Intervals.createMinMax( 1, 2, 5, 7 );
-		ImgLib2Assert.assertIntervalEquals( expected, result );
-	}
+    public void testHyperSlice() {
+        final Interval input = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+        final Interval result = Intervals.hyperSlice( input, 2 );
+        final Interval expected = Intervals.createMinMax( 1, 2, 5, 7 );
+        ImgLib2Assert.assertIntervalEquals( expected, result );
+    }
 }

--- a/src/test/java/net/imglib2/view/MixedTransformsTest.java
+++ b/src/test/java/net/imglib2/view/MixedTransformsTest.java
@@ -1,0 +1,131 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.view;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+import net.imglib2.Interval;
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.transform.integer.Mixed;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Localizables;
+
+public class MixedTransformsTest 
+{
+    @Test
+    public void testTranslate() {
+        RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
+        Mixed transform = MixedTransforms.translate(10, 9, 8);
+		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {10, 11, 12} );
+		assertArrayEquals( new long[] {0, 2, 4}, Localizables.asLongArray( ra.get() ) );
+    }
+
+    @Test
+    public void testRotate() {
+        RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
+        Mixed transform = MixedTransforms.rotate( 1, 0, input.numDimensions() );
+        RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {2, -1, 3} );
+		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+    }
+
+    @Test
+    public void testPermute() {
+        RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
+        Mixed transform = MixedTransforms.permute( 0, 2, input.numDimensions() );
+		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {3, 2, 1} );
+		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+    }
+
+    @Test
+    public void testMoveAxis() {
+        RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
+        Mixed transform = MixedTransforms.moveAxis( 0, 2, input.numDimensions() );
+		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {2, 3, 1} );
+		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+    }
+
+    @Test
+    public void testInvertAxis() {
+        RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
+        Mixed transform = MixedTransforms.invertAxis( 1, input.numDimensions() );
+		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {1, -2, 3} );
+		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+    }
+
+    @Test
+    public void testZeroMin() {
+        RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
+        final Interval interval = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
+        Mixed transform = MixedTransforms.zeroMin(interval);
+		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {0, 0, 0} );
+		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+    }
+
+    @Test
+    public void testAddDimension() {
+        RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
+        Mixed transform = MixedTransforms.addDimension( input.numDimensions() );
+		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {1, 2, 3, 17} );
+		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+    }
+
+    @Test
+    public void testHyperSlice() {
+        RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
+        Mixed transform = MixedTransforms.hyperSlice( 2, 3, input.numDimensions() );
+		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+		RandomAccess< Localizable > ra = view.randomAccess();
+		ra.setPosition( new long[] {1, 2} );
+		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+    }
+}

--- a/src/test/java/net/imglib2/view/MixedTransformsTest.java
+++ b/src/test/java/net/imglib2/view/MixedTransformsTest.java
@@ -52,10 +52,10 @@ public class MixedTransformsTest
     public void testTranslate() {
         RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
         Mixed transform = MixedTransforms.translate(10, 9, 8);
-		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {10, 11, 12} );
-		assertArrayEquals( new long[] {0, 2, 4}, Localizables.asLongArray( ra.get() ) );
+        RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+        RandomAccess< Localizable > ra = view.randomAccess();
+        ra.setPosition( new long[] {10, 11, 12} );
+        assertArrayEquals( new long[] {0, 2, 4}, Localizables.asLongArray( ra.get() ) );
     }
 
     @Test
@@ -63,39 +63,39 @@ public class MixedTransformsTest
         RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
         Mixed transform = MixedTransforms.rotate( 1, 0, input.numDimensions() );
         RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {2, -1, 3} );
-		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+        RandomAccess< Localizable > ra = view.randomAccess();
+        ra.setPosition( new long[] {2, -1, 3} );
+        assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
     }
 
     @Test
     public void testPermute() {
         RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
         Mixed transform = MixedTransforms.permute( 0, 2, input.numDimensions() );
-		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {3, 2, 1} );
-		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+        RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+        RandomAccess< Localizable > ra = view.randomAccess();
+        ra.setPosition( new long[] {3, 2, 1} );
+        assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
     }
 
     @Test
     public void testMoveAxis() {
         RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
         Mixed transform = MixedTransforms.moveAxis( 0, 2, input.numDimensions() );
-		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {2, 3, 1} );
-		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+        RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+        RandomAccess< Localizable > ra = view.randomAccess();
+        ra.setPosition( new long[] {2, 3, 1} );
+        assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
     }
 
     @Test
     public void testInvertAxis() {
         RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
         Mixed transform = MixedTransforms.invertAxis( 1, input.numDimensions() );
-		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {1, -2, 3} );
-		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+        RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+        RandomAccess< Localizable > ra = view.randomAccess();
+        ra.setPosition( new long[] {1, -2, 3} );
+        assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
     }
 
     @Test
@@ -103,29 +103,29 @@ public class MixedTransformsTest
         RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
         final Interval interval = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
         Mixed transform = MixedTransforms.zeroMin(interval);
-		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {0, 0, 0} );
-		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+        RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+        RandomAccess< Localizable > ra = view.randomAccess();
+        ra.setPosition( new long[] {0, 0, 0} );
+        assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
     }
 
     @Test
     public void testAddDimension() {
         RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
         Mixed transform = MixedTransforms.addDimension( input.numDimensions() );
-		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {1, 2, 3, 17} );
-		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+        RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+        RandomAccess< Localizable > ra = view.randomAccess();
+        ra.setPosition( new long[] {1, 2, 3, 17} );
+        assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
     }
 
     @Test
     public void testHyperSlice() {
         RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
         Mixed transform = MixedTransforms.hyperSlice( 2, 3, input.numDimensions() );
-		RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {1, 2} );
-		assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
+        RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
+        RandomAccess< Localizable > ra = view.randomAccess();
+        ra.setPosition( new long[] {1, 2} );
+        assertArrayEquals( new long[] {1, 2, 3}, Localizables.asLongArray( ra.get() ) );
     }
 }


### PR DESCRIPTION
This PR basically moves a lot of the code hidden in the static methods in `Views` into helper methods that create `MixedTransform`s or modify `Interval`s. 

The intention behind this refactoring is to simplify the application of a transformation -- e.g. one that was applied to image data -- also to other corresponding objects like metadata.

The API of `Views` remains unchanged, and the tests that currently pass on master also pass after this refactoring.

CC: @gab1one @MarcelWiedenmann @dietzc @HedgehogCode