### PR TITLE
Add Views.translateInverse() to replace Views.offset()

### DIFF
--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -170,6 +170,7 @@ public class Intervals
 	{
 		return expand( interval, new FinalDimensions( border ) );
 	}
+
 	/**
 	 * Grow/shrink an interval in all dimensions.
 	 * 
@@ -272,6 +273,33 @@ public class Intervals
 		{
 			min[ d ] += translation[ d ];
 			max[ d ] += translation[ d ];
+		}
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Translate an interval by {@code -translation}.
+	 *
+	 * Create a {@link FinalInterval}, which is the input interval shifted by
+	 * {@code -translation}.
+	 *
+	 * @param interval
+	 *            the input interval
+	 * @param translation
+	 *            by how many pixels to inverse-shift the interval
+	 * @return translated interval
+	 */
+	public static FinalInterval translateInverse( final Interval interval, final long... translation )
+	{
+		final int n = interval.numDimensions();
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		interval.min( min );
+		interval.max( max );
+		for ( int d = 0; d < n; ++d )
+		{
+			min[ d ] -= translation[ d ];
+			max[ d ] -= translation[ d ];
 		}
 		return new FinalInterval( min, max );
 	}

--- a/src/main/java/net/imglib2/view/ViewTransforms.java
+++ b/src/main/java/net/imglib2/view/ViewTransforms.java
@@ -176,7 +176,7 @@ public class ViewTransforms
 	 * Warning: The transformation used by a view in {@link Views} is always
 	 * inverse to the operation that is performed by the View.
 	 * <p>
-	 * Therefor this method actually returns the inverse translation.
+	 * Therefore this method actually returns the inverse translation.
 	 */
 	public static MixedTransform translate( final long... translation )
 	{
@@ -188,12 +188,29 @@ public class ViewTransforms
 
 	/**
 	 * Returns the transformation that is used by
+	 * {@link Views#translateInverse(RandomAccessible, long...)}.
+	 * <p>
+	 * Warning: The transformation used by a view in {@link Views} is always
+	 * inverse to the operation that is performed by the View.
+	 * <p>
+	 * Therefore this method actually returns the (not inverse) translation.
+	 */
+	public static MixedTransform translateInverse( final long... translation )
+	{
+		final int n = translation.length;
+		final MixedTransform t = new MixedTransform( n, n );
+		t.setTranslation( translation );
+		return t;
+	}
+
+	/**
+	 * Returns the transformation that is used by
 	 * {@link Views#moveAxis(RandomAccessible, int, int)}.
 	 * <p>
 	 * Warning: The transformation used by a view in {@link Views} is always
 	 * inverse to the operation that is performed by the View.
 	 * <p>
-	 * Therefor the axis permutation return by this method
+	 * Therefore the axis permutation return by this method
 	 * is actually inverse as described in {@link Views#moveAxis(RandomAccessible, int, int)}.
 	 */
 	public static MixedTransform moveAxis( final int numDimensions, final int fromAxis, final int toAxis )

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -503,11 +503,56 @@ public class Views
 	}
 
 	/**
-	 * @deprecated Please use {@link Views#translate(RandomAccessible, long...)}
-	 * with a negative offset instead.
+	 * Translate the source view by the given inverse translation vector. Pixel
+	 * <em>x</em> in the source view has coordinates <em>(x - translation)</em>
+	 * in the resulting view.
 	 * <p>
+	 * The effect is that the pixel at {@code translation} in
+	 * {@code randomAccessible} is at the origin in the resulting view.
+	 *
+	 * @param randomAccessible
+	 *            the source
+	 * @param translation
+	 *            inverse translation vector of the source view. The pixel at
+	 *            <em>x</em> in the source view becomes <em>(x -
+	 *            translation)</em> in the resulting view.
+	 */
+	public static < T > MixedTransformView< T > translateInverse( final RandomAccessible< T > randomAccessible, final long... translation )
+	{
+		final Mixed t = ViewTransforms.translateInverse( translation );
+		return new MixedTransformView<>( randomAccessible, t );
+	}
+
+	/**
+	 * Translate the source view by the given inverse translation vector. Pixel
+	 * <em>x</em> in the source view has coordinates <em>(x - translation)</em>
+	 * in the resulting view.
+	 * <p>
+	 * The effect is that the pixel at {@code translation} in {@code interval}
+	 * is at the origin in the resulting view.
+	 *
+	 * @param interval
+	 *            the source
+	 * @param translation
+	 *            inverse translation vector of the source view. The pixel at
+	 *            <em>x</em> in the source view becomes <em>(x -
+	 *            translation)</em> in the resulting view.
+	 */
+	public static < T > IntervalView< T > translateInverse( final RandomAccessibleInterval< T > interval, final long... translation )
+	{
+		return Views.interval(
+				Views.translateInverse( ( RandomAccessible< T > ) interval, translation ),
+				Intervals.translateInverse( interval, translation ) );
+	}
+
+	/**
 	 * Translate such that pixel at offset in randomAccessible is at the origin
 	 * in the resulting view. This is equivalent to translating by -offset.
+	 *
+	 * @deprecated Please use
+	 *             {@link Views#translateInverse(RandomAccessible, long...)}
+	 *             instead.
+	 *
 	 * @param randomAccessible
 	 *            the source
 	 * @param offset
@@ -517,16 +562,16 @@ public class Views
 	@Deprecated
 	public static < T > MixedTransformView< T > offset( final RandomAccessible< T > randomAccessible, final long... offset )
 	{
-		final long[] translation = Arrays.stream( offset ).map( o -> -o ).toArray();
-		return Views.translate( randomAccessible, translation );
+		return Views.translateInverse( randomAccessible, offset );
 	}
 
 	/**
-	 * @deprecated Please use {@link Views#translate(RandomAccessibleInterval, long...)}
-	 * with a negative offset instead.
-	 * <p>
 	 * Translate such that pixel at offset in interval is at the origin in the
 	 * resulting view. This is equivalent to translating by -offset.
+	 *
+	 * @deprecated Please use
+	 *             {@link Views#translateInverse(RandomAccessibleInterval, long...)}
+	 *             instead.
 	 *
 	 * @param interval
 	 *            the source
@@ -537,8 +582,7 @@ public class Views
 	@Deprecated
 	public static < T > IntervalView< T > offset( final RandomAccessibleInterval< T > interval, final long... offset )
 	{
-		final long[] translation = Arrays.stream( offset ).map( o -> -o ).toArray();
-		return Views.translate( interval, translation );
+		return Views.translateInverse( interval, offset );
 	}
 
 	/**


### PR DESCRIPTION
This adds `Views.translateInverse` to replace the recently deprecated (because of naming) `Views.offset`. Following recently merged (#238) split of functionality out of `Views`, corresponding `Intervals.translateInverse` and `MixedTransforms.translateInverse` methods are also introduced (and used).

@hanslovsky @maarzt Does this work for everybody?