### PR TITLE
Rename MixedTransform to InverseTransform

### DIFF
--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -362,7 +362,7 @@ public class Intervals
 	public static FinalInterval moveAxis( final Interval interval, final int fromAxis, final int toAxis )
 	{
 		final int n = interval.numDimensions();
-		final Mixed t = ViewTransforms.moveAxis( fromAxis, toAxis, n );
+		final Mixed t = ViewTransforms.moveAxis( n, fromAxis, toAxis );
 		final int[] newAxisIndices = new int[ n ];
 		t.getComponentMapping( newAxisIndices );
 

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -43,7 +43,7 @@ import net.imglib2.Localizable;
 import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.transform.integer.Mixed;
-import net.imglib2.view.MixedTransforms;
+import net.imglib2.view.ViewTransforms;
 
 /**
  * Convenience methods for manipulating {@link Interval Intervals}.
@@ -362,7 +362,7 @@ public class Intervals
 	public static FinalInterval moveAxis( final Interval interval, final int fromAxis, final int toAxis )
 	{
 		final int n = interval.numDimensions();
-		final Mixed t = MixedTransforms.moveAxis( fromAxis, toAxis, n );
+		final Mixed t = ViewTransforms.moveAxis( fromAxis, toAxis, n );
 		final int[] newAxisIndices = new int[ n ];
 		t.getComponentMapping( newAxisIndices );
 

--- a/src/main/java/net/imglib2/view/ViewTransforms.java
+++ b/src/main/java/net/imglib2/view/ViewTransforms.java
@@ -49,7 +49,7 @@ import net.imglib2.transform.integer.MixedTransform;
  * @author Tobias Pietzsch
  * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
  */
-public class MixedTransforms
+public class ViewTransforms
 {
 	/**
 	 * Create a {@link MixedTransform} that rotates by 90 degrees. The rotation
@@ -230,7 +230,7 @@ public class MixedTransforms
 		final long[] offset = new long[ n ];
 		interval.min( offset );
 		final long[] translation = Arrays.stream( offset ).map( o -> -o ).toArray();
-		return MixedTransforms.translate( translation );
+		return ViewTransforms.translate( translation );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/view/ViewTransforms.java
+++ b/src/main/java/net/imglib2/view/ViewTransforms.java
@@ -66,17 +66,17 @@ public class ViewTransforms
 	 * The rotation returned by this operation therefore is inverse to the
 	 * rotation described in {@link Views#rotate(RandomAccessible, int, int)}
 	 */
-	public static Mixed rotate( final int fromAxis, final int toAxis, final int n )
+	public static Mixed rotate( final int numDimensions, final int fromAxis, final int toAxis )
 	{
 		if ( fromAxis == toAxis )
-			return new MixedTransform( n, n );
+			return new MixedTransform( numDimensions, numDimensions );
 
-		final MixedTransform t = new MixedTransform( n, n );
+		final MixedTransform t = new MixedTransform( numDimensions, numDimensions );
 		if ( fromAxis != toAxis )
 		{
-			final int[] component = new int[ n ];
-			final boolean[] inv = new boolean[ n ];
-			for ( int e = 0; e < n; ++e )
+			final int[] component = new int[ numDimensions ];
+			final boolean[] inv = new boolean[ numDimensions ];
+			for ( int e = 0; e < numDimensions; ++e )
 			{
 				if ( e == toAxis )
 				{
@@ -107,17 +107,17 @@ public class ViewTransforms
 	 * But that's not important for this type of permutation. As
 	 * the permutation stays the same when inverted.
 	 */
-	public static Mixed permute( final int fromAxis, final int toAxis, final int n )
+	public static Mixed permute( final int numDimensions, final int fromAxis, final int toAxis )
 	{
 		if ( fromAxis == toAxis )
-			return new MixedTransform( n, n );
+			return new MixedTransform( numDimensions, numDimensions );
 
-		final int[] component = new int[ n ];
-		for ( int e = 0; e < n; ++e )
+		final int[] component = new int[ numDimensions ];
+		for ( int e = 0; e < numDimensions; ++e )
 			component[ e ] = e;
 		component[ fromAxis ] = toAxis;
 		component[ toAxis ] = fromAxis;
-		final MixedTransform t = new MixedTransform( n, n );
+		final MixedTransform t = new MixedTransform( numDimensions, numDimensions );
 		t.setComponentMapping( component );
 		return t;
 	}
@@ -130,22 +130,22 @@ public class ViewTransforms
 	 * inverse to the operations that are performed by the views.
 	 * <p>
 	 *
-	 * @param n             Number of dimensions including that dimension
+	 * @param numDimensions Number of dimensions including that dimension
 	 *                      that is sliced / inserted.
 	 * @param d             Index of that dimension that is sliced / inserted.
 	 * @param pos           Position of the slice / value of the coordinate that's
 	 *                      inserted.
 	 * @return Transformation that inserts a coordinate at the given index.
 	 */
-	public static MixedTransform hyperSlice( final int d, final long pos, final int m )
+	public static MixedTransform hyperSlice( final int numDimensions, final int d, final long pos )
 	{
-		final int n = m - 1;
-		final MixedTransform t = new MixedTransform( n, m );
-		final long[] translation = new long[ m ];
+		final int n = numDimensions - 1;
+		final MixedTransform t = new MixedTransform( n, numDimensions );
+		final long[] translation = new long[ numDimensions ];
 		translation[ d ] = pos;
-		final boolean[] zero = new boolean[ m ];
-		final int[] component = new int[ m ];
-		for ( int e = 0; e < m; ++e )
+		final boolean[] zero = new boolean[ numDimensions ];
+		final int[] component = new int[ numDimensions ];
+		for ( int e = 0; e < numDimensions; ++e )
 		{
 			if ( e < d )
 			{
@@ -196,23 +196,23 @@ public class ViewTransforms
 	 * Therefor the axis permutation return by this method
 	 * is actually inverse as described in {@link Views#moveAxis(RandomAccessible, int, int)}.
 	 */
-	public static MixedTransform moveAxis( final int fromAxis, final int toAxis, final int n )
+	public static MixedTransform moveAxis( final int numDimensions, final int fromAxis, final int toAxis )
 	{
 		if ( fromAxis == toAxis )
-			return new MixedTransform( n, n );
+			return new MixedTransform( numDimensions, numDimensions );
 
 		final List< Integer > axisIndices = new ArrayList<>();
-		IntStream.rangeClosed( 0, n - 1 ).forEach( axisIndices::add );
+		IntStream.rangeClosed( 0, numDimensions - 1 ).forEach( axisIndices::add );
 		axisIndices.remove( fromAxis );
 		axisIndices.add( toAxis, fromAxis );
 
-		final int components[] = new int[ n ];
-		for ( int i = 0; i < n; i++ )
+		final int components[] = new int[ numDimensions ];
+		for ( int i = 0; i < numDimensions; i++ )
 		{
 			components[ axisIndices.get( i ) ] = i;
 		}
 
-		final MixedTransform t = new MixedTransform( n, n );
+		final MixedTransform t = new MixedTransform( numDimensions, numDimensions );
 		t.setComponentMapping( components );
 		return t;
 	}
@@ -240,14 +240,14 @@ public class ViewTransforms
 	 * Warning: The transformation used by a view in {@link Views} is always
 	 * inverse to the operation that is performed by the View.
 	 *
-	 * @param currentNumDims Number of dimensions not including
+	 * @param numDimensions Number of dimensions without
 	 *                       the coordinate that's added/removed.
 	 * @return A transformation that removes the last coordinate.
 	 */
-	public static MixedTransform addDimension( final int currentNumDims )
+	public static MixedTransform addDimension( final int numDimensions )
 	{
-		final int newNumDims = currentNumDims + 1;
-		return new MixedTransform( newNumDims, currentNumDims );
+		final int newNumDims = numDimensions + 1;
+		return new MixedTransform( newNumDims, numDimensions );
 	}
 
 	/**
@@ -260,15 +260,15 @@ public class ViewTransforms
 	 * is the axis inversion itself.
 	 * <p>
 	 *
+	 * @param numDimensions Number of dimensions of the coordinate space.
 	 * @param d Index of the coordinate that's inverted.
-	 * @param n Number of dimensions of the coordinate space.
 	 * @return Transformation that inverts the specified coordinate.
 	 */
-	public static MixedTransform invertAxis( final int d, final int n )
+	public static MixedTransform invertAxis( final int numDimensions, final int d )
 	{
-		final boolean[] inv = new boolean[ n ];
+		final boolean[] inv = new boolean[ numDimensions ];
 		inv[ d ] = true;
-		final MixedTransform t = new MixedTransform( n, n );
+		final MixedTransform t = new MixedTransform( numDimensions, numDimensions );
 		t.setComponentInversion( inv );
 		return t;
 	}

--- a/src/main/java/net/imglib2/view/ViewTransforms.java
+++ b/src/main/java/net/imglib2/view/ViewTransforms.java
@@ -33,18 +33,23 @@
  */
 package net.imglib2.view;
 
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.transform.integer.Mixed;
+import net.imglib2.transform.integer.MixedTransform;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import net.imglib2.Interval;
-import net.imglib2.transform.integer.Mixed;
-import net.imglib2.transform.integer.MixedTransform;
-
 /**
- * Utility methods to create mixed transforms for common operations. Used by
- * {@link Views}.
+ * Utility methods to create transformation for the common
+ * operations that are provided in {@link Views}.
+ * <p>
+ * Warning: The transformations used in {@link Views} are always
+ * inverse to the operations that are performed by the views.
  *
  * @author Tobias Pietzsch
  * @author Carsten Haubold, KNIME GmbH, Konstanz, Germany
@@ -52,22 +57,14 @@ import net.imglib2.transform.integer.MixedTransform;
 public class ViewTransforms
 {
 	/**
-	 * Create a {@link MixedTransform} that rotates by 90 degrees. The rotation
-	 * is specified by two axis indices, such that the {@code fromAxis} is
-	 * rotated to the {@code toAxis}.
-	 *
-	 * For example: {@code rotate(0, 1, 3)} creates a transform that rotates the
-	 * X axis (of a XYZ space) to the Y axis. Applying the transform to
-	 * <em>(1,2,3)</em> yields <em>(2,-1,3)</em>.
-	 *
-	 * @param fromAxis
-	 *            axis index.
-	 * @param toAxis
-	 *            axis index.
-	 * @param n
-	 *            number of dimensions of the space.
-	 * @return a transform that rotates the {@code fromAxis} to the
-	 *         {@code toAxis}.
+	 * Returns the transformation that is used by
+	 * {@link Views#rotate(RandomAccessible, int, int)}.
+	 * <p>
+	 * Warning: The transformations used in {@link Views} are always
+	 * inverse to the operations that are performed by the views.
+	 * <p>
+	 * The rotation returned by this operation therefore is inverse to the
+	 * rotation described in {@link Views#rotate(RandomAccessible, int, int)}
 	 */
 	public static Mixed rotate( final int fromAxis, final int toAxis, final int n )
 	{
@@ -102,17 +99,13 @@ public class ViewTransforms
 	}
 
 	/**
-	 * Create a transformation that permutes axes. fromAxis and toAxis are
-	 * swapped.
-	 *
-	 * If fromAxis=0 and toAxis=2, this means that the X-axis of the source view
-	 * is mapped to the Z-Axis of the permuted view and vice versa. For a XYZ
-	 * source, a ZYX view would be created.
-	 *
-	 * @param fromAxis
-	 * @param toAxis
-	 * @param n
-	 * @return
+	 * Returns the transformation that is used by
+	 * {@link Views#permute(RandomAccessible, int, int)}.
+	 * <p>
+	 * Warning: The transformations used in {@link Views} are always
+	 * inverse to the operations that are performed by the views.
+	 * But that's not important for this type of permutation. As
+	 * the permutation stays the same when inverted.
 	 */
 	public static Mixed permute( final int fromAxis, final int toAxis, final int n )
 	{
@@ -130,13 +123,19 @@ public class ViewTransforms
 	}
 
 	/**
-	 * Create a transform that takes a (n-1)-dimensional slice of a
-	 * n-dimensional view, fixing d-component of coordinates to pos.
+	 * Returns the transformation that is used by
+	 * {@link Views#hyperSlice(RandomAccessible, int, long)}.
+	 * <p>
+	 * Warning: The transformations used in {@link Views} are always
+	 * inverse to the operations that are performed by the views.
+	 * <p>
 	 *
-	 * @param d
-	 * @param pos
-	 * @param m
-	 * @return
+	 * @param n             Number of dimensions including that dimension
+	 *                      that is sliced / inserted.
+	 * @param d             Index of that dimension that is sliced / inserted.
+	 * @param pos           Position of the slice / value of the coordinate that's
+	 *                      inserted.
+	 * @return Transformation that inserts a coordinate at the given index.
 	 */
 	public static MixedTransform hyperSlice( final int d, final long pos, final int m )
 	{
@@ -171,14 +170,13 @@ public class ViewTransforms
 	}
 
 	/**
-	 * Create a {@link MixedTransform} that describes the translation vector.
-	 * When applied to a View, each pixel <em>x</em> in the source view has
-	 * coordinates <em>(x + translation)</em> in the resulting view.
-	 *
-	 * @param translation
-	 *            translation vector of the source view. The pixel at <em>x</em>
-	 *            in the source view becomes <em>(x + translation)</em> in the
-	 *            resulting view.
+	 * Returns the transformation that is used by
+	 * {@link Views#translate(RandomAccessible, long...)}.
+	 * <p>
+	 * Warning: The transformation used by a view in {@link Views} is always
+	 * inverse to the operation that is performed by the View.
+	 * <p>
+	 * Therefor this method actually returns the inverse translation.
 	 */
 	public static MixedTransform translate( final long... translation )
 	{
@@ -189,11 +187,14 @@ public class ViewTransforms
 	}
 
 	/**
-	 * Create a transformation that moves an axis. fromAxis is moved to toAxis.
-	 * While the order of the other axes is preserved.
-	 *
-	 * If fromAxis=2 and toAxis=4, and axis order of image is XYCZT, then a view
-	 * to the image with axis order XYZTC would be created.
+	 * Returns the transformation that is used by
+	 * {@link Views#moveAxis(RandomAccessible, int, int)}.
+	 * <p>
+	 * Warning: The transformation used by a view in {@link Views} is always
+	 * inverse to the operation that is performed by the View.
+	 * <p>
+	 * Therefor the axis permutation return by this method
+	 * is actually inverse as described in {@link Views#moveAxis(RandomAccessible, int, int)}.
 	 */
 	public static MixedTransform moveAxis( final int fromAxis, final int toAxis, final int n )
 	{
@@ -217,12 +218,11 @@ public class ViewTransforms
 	}
 
 	/**
-	 * Create a transformation that moves the min coordinate of the given
-	 * interval to the origin
-	 *
-	 * @param interval
-	 *            the source.
-	 * @return transformation
+	 * Returns the transformation that is used by
+	 * {@link Views#zeroMin(RandomAccessibleInterval)}.
+	 * <p>
+	 * Warning: The transformation used by a view in {@link Views} is always
+	 * inverse to the operation that is performed by the View.
 	 */
 	public static MixedTransform zeroMin( final Interval interval )
 	{
@@ -234,10 +234,15 @@ public class ViewTransforms
 	}
 
 	/**
-	 * Create a transformation that adds a new dimension at the end
+	 * Returns the transformation that is used by
+	 * {@link Views#addDimension(RandomAccessible)}.
+	 * <p>
+	 * Warning: The transformation used by a view in {@link Views} is always
+	 * inverse to the operation that is performed by the View.
 	 *
-	 * @param currentNumDims
-	 * @return
+	 * @param currentNumDims Number of dimensions not including
+	 *                       the coordinate that's added/removed.
+	 * @return A transformation that removes the last coordinate.
 	 */
 	public static MixedTransform addDimension( final int currentNumDims )
 	{
@@ -246,11 +251,18 @@ public class ViewTransforms
 	}
 
 	/**
-	 * Create a transform that inverts the d'th axis of an n-dimensional space.
+	 * Returns the transformation that is used by
+	 * {@link Views#invertAxis(RandomAccessible, int)}.
+	 * <p>
+	 * Warning: The transformation used by a view in {@link Views} is always
+	 * inverse to the operation that is performed by the View.
+	 * But that's not relevant here, because inverse of an axis inversion
+	 * is the axis inversion itself.
+	 * <p>
 	 *
-	 * @param d
-	 * @param n
-	 * @return
+	 * @param d Index of the coordinate that's inverted.
+	 * @param n Number of dimensions of the coordinate space.
+	 * @return Transformation that inverts the specified coordinate.
 	 */
 	public static MixedTransform invertAxis( final int d, final int n )
 	{

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -395,7 +395,7 @@ public class Views
 	public static < T > MixedTransformView< T > rotate( final RandomAccessible< T > randomAccessible, final int fromAxis, final int toAxis )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, ViewTransforms.rotate( fromAxis, toAxis, n ) );
+		return new MixedTransformView<>( randomAccessible, ViewTransforms.rotate( n, fromAxis, toAxis ) );
 	}
 
 	/**
@@ -424,7 +424,7 @@ public class Views
 	public static < T > MixedTransformView< T > permute( final RandomAccessible< T > randomAccessible, final int fromAxis, final int toAxis )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, ViewTransforms.permute( fromAxis, toAxis, n ) );
+		return new MixedTransformView<>( randomAccessible, ViewTransforms.permute( n, fromAxis, toAxis ) );
 	}
 
 	/**
@@ -448,7 +448,7 @@ public class Views
 	 */
 	public static < T > RandomAccessible< T > moveAxis( final RandomAccessible< T > image, final int fromAxis, final int toAxis )
 	{
-		return new MixedTransformView<>( image, ViewTransforms.moveAxis( fromAxis, toAxis, image.numDimensions() ) );
+		return new MixedTransformView<>( image, ViewTransforms.moveAxis( image.numDimensions(), fromAxis, toAxis ) );
 	}
 
 	/**
@@ -461,7 +461,7 @@ public class Views
 	public static < T > RandomAccessibleInterval< T > moveAxis( final RandomAccessibleInterval< T > image, final int fromAxis, final int toAxis )
 	{
 		final int n = image.numDimensions();
-		final Mixed t = ViewTransforms.moveAxis( fromAxis, toAxis, n );
+		final Mixed t = ViewTransforms.moveAxis( n, fromAxis, toAxis );
 		return Views.interval( new MixedTransformView<>( image, t ), Intervals.moveAxis( image, fromAxis, toAxis ) );
 	}
 
@@ -565,7 +565,7 @@ public class Views
 	public static < T > MixedTransformView< T > hyperSlice( final RandomAccessible< T > view, final int d, final long pos )
 	{
 		final int m = view.numDimensions();
-		final Mixed t = ViewTransforms.hyperSlice( d, pos, m );
+		final Mixed t = ViewTransforms.hyperSlice( m, d, pos );
 		return new MixedTransformView<>( view, t );
 	}
 
@@ -628,7 +628,7 @@ public class Views
 	public static < T > MixedTransformView< T > invertAxis( final RandomAccessible< T > randomAccessible, final int d )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, ViewTransforms.invertAxis( d, n ) );
+		return new MixedTransformView<>( randomAccessible, ViewTransforms.invertAxis( n, d ) );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -395,7 +395,7 @@ public class Views
 	public static < T > MixedTransformView< T > rotate( final RandomAccessible< T > randomAccessible, final int fromAxis, final int toAxis )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, MixedTransforms.rotate( fromAxis, toAxis, n ) );
+		return new MixedTransformView<>( randomAccessible, ViewTransforms.rotate( fromAxis, toAxis, n ) );
 	}
 
 	/**
@@ -424,7 +424,7 @@ public class Views
 	public static < T > MixedTransformView< T > permute( final RandomAccessible< T > randomAccessible, final int fromAxis, final int toAxis )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, MixedTransforms.permute( fromAxis, toAxis, n ) );
+		return new MixedTransformView<>( randomAccessible, ViewTransforms.permute( fromAxis, toAxis, n ) );
 	}
 
 	/**
@@ -448,7 +448,7 @@ public class Views
 	 */
 	public static < T > RandomAccessible< T > moveAxis( final RandomAccessible< T > image, final int fromAxis, final int toAxis )
 	{
-		return new MixedTransformView<>( image, MixedTransforms.moveAxis( fromAxis, toAxis, image.numDimensions() ) );
+		return new MixedTransformView<>( image, ViewTransforms.moveAxis( fromAxis, toAxis, image.numDimensions() ) );
 	}
 
 	/**
@@ -461,7 +461,7 @@ public class Views
 	public static < T > RandomAccessibleInterval< T > moveAxis( final RandomAccessibleInterval< T > image, final int fromAxis, final int toAxis )
 	{
 		final int n = image.numDimensions();
-		final Mixed t = MixedTransforms.moveAxis( fromAxis, toAxis, n );
+		final Mixed t = ViewTransforms.moveAxis( fromAxis, toAxis, n );
 		return Views.interval( new MixedTransformView<>( image, t ), Intervals.moveAxis( image, fromAxis, toAxis ) );
 	}
 
@@ -479,7 +479,7 @@ public class Views
 	 */
 	public static < T > MixedTransformView< T > translate( final RandomAccessible< T > randomAccessible, final long... translation )
 	{
-		final Mixed t = MixedTransforms.translate( translation );
+		final Mixed t = ViewTransforms.translate( translation );
 		return new MixedTransformView<>( randomAccessible, t );
 	}
 
@@ -550,7 +550,7 @@ public class Views
 	 */
 	public static < T > IntervalView< T > zeroMin( final RandomAccessibleInterval< T > interval )
 	{
-		final Mixed t = MixedTransforms.zeroMin( interval );
+		final Mixed t = ViewTransforms.zeroMin( interval );
 		final long[] offset = new long[ interval.numDimensions() ];
 		interval.min( offset );
 		final long[] translation = Arrays.stream( offset ).map( o -> -o ).toArray();
@@ -565,7 +565,7 @@ public class Views
 	public static < T > MixedTransformView< T > hyperSlice( final RandomAccessible< T > view, final int d, final long pos )
 	{
 		final int m = view.numDimensions();
-		final Mixed t = MixedTransforms.hyperSlice( d, pos, m );
+		final Mixed t = ViewTransforms.hyperSlice( d, pos, m );
 		return new MixedTransformView<>( view, t );
 	}
 
@@ -593,7 +593,7 @@ public class Views
 	{
 		final int m = randomAccessible.numDimensions();
 
-		return new MixedTransformView<>( randomAccessible, MixedTransforms.addDimension( m ) );
+		return new MixedTransformView<>( randomAccessible, ViewTransforms.addDimension( m ) );
 	}
 
 	/**
@@ -628,7 +628,7 @@ public class Views
 	public static < T > MixedTransformView< T > invertAxis( final RandomAccessible< T > randomAccessible, final int d )
 	{
 		final int n = randomAccessible.numDimensions();
-		return new MixedTransformView<>( randomAccessible, MixedTransforms.invertAxis( d, n ) );
+		return new MixedTransformView<>( randomAccessible, ViewTransforms.invertAxis( d, n ) );
 	}
 
 	/**

--- a/src/test/java/net/imglib2/view/MixedTransformsTest.java
+++ b/src/test/java/net/imglib2/view/MixedTransformsTest.java
@@ -34,106 +34,85 @@
 
 package net.imglib2.view;
 
-import static org.junit.Assert.assertArrayEquals;
-
 import net.imglib2.Interval;
-import net.imglib2.Localizable;
-import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessible;
 import net.imglib2.transform.integer.Mixed;
 import net.imglib2.util.Intervals;
-import net.imglib2.util.Localizables;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
 
 public class MixedTransformsTest
 {
 	@Test
 	public void testTranslate()
 	{
-		final RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
 		final Mixed transform = MixedTransforms.translate( 10, 9, 8 );
-		final RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		final RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] { 10, 11, 12 } );
-		assertArrayEquals( new long[] { 0, 2, 4 }, Localizables.asLongArray( ra.get() ) );
+		final long[] result = apply( transform, new long[] { 10, 11, 12 } );
+		assertArrayEquals( new long[] { 0, 2, 4 }, result );
 	}
 
 	@Test
 	public void testRotate()
 	{
-		final RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
-		final Mixed transform = MixedTransforms.rotate( 1, 0, input.numDimensions() );
-		final RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		final RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] { 2, -1, 3 } );
-		assertArrayEquals( new long[] { 1, 2, 3 }, Localizables.asLongArray( ra.get() ) );
+		final Mixed transform = MixedTransforms.rotate( 1, 0, 3 );
+		final long[] result = apply( transform, new long[] { 2, -1, 3 } );
+		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
 
 	@Test
 	public void testPermute()
 	{
-		final RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
-		final Mixed transform = MixedTransforms.permute( 0, 2, input.numDimensions() );
-		final RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		final RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] { 3, 2, 1 } );
-		assertArrayEquals( new long[] { 1, 2, 3 }, Localizables.asLongArray( ra.get() ) );
+		final Mixed transform = MixedTransforms.permute( 0, 2, 3 );
+		final long[] result = apply( transform, new long[] { 3, 2, 1 } );
+		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
 
 	@Test
 	public void testMoveAxis()
 	{
-		final RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
-		final Mixed transform = MixedTransforms.moveAxis( 0, 2, input.numDimensions() );
-		final RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		final RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] { 2, 3, 1 } );
-		assertArrayEquals( new long[] { 1, 2, 3 }, Localizables.asLongArray( ra.get() ) );
+		final Mixed transform = MixedTransforms.moveAxis( 0, 2, 3 );
+		final long[] result = apply( transform, new long[] { 2, 3, 1 } );
+		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
 
 	@Test
 	public void testInvertAxis()
 	{
-		final RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
-		final Mixed transform = MixedTransforms.invertAxis( 1, input.numDimensions() );
-		final RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		final RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] { 1, -2, 3 } );
-		assertArrayEquals( new long[] { 1, 2, 3 }, Localizables.asLongArray( ra.get() ) );
+		final Mixed transform = MixedTransforms.invertAxis( 1, 3 );
+		final long[] result = apply( transform, new long[] { 1, -2, 3 } );
+		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
 
 	@Test
 	public void testZeroMin()
 	{
-		final RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
 		final Interval interval = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
 		final Mixed transform = MixedTransforms.zeroMin( interval );
-		final RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		final RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] { 0, 0, 0 } );
-		assertArrayEquals( new long[] { 1, 2, 3 }, Localizables.asLongArray( ra.get() ) );
+		final long[] result = apply( transform, new long[] { 0, 0, 0 } );
+		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
 
 	@Test
 	public void testAddDimension()
 	{
-		final RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
-		final Mixed transform = MixedTransforms.addDimension( input.numDimensions() );
-		final RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		final RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] { 1, 2, 3, 17 } );
-		assertArrayEquals( new long[] { 1, 2, 3 }, Localizables.asLongArray( ra.get() ) );
+		final Mixed transform = MixedTransforms.addDimension( 3 );
+		final long[] result = apply( transform, new long[] { 1, 2, 3, 17 } );
+		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
 
 	@Test
 	public void testHyperSlice()
 	{
-		final RandomAccessible< Localizable > input = Localizables.randomAccessible( 3 );
-		final Mixed transform = MixedTransforms.hyperSlice( 2, 3, input.numDimensions() );
-		final RandomAccessible< Localizable > view = new MixedTransformView<>( input, transform );
-		final RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] { 1, 2 } );
-		assertArrayEquals( new long[] { 1, 2, 3 }, Localizables.asLongArray( ra.get() ) );
+		final Mixed transform = MixedTransforms.hyperSlice( 2, 3, 3 );
+		final long[] result = apply( transform, new long[] { 1, 2 } );
+		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
+
+	private long[] apply( Mixed transform, long[] source )
+	{
+		long[] result = new long[ 3 ];
+		transform.apply( source, result );
+		return result;
+	}
+
 }

--- a/src/test/java/net/imglib2/view/ViewTransformsTest.java
+++ b/src/test/java/net/imglib2/view/ViewTransformsTest.java
@@ -41,12 +41,12 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 
-public class MixedTransformsTest
+public class ViewTransformsTest
 {
 	@Test
 	public void testTranslate()
 	{
-		final Mixed transform = MixedTransforms.translate( 10, 9, 8 );
+		final Mixed transform = ViewTransforms.translate( 10, 9, 8 );
 		final long[] result = apply( transform, new long[] { 10, 11, 12 } );
 		assertArrayEquals( new long[] { 0, 2, 4 }, result );
 	}
@@ -54,7 +54,7 @@ public class MixedTransformsTest
 	@Test
 	public void testRotate()
 	{
-		final Mixed transform = MixedTransforms.rotate( 1, 0, 3 );
+		final Mixed transform = ViewTransforms.rotate( 1, 0, 3 );
 		final long[] result = apply( transform, new long[] { 2, -1, 3 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -62,7 +62,7 @@ public class MixedTransformsTest
 	@Test
 	public void testPermute()
 	{
-		final Mixed transform = MixedTransforms.permute( 0, 2, 3 );
+		final Mixed transform = ViewTransforms.permute( 0, 2, 3 );
 		final long[] result = apply( transform, new long[] { 3, 2, 1 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -70,7 +70,7 @@ public class MixedTransformsTest
 	@Test
 	public void testMoveAxis()
 	{
-		final Mixed transform = MixedTransforms.moveAxis( 0, 2, 3 );
+		final Mixed transform = ViewTransforms.moveAxis( 0, 2, 3 );
 		final long[] result = apply( transform, new long[] { 2, 3, 1 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -78,7 +78,7 @@ public class MixedTransformsTest
 	@Test
 	public void testInvertAxis()
 	{
-		final Mixed transform = MixedTransforms.invertAxis( 1, 3 );
+		final Mixed transform = ViewTransforms.invertAxis( 1, 3 );
 		final long[] result = apply( transform, new long[] { 1, -2, 3 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -87,7 +87,7 @@ public class MixedTransformsTest
 	public void testZeroMin()
 	{
 		final Interval interval = Intervals.createMinMax( 1, 2, 3, 5, 7, 9 );
-		final Mixed transform = MixedTransforms.zeroMin( interval );
+		final Mixed transform = ViewTransforms.zeroMin( interval );
 		final long[] result = apply( transform, new long[] { 0, 0, 0 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -95,7 +95,7 @@ public class MixedTransformsTest
 	@Test
 	public void testAddDimension()
 	{
-		final Mixed transform = MixedTransforms.addDimension( 3 );
+		final Mixed transform = ViewTransforms.addDimension( 3 );
 		final long[] result = apply( transform, new long[] { 1, 2, 3, 17 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -103,7 +103,7 @@ public class MixedTransformsTest
 	@Test
 	public void testHyperSlice()
 	{
-		final Mixed transform = MixedTransforms.hyperSlice( 2, 3, 3 );
+		final Mixed transform = ViewTransforms.hyperSlice( 2, 3, 3 );
 		final long[] result = apply( transform, new long[] { 1, 2 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}

--- a/src/test/java/net/imglib2/view/ViewTransformsTest.java
+++ b/src/test/java/net/imglib2/view/ViewTransformsTest.java
@@ -54,7 +54,7 @@ public class ViewTransformsTest
 	@Test
 	public void testRotate()
 	{
-		final Mixed transform = ViewTransforms.rotate( 1, 0, 3 );
+		final Mixed transform = ViewTransforms.rotate( 3, 1, 0 );
 		final long[] result = apply( transform, new long[] { 2, -1, 3 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -62,7 +62,7 @@ public class ViewTransformsTest
 	@Test
 	public void testPermute()
 	{
-		final Mixed transform = ViewTransforms.permute( 0, 2, 3 );
+		final Mixed transform = ViewTransforms.permute( 3, 0, 2 );
 		final long[] result = apply( transform, new long[] { 3, 2, 1 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -70,7 +70,7 @@ public class ViewTransformsTest
 	@Test
 	public void testMoveAxis()
 	{
-		final Mixed transform = ViewTransforms.moveAxis( 0, 2, 3 );
+		final Mixed transform = ViewTransforms.moveAxis( 3, 0, 2 );
 		final long[] result = apply( transform, new long[] { 2, 3, 1 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -78,7 +78,7 @@ public class ViewTransformsTest
 	@Test
 	public void testInvertAxis()
 	{
-		final Mixed transform = ViewTransforms.invertAxis( 1, 3 );
+		final Mixed transform = ViewTransforms.invertAxis( 3, 1 );
 		final long[] result = apply( transform, new long[] { 1, -2, 3 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}
@@ -103,7 +103,7 @@ public class ViewTransformsTest
 	@Test
 	public void testHyperSlice()
 	{
-		final Mixed transform = ViewTransforms.hyperSlice( 2, 3, 3 );
+		final Mixed transform = ViewTransforms.hyperSlice( 3, 2, 3 );
 		final long[] result = apply( transform, new long[] { 1, 2 } );
 		assertArrayEquals( new long[] { 1, 2, 3 }, result );
 	}


### PR DESCRIPTION
The class ```MixedTransforms``` needs to be renamed. Because it's currently strange that:
```MixedTransforms.translate(...)``` actually return an inverse transformation. ```MixedTransforms``` does behave like that way, because ```Views``` always use the inverse transformation. But reflect this intention and behavior, we should rename the recently added class from ```MixedTransforms``` to ```ViewTransforms```.