### PR TITLE
Add utility class to wrap images as 1D collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>imglib2</artifactId>
-	<version>5.6.4-SNAPSHOT</version>
+	<version>5.7.0-SNAPSHOT</version>
 
 	<name>ImgLib2 Core Library</name>
 	<description>A multidimensional, type-agnostic image processing library.</description>

--- a/src/main/java/net/imglib2/util/FlatCollections.java
+++ b/src/main/java/net/imglib2/util/FlatCollections.java
@@ -49,6 +49,7 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
 
 /**
  * Utility class for wrapping ImgLib2 images as read-only {@link Collection}s.
@@ -67,6 +68,14 @@ public final class FlatCollections
 	 * Wraps an {@link IterableInterval} as a {@link Collection}. The wrapped
 	 * collection is read-only, throwing {@link UnsupportedOperationException}
 	 * if the caller attempts to mutate it.
+	 * <p>
+	 * With this method, and <em>unlike
+	 * {@link #list(RandomAccessibleInterval, Function)}</em>, the iteration
+	 * order of the wrapped collection will <em>match that of the source
+	 * image</em>. It is best not to make any assumptions about the iteration
+	 * order of the collection&mdash;only that each element of the wrapped image
+	 * will appear once in the iteration.
+	 * </p>
 	 * 
 	 * @param image
 	 *            The {@link IterableInterval} to wrap as a Java collection.
@@ -163,6 +172,16 @@ public final class FlatCollections
 	 * Wraps a {@link RandomAccessibleInterval} as a {@link List}. The wrapped
 	 * list is read-only, throwing {@link UnsupportedOperationException} if the
 	 * caller attempts to mutate it.
+	 * <p>
+	 * With this method, and <em>unlike
+	 * {@link #collection(IterableInterval, Function)}</em>, the iteration order
+	 * of the wrapped list will <em>always be the
+	 * {@link net.imglib2.FlatIterationOrder flat iteration order}</em>, as
+	 * though {@link Views#flatIterable} were used on the source
+	 * {@link RandomAccessibleInterval} image. As such, iterating the original
+	 * image and the wrapped {@link List} may result in differing sequences of
+	 * elements.
+	 * </p>
 	 * 
 	 * @param image
 	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.

--- a/src/main/java/net/imglib2/util/FlatCollections.java
+++ b/src/main/java/net/imglib2/util/FlatCollections.java
@@ -1,0 +1,408 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2019 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.util;
+
+import java.math.BigInteger;
+import java.util.AbstractCollection;
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.ShortType;
+
+/**
+ * Utility class for wrapping ImgLib2 images as read-only {@link Collection}s.
+ * <p>
+ * This is useful when you want to pass an ImgLib2 {@link IterableInterval} or
+ * {@link RandomAccessibleInterval} to an API that works with Java
+ * {@link Collection} objects, such as Google Guava's <a href=
+ * "https://javadoc.scijava.org/Guava/?com/google/common/math/Quantiles.html">Quantiles</a>.
+ *
+ * @author Curtis Rueden
+ */
+public final class FlatCollections
+{
+
+	/**
+	 * Wraps an {@link IterableInterval} as a {@link Collection}. The wrapped
+	 * collection is read-only, throwing {@link UnsupportedOperationException}
+	 * if the caller attempts to mutate it.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @param converter
+	 *            Conversion function to use for accessing elements of the
+	 *            collection. This function will be transparently called on the
+	 *            corresponding source sample from the ImgLib2 image.
+	 * @return Wrapped {@link Collection} of the converted type.
+	 */
+	public static < T, E > Collection< E > collection( final IterableInterval< T > image, final Function< T, E > converter )
+	{
+		return new CollectionFromII<>( image, converter );
+	}
+
+	/**
+	 * Wraps a {@link BooleanType} iterable image as a collection.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @return Wrapped {@link Collection} with {@link Boolean} elements.
+	 * @see #collection(IterableInterval, Function)
+	 */
+	public static < B extends BooleanType< B > > Collection< Boolean > booleanCollection( final IterableInterval< B > image )
+	{
+		return collection( image, t -> t.get() );
+	}
+
+	/**
+	 * Wraps a {@link ByteType} iterable image as a collection.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @return Wrapped {@link Collection} with {@link Byte} elements.
+	 * @see #collection(IterableInterval, Function)
+	 */
+	public static Collection< Byte > byteCollection( final IterableInterval< ByteType > image )
+	{
+		return collection( image, t -> t.get() );
+	}
+
+	/**
+	 * Wraps a {@link RealType} iterable image as a collection.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @return Wrapped {@link Collection} with {@link Double} elements.
+	 * @see #collection(IterableInterval, Function)
+	 */
+	public static < T extends RealType< T > > Collection< Double > doubleCollection( final IterableInterval< T > image )
+	{
+		return collection( image, t -> t.getRealDouble() );
+	}
+
+	/**
+	 * Wraps a {@link RealType} iterable image as a collection.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @return Wrapped {@link Collection} with {@link Float} elements.
+	 * @see #collection(IterableInterval, Function)
+	 */
+	public static < T extends RealType< T > > Collection< Float > floatCollection( final IterableInterval< T > image )
+	{
+		return collection( image, t -> t.getRealFloat() );
+	}
+
+	/**
+	 * Wraps an {@link IntegerType} iterable image as a collection.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @return Wrapped {@link Collection} with {@link Integer} elements.
+	 * @see #collection(IterableInterval, Function)
+	 */
+	public static < T extends IntegerType< T > > Collection< Integer > integerCollection( final IterableInterval< T > image )
+	{
+		return collection( image, t -> t.getInteger() );
+	}
+
+	/**
+	 * Wraps an {@link IntegerType} iterable image as a collection.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @return Wrapped {@link Collection} with {@link Long} elements.
+	 * @see #collection(IterableInterval, Function)
+	 */
+	public static < T extends IntegerType< T > > Collection< Long > longCollection( final IterableInterval< T > image )
+	{
+		return collection( image, t -> t.getIntegerLong() );
+	}
+
+	/**
+	 * Wraps a {@link ShortType} iterable image as a collection.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @return Wrapped {@link Collection} with {@link Short} elements.
+	 * @see #collection(IterableInterval, Function)
+	 */
+	public static Collection< Short > shortCollection( final IterableInterval< ShortType > image )
+	{
+		return collection( image, t -> t.get() );
+	}
+
+	/**
+	 * Wraps an {@link IntegerType} iterable image as a collection.
+	 * 
+	 * @param image
+	 *            The {@link IterableInterval} to wrap as a Java collection.
+	 * @return Wrapped {@link Collection} with {@link BigInteger} elements.
+	 * @see #collection(IterableInterval, Function)
+	 */
+	public static < T extends IntegerType< T > > Collection< BigInteger > bigIntegerCollection( final IterableInterval< T > image )
+	{
+		return collection( image, t -> t.getBigInteger() );
+	}
+
+	/**
+	 * Wraps a {@link RandomAccessibleInterval} as a {@link List}. The wrapped
+	 * list is read-only, throwing {@link UnsupportedOperationException} if the
+	 * caller attempts to mutate it.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @param converter
+	 *            Conversion function to use for accessing elements of the list.
+	 *            This function will be transparently called on the
+	 *            corresponding source sample from the ImgLib2 image.
+	 * @return Wrapped {@link List} of the converted type.
+	 */
+	public static < T, E > List< E > list( final RandomAccessibleInterval< T > image, final Function< T, E > converter )
+	{
+		return new ListFromRAI<>( image, converter );
+	}
+
+	/**
+	 * Wraps a {@link BooleanType} random-accessible image as a list.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @return Wrapped {@link List} with {@link Boolean} elements.
+	 * @see #list(RandomAccessibleInterval, Function)
+	 */
+	public static < B extends BooleanType< B > > List< Boolean > booleanList( final RandomAccessibleInterval< B > image )
+	{
+		return list( image, t -> t.get() );
+	}
+
+	/**
+	 * Wraps a {@link ByteType} random-accessible image as a list.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @return Wrapped {@link List} with {@link Byte} elements.
+	 * @see #list(RandomAccessibleInterval, Function)
+	 */
+	public static List< Byte > byteList( final RandomAccessibleInterval< ByteType > image )
+	{
+		return list( image, t -> t.get() );
+	}
+
+	/**
+	 * Wraps a {@link RealType} random-accessible image as a list.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @return Wrapped {@link List} with {@link Double} elements.
+	 * @see #list(RandomAccessibleInterval, Function)
+	 */
+	public static < T extends RealType< T > > List< Double > doubleList( final RandomAccessibleInterval< T > image )
+	{
+		return list( image, t -> t.getRealDouble() );
+	}
+
+	/**
+	 * Wraps a {@link RealType} random-accessible image as a list.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @return Wrapped {@link List} with {@link Float} elements.
+	 * @see #list(RandomAccessibleInterval, Function)
+	 */
+	public static < T extends RealType< T > > List< Float > floatList( final RandomAccessibleInterval< T > image )
+	{
+		return list( image, t -> t.getRealFloat() );
+	}
+
+	/**
+	 * Wraps an {@link IntegerType} random-accessible image as a list.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @return Wrapped {@link List} with {@link Integer} elements.
+	 * @see #list(RandomAccessibleInterval, Function)
+	 */
+	public static < T extends IntegerType< T > > List< Integer > integerList( final RandomAccessibleInterval< T > image )
+	{
+		return list( image, t -> t.getInteger() );
+	}
+
+	/**
+	 * Wraps an {@link IntegerType} random-accessible image as a list.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @return Wrapped {@link List} with {@link Long} elements.
+	 * @see #list(RandomAccessibleInterval, Function)
+	 */
+	public static < T extends IntegerType< T > > List< Long > longList( final RandomAccessibleInterval< T > image )
+	{
+		return list( image, t -> t.getIntegerLong() );
+	}
+
+	/**
+	 * Wraps a {@link ShortType} random-accessible image as a list.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @return Wrapped {@link List} with {@link Short} elements.
+	 * @see #list(RandomAccessibleInterval, Function)
+	 */
+	public static List< Short > shortList( final RandomAccessibleInterval< ShortType > image )
+	{
+		return list( image, t -> t.get() );
+	}
+
+	/**
+	 * Wraps a {@link IntegerType} random-accessible image as a list.
+	 * 
+	 * @param image
+	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
+	 * @return Wrapped {@link List} with {@link BigInteger} elements.
+	 * @see #list(RandomAccessibleInterval, Function)
+	 */
+	public static < T extends IntegerType< T > > List< BigInteger > bigIntegerList( final RandomAccessibleInterval< T > image )
+	{
+		return list( image, t -> t.getBigInteger() );
+	}
+
+	/** A {@link RandomAccessibleInterval} expressed as a {@link List}. */
+	private static class ListFromRAI< T, E > extends AbstractList< E >
+	{
+
+		private final RandomAccessibleInterval< T > rai;
+
+		private final Function< T, E > converter;
+
+		private final int size;
+
+		private final ThreadLocal< RandomAccess< T > > ra = new ThreadLocal< RandomAccess< T > >()
+		{
+
+			@Override
+			public RandomAccess< T > initialValue()
+			{
+				return rai.randomAccess();
+			}
+		};
+
+		public ListFromRAI( final RandomAccessibleInterval< T > rai, final Function< T, E > converter )
+		{
+			this.rai = rai;
+			this.converter = converter;
+			size = sizeAsInt( Intervals.numElements( rai ) );
+		}
+
+		@Override
+		public E get( final int index )
+		{
+			final RandomAccess< T > access = ra.get();
+			IntervalIndexer.indexToPositionForInterval( index, rai, access );
+			return converter.apply( access.get() );
+		}
+
+		@Override
+		public int size()
+		{
+			return size;
+		}
+	}
+
+	/** An {@link IterableInterval} expressed as a {@link Collection}. */
+	private static class CollectionFromII< T, E > extends AbstractCollection< E >
+	{
+
+		private final IterableInterval< T > image;
+
+		private final Function< T, E > converter;
+
+		private final int size;
+
+		private CollectionFromII( final IterableInterval< T > image, final Function< T, E > converter )
+		{
+			this.image = image;
+			this.converter = converter;
+			size = sizeAsInt( Intervals.numElements( image ) );
+		}
+
+		@Override
+		public int size()
+		{
+			return size;
+		}
+
+		@Override
+		public Iterator< E > iterator()
+		{
+			return new Iterator< E >()
+			{
+
+				private final Cursor< T > cursor = image.cursor();
+
+				@Override
+				public boolean hasNext()
+				{
+					return cursor.hasNext();
+				}
+
+				@Override
+				public E next()
+				{
+					return converter.apply( cursor.next() );
+				}
+			};
+		}
+	}
+
+	private static int sizeAsInt( final long size )
+	{
+		if ( size < 0 )
+			throw new IllegalArgumentException( "Negative size: " + size );
+		if ( size > Integer.MAX_VALUE )
+			throw new IllegalArgumentException( "Size too large: " + size );
+		return ( int ) size;
+	}
+}

--- a/src/main/java/net/imglib2/util/FlatCollections.java
+++ b/src/main/java/net/imglib2/util/FlatCollections.java
@@ -98,7 +98,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link Collection} with {@link Boolean} elements.
 	 * @see #collection(IterableInterval, Function)
 	 */
-	public static < B extends BooleanType< B > > Collection< Boolean > booleanCollection( final IterableInterval< B > image )
+	public static Collection< Boolean > booleanCollection( final IterableInterval< ? extends BooleanType< ? > > image )
 	{
 		return collection( image, t -> t.get() );
 	}
@@ -111,7 +111,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link Collection} with {@link Double} elements.
 	 * @see #collection(IterableInterval, Function)
 	 */
-	public static < T extends RealType< T > > Collection< Double > doubleCollection( final IterableInterval< T > image )
+	public static Collection< Double > doubleCollection( final IterableInterval< ? extends RealType< ? > > image )
 	{
 		return collection( image, t -> t.getRealDouble() );
 	}
@@ -124,7 +124,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link Collection} with {@link Float} elements.
 	 * @see #collection(IterableInterval, Function)
 	 */
-	public static < T extends RealType< T > > Collection< Float > floatCollection( final IterableInterval< T > image )
+	public static Collection< Float > floatCollection( final IterableInterval< ? extends RealType< ? > > image )
 	{
 		return collection( image, t -> t.getRealFloat() );
 	}
@@ -137,7 +137,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link Collection} with {@link Integer} elements.
 	 * @see #collection(IterableInterval, Function)
 	 */
-	public static < T extends IntegerType< T > > Collection< Integer > integerCollection( final IterableInterval< T > image )
+	public static Collection< Integer > integerCollection( final IterableInterval< ? extends IntegerType< ? > > image )
 	{
 		return collection( image, t -> t.getInteger() );
 	}
@@ -150,7 +150,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link Collection} with {@link Long} elements.
 	 * @see #collection(IterableInterval, Function)
 	 */
-	public static < T extends IntegerType< T > > Collection< Long > longCollection( final IterableInterval< T > image )
+	public static Collection< Long > longCollection( final IterableInterval< ? extends IntegerType< ? > > image )
 	{
 		return collection( image, t -> t.getIntegerLong() );
 	}
@@ -163,7 +163,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link Collection} with {@link BigInteger} elements.
 	 * @see #collection(IterableInterval, Function)
 	 */
-	public static < T extends IntegerType< T > > Collection< BigInteger > bigIntegerCollection( final IterableInterval< T > image )
+	public static Collection< BigInteger > bigIntegerCollection( final IterableInterval< ? extends IntegerType< ? > > image )
 	{
 		return collection( image, t -> t.getBigInteger() );
 	}
@@ -204,7 +204,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link List} with {@link Boolean} elements.
 	 * @see #list(RandomAccessibleInterval, Function)
 	 */
-	public static < B extends BooleanType< B > > List< Boolean > booleanList( final RandomAccessibleInterval< B > image )
+	public static List< Boolean > booleanList( final RandomAccessibleInterval< ? extends BooleanType< ? > > image )
 	{
 		return list( image, t -> t.get() );
 	}
@@ -217,7 +217,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link List} with {@link Double} elements.
 	 * @see #list(RandomAccessibleInterval, Function)
 	 */
-	public static < T extends RealType< T > > List< Double > doubleList( final RandomAccessibleInterval< T > image )
+	public static List< Double > doubleList( final RandomAccessibleInterval< ? extends RealType< ? > > image )
 	{
 		return list( image, t -> t.getRealDouble() );
 	}
@@ -230,7 +230,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link List} with {@link Float} elements.
 	 * @see #list(RandomAccessibleInterval, Function)
 	 */
-	public static < T extends RealType< T > > List< Float > floatList( final RandomAccessibleInterval< T > image )
+	public static List< Float > floatList( final RandomAccessibleInterval< ? extends RealType< ? > > image )
 	{
 		return list( image, t -> t.getRealFloat() );
 	}
@@ -243,7 +243,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link List} with {@link Integer} elements.
 	 * @see #list(RandomAccessibleInterval, Function)
 	 */
-	public static < T extends IntegerType< T > > List< Integer > integerList( final RandomAccessibleInterval< T > image )
+	public static List< Integer > integerList( final RandomAccessibleInterval< ? extends IntegerType< ? > > image )
 	{
 		return list( image, t -> t.getInteger() );
 	}
@@ -256,7 +256,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link List} with {@link Long} elements.
 	 * @see #list(RandomAccessibleInterval, Function)
 	 */
-	public static < T extends IntegerType< T > > List< Long > longList( final RandomAccessibleInterval< T > image )
+	public static List< Long > longList( final RandomAccessibleInterval< ? extends IntegerType< ? > > image )
 	{
 		return list( image, t -> t.getIntegerLong() );
 	}
@@ -269,7 +269,7 @@ public final class FlatCollections
 	 * @return Wrapped {@link List} with {@link BigInteger} elements.
 	 * @see #list(RandomAccessibleInterval, Function)
 	 */
-	public static < T extends IntegerType< T > > List< BigInteger > bigIntegerList( final RandomAccessibleInterval< T > image )
+	public static List< BigInteger > bigIntegerList( final RandomAccessibleInterval< ? extends IntegerType< ? > > image )
 	{
 		return list( image, t -> t.getBigInteger() );
 	}

--- a/src/main/java/net/imglib2/util/FlatCollections.java
+++ b/src/main/java/net/imglib2/util/FlatCollections.java
@@ -49,8 +49,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.integer.ByteType;
-import net.imglib2.type.numeric.integer.ShortType;
 
 /**
  * Utility class for wrapping ImgLib2 images as read-only {@link Collection}s.
@@ -92,19 +90,6 @@ public final class FlatCollections
 	 * @see #collection(IterableInterval, Function)
 	 */
 	public static < B extends BooleanType< B > > Collection< Boolean > booleanCollection( final IterableInterval< B > image )
-	{
-		return collection( image, t -> t.get() );
-	}
-
-	/**
-	 * Wraps a {@link ByteType} iterable image as a collection.
-	 * 
-	 * @param image
-	 *            The {@link IterableInterval} to wrap as a Java collection.
-	 * @return Wrapped {@link Collection} with {@link Byte} elements.
-	 * @see #collection(IterableInterval, Function)
-	 */
-	public static Collection< Byte > byteCollection( final IterableInterval< ByteType > image )
 	{
 		return collection( image, t -> t.get() );
 	}
@@ -162,19 +147,6 @@ public final class FlatCollections
 	}
 
 	/**
-	 * Wraps a {@link ShortType} iterable image as a collection.
-	 * 
-	 * @param image
-	 *            The {@link IterableInterval} to wrap as a Java collection.
-	 * @return Wrapped {@link Collection} with {@link Short} elements.
-	 * @see #collection(IterableInterval, Function)
-	 */
-	public static Collection< Short > shortCollection( final IterableInterval< ShortType > image )
-	{
-		return collection( image, t -> t.get() );
-	}
-
-	/**
 	 * Wraps an {@link IntegerType} iterable image as a collection.
 	 * 
 	 * @param image
@@ -214,19 +186,6 @@ public final class FlatCollections
 	 * @see #list(RandomAccessibleInterval, Function)
 	 */
 	public static < B extends BooleanType< B > > List< Boolean > booleanList( final RandomAccessibleInterval< B > image )
-	{
-		return list( image, t -> t.get() );
-	}
-
-	/**
-	 * Wraps a {@link ByteType} random-accessible image as a list.
-	 * 
-	 * @param image
-	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
-	 * @return Wrapped {@link List} with {@link Byte} elements.
-	 * @see #list(RandomAccessibleInterval, Function)
-	 */
-	public static List< Byte > byteList( final RandomAccessibleInterval< ByteType > image )
 	{
 		return list( image, t -> t.get() );
 	}
@@ -281,19 +240,6 @@ public final class FlatCollections
 	public static < T extends IntegerType< T > > List< Long > longList( final RandomAccessibleInterval< T > image )
 	{
 		return list( image, t -> t.getIntegerLong() );
-	}
-
-	/**
-	 * Wraps a {@link ShortType} random-accessible image as a list.
-	 * 
-	 * @param image
-	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
-	 * @return Wrapped {@link List} with {@link Short} elements.
-	 * @see #list(RandomAccessibleInterval, Function)
-	 */
-	public static List< Short > shortList( final RandomAccessibleInterval< ShortType > image )
-	{
-		return list( image, t -> t.get() );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/util/FlatCollections.java
+++ b/src/main/java/net/imglib2/util/FlatCollections.java
@@ -92,7 +92,11 @@ public final class FlatCollections
 
 	/**
 	 * Wraps a {@link BooleanType} iterable image as a collection.
-	 * 
+	 * <p>
+	 * Warning: Don't make any assumption on the iteration order,
+	 * only that each pixel will appear once. Performance may be
+	 * low as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link IterableInterval} to wrap as a Java collection.
 	 * @return Wrapped {@link Collection} with {@link Boolean} elements.
@@ -105,7 +109,11 @@ public final class FlatCollections
 
 	/**
 	 * Wraps a {@link RealType} iterable image as a collection.
-	 * 
+	 * <p>
+	 * Warning: Don't make any assumption on the iteration order,
+	 * only that each pixel will appear once. Performance may be
+	 * low as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link IterableInterval} to wrap as a Java collection.
 	 * @return Wrapped {@link Collection} with {@link Double} elements.
@@ -118,7 +126,11 @@ public final class FlatCollections
 
 	/**
 	 * Wraps a {@link RealType} iterable image as a collection.
-	 * 
+	 * <p>
+	 * Warning: Don't make any assumption on the iteration order,
+	 * only that each pixel will appear once. Performance may be
+	 * low as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link IterableInterval} to wrap as a Java collection.
 	 * @return Wrapped {@link Collection} with {@link Float} elements.
@@ -131,7 +143,11 @@ public final class FlatCollections
 
 	/**
 	 * Wraps an {@link IntegerType} iterable image as a collection.
-	 * 
+	 * <p>
+	 * Warning: Don't make any assumption on the iteration order,
+	 * only that each pixel will appear once. Performance may be
+	 * low as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link IterableInterval} to wrap as a Java collection.
 	 * @return Wrapped {@link Collection} with {@link Integer} elements.
@@ -144,7 +160,11 @@ public final class FlatCollections
 
 	/**
 	 * Wraps an {@link IntegerType} iterable image as a collection.
-	 * 
+	 * <p>
+	 * Warning: Don't make any assumption on the iteration order,
+	 * only that each pixel will appear once. Performance may be
+	 * low as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link IterableInterval} to wrap as a Java collection.
 	 * @return Wrapped {@link Collection} with {@link Long} elements.
@@ -157,7 +177,11 @@ public final class FlatCollections
 
 	/**
 	 * Wraps an {@link IntegerType} iterable image as a collection.
-	 * 
+	 * <p>
+	 * Warning: Don't make any assumption on the iteration order,
+	 * only that each pixel will appear once. Performance may be
+	 * low as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link IterableInterval} to wrap as a Java collection.
 	 * @return Wrapped {@link Collection} with {@link BigInteger} elements.
@@ -198,7 +222,9 @@ public final class FlatCollections
 
 	/**
 	 * Wraps a {@link BooleanType} random-accessible image as a list.
-	 * 
+	 * <p>
+	 * Warning: Performance may be low, as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
 	 * @return Wrapped {@link List} with {@link Boolean} elements.
@@ -211,7 +237,9 @@ public final class FlatCollections
 
 	/**
 	 * Wraps a {@link RealType} random-accessible image as a list.
-	 * 
+	 * <p>
+	 * Warning: Performance may be low, as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
 	 * @return Wrapped {@link List} with {@link Double} elements.
@@ -224,7 +252,9 @@ public final class FlatCollections
 
 	/**
 	 * Wraps a {@link RealType} random-accessible image as a list.
-	 * 
+	 * <p>
+	 * Warning: Performance may be low, as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
 	 * @return Wrapped {@link List} with {@link Float} elements.
@@ -237,7 +267,9 @@ public final class FlatCollections
 
 	/**
 	 * Wraps an {@link IntegerType} random-accessible image as a list.
-	 * 
+	 * <p>
+	 * Warning: Performance may be low, as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
 	 * @return Wrapped {@link List} with {@link Integer} elements.
@@ -250,7 +282,9 @@ public final class FlatCollections
 
 	/**
 	 * Wraps an {@link IntegerType} random-accessible image as a list.
-	 * 
+	 * <p>
+	 * Warning: Performance may be low, as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
 	 * @return Wrapped {@link List} with {@link Long} elements.
@@ -263,7 +297,9 @@ public final class FlatCollections
 
 	/**
 	 * Wraps a {@link IntegerType} random-accessible image as a list.
-	 * 
+	 * <p>
+	 * Warning: Performance may be low, as the collection uses boxed types.
+	 *
 	 * @param image
 	 *            The {@link RandomAccessibleInterval} to wrap as a Java list.
 	 * @return Wrapped {@link List} with {@link BigInteger} elements.

--- a/src/test/java/net/imglib2/util/FlatCollectionsBenchmark.java
+++ b/src/test/java/net/imglib2/util/FlatCollectionsBenchmark.java
@@ -1,0 +1,61 @@
+package net.imglib2.util;
+
+import net.imglib2.img.Img;
+import net.imglib2.test.RandomImgs;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.IntType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.Collection;
+
+/**
+ * Benchmark for {@link FlatCollections}.
+ * <p>
+ * The Benchmark demonstrates the performance reduction
+ * when wrapping an ImgLib2 image as Java {@link Collection}.
+ * The low performance is probably caused by the boxing of
+ * primitive types in Java.
+ */
+@State( Scope.Benchmark )
+public class FlatCollectionsBenchmark
+{
+	Img< IntType > image = RandomImgs.seed( 42 ).nextImage( new IntType(), 100, 100, 100);
+
+	Collection< Integer > list = FlatCollections.integerCollection( image );
+
+	@Benchmark
+	public double benchmarkSumList() {
+		double sum = 0;
+		for( Integer pixel : list )
+			sum += pixel;
+		return sum;
+	}
+
+	@Benchmark
+	public double benchmarkSumImg() {
+		double sum = 0;
+		for( RealType<?> pixel : image )
+			sum += pixel.getRealDouble();
+		return sum;
+	}
+
+	public static void main( final String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( FlatCollectionsBenchmark.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/util/FlatCollectionsTest.java
+++ b/src/test/java/net/imglib2/util/FlatCollectionsTest.java
@@ -1,0 +1,256 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2019 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.list.ListImg;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link FlatCollections}.
+ *
+ * @author Curtis Rueden
+ */
+public final class FlatCollectionsTest
+{
+
+	private final Img< String > imgString = new ListImg<>( Arrays.asList( "A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3", "D1", "D2", "D3" ), 3, 4 );
+
+	private final Img< NativeBoolType > imgBoolean = ArrayImgs.booleans( new boolean[] { true, true, false, false, false, true, true, false }, 2, 4 );
+
+	private final Img< ByteType > imgByte = ArrayImgs.bytes( new byte[] { 7, 3, 0, 56, -66, -1, 33, 127, 1, 99, 42, -128 }, 3, 4 );
+
+	private final Img< DoubleType > imgDouble = ArrayImgs.doubles( new double[] { 0.1, 0.02, 0.003, 0.0004, 0.00005, 0.000006, 0.0000007, 0.00000008, 0.000000009, 0, -0.9, -0.08 }, 3, 4 );
+
+	private final Img< IntType > imgInt = ArrayImgs.ints( new int[] { 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000, -1_000_000_000, -100_000_000 }, 3, 4 );
+
+	private final Img< LongType > imgLong = ArrayImgs.longs( new long[] { 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000, 10_000_000_000L, 100_000_000_000L }, 3, 4 );
+
+	private final Img< ShortType > imgShort = ArrayImgs.shorts( new short[] { 32767, 32766, 32765, 32764, 32763, 10000, 10001, 10002, 10003, -32768, -32767, -32766 }, 2, 3, 2 );
+
+	private final Img< UnsignedLongType > imgBig = ArrayImgs.unsignedLongs( new long[] { 2 * Long.MAX_VALUE, 3 * Long.MAX_VALUE, 4 * Long.MAX_VALUE, Long.MIN_VALUE, Long.MIN_VALUE / 2, Long.MIN_VALUE / 3 }, 3, 2 );
+
+	@Test
+	public void testCollection()
+	{
+		assertImageEqualsCollection( imgString, FlatCollections.collection( imgString, s -> s ), Objects::equals );
+	}
+
+	@Test
+	public void testBooleanCollection()
+	{
+		assertImageEqualsCollection( imgBoolean, FlatCollections.booleanCollection( imgBoolean ), ( e, a ) -> e.get() == a );
+	}
+
+	@Test
+	public void testByteCollection()
+	{
+		assertImageEqualsCollection( imgByte, FlatCollections.byteCollection( imgByte ), ( e, a ) -> e.get() == a );
+	}
+
+	@Test
+	public void testDoubleCollection()
+	{
+		assertImageEqualsCollection( imgDouble, FlatCollections.doubleCollection( imgDouble ), ( e, a ) -> e.get() == a );
+		assertImageEqualsCollection( imgByte, FlatCollections.doubleCollection( imgByte ), ( e, a ) -> e.getRealDouble() == a );
+		assertImageEqualsCollection( imgShort, FlatCollections.doubleCollection( imgShort ), ( e, a ) -> e.getRealDouble() == a );
+	}
+
+	@Test
+	public void testFloatCollection()
+	{
+		assertImageEqualsCollection( imgByte, FlatCollections.floatCollection( imgByte ), ( e, a ) -> e.getRealFloat() == a );
+		assertImageEqualsCollection( imgDouble, FlatCollections.floatCollection( imgDouble ), ( e, a ) -> e.getRealFloat() == a );
+		assertImageEqualsCollection( imgShort, FlatCollections.floatCollection( imgShort ), ( e, a ) -> e.getRealFloat() == a );
+	}
+
+	@Test
+	public void testIntegerCollection()
+	{
+		assertImageEqualsCollection( imgByte, FlatCollections.integerCollection( imgByte ), ( e, a ) -> e.getInteger() == a );
+		assertImageEqualsCollection( imgInt, FlatCollections.integerCollection( imgInt ), ( e, a ) -> e.get() == a );
+		assertImageEqualsCollection( imgLong, FlatCollections.integerCollection( imgLong ), ( e, a ) -> e.getInteger() == a ); // lossy
+		assertImageEqualsCollection( imgShort, FlatCollections.integerCollection( imgShort ), ( e, a ) -> e.getInteger() == a );
+		assertImageEqualsCollection( imgBig, FlatCollections.integerCollection( imgBig ), ( e, a ) -> e.getInteger() == a ); // lossy
+	}
+
+	@Test
+	public void testLongCollection()
+	{
+		assertImageEqualsCollection( imgByte, FlatCollections.longCollection( imgByte ), ( e, a ) -> e.getIntegerLong() == a );
+		assertImageEqualsCollection( imgLong, FlatCollections.longCollection( imgLong ), ( e, a ) -> e.get() == a );
+		assertImageEqualsCollection( imgShort, FlatCollections.longCollection( imgShort ), ( e, a ) -> e.getIntegerLong() == a );
+		assertImageEqualsCollection( imgBig, FlatCollections.longCollection( imgBig ), ( e, a ) -> e.getIntegerLong() == a ); // lossy
+	}
+
+	@Test
+	public void testShortCollection()
+	{
+		assertImageEqualsCollection( imgShort, FlatCollections.shortCollection( imgShort ), ( e, a ) -> e.get() == a );
+	}
+
+	@Test
+	public void testBigIntegerCollection()
+	{
+		assertImageEqualsCollection( imgBig, FlatCollections.bigIntegerCollection( imgBig ), ( e, a ) -> Objects.equals( e.getBigInteger(), a ) );
+	}
+
+	@Test
+	public void testList()
+	{
+		assertImageEqualsCollection( imgString, FlatCollections.list( imgString, s -> s ), Objects::equals );
+	}
+
+	@Test
+	public void testBooleanList()
+	{
+		assertImageEqualsCollection( imgBoolean, FlatCollections.booleanList( imgBoolean ), ( e, a ) -> e.get() == a );
+	}
+
+	@Test
+	public void testByteList()
+	{
+		assertImageEqualsCollection( imgByte, FlatCollections.byteList( imgByte ), ( e, a ) -> e.get() == a );
+	}
+
+	@Test
+	public void testDoubleList()
+	{
+		assertImageEqualsCollection( imgDouble, FlatCollections.doubleList( imgDouble ), ( e, a ) -> e.get() == a );
+		assertImageEqualsCollection( imgByte, FlatCollections.doubleList( imgByte ), ( e, a ) -> e.getRealDouble() == a );
+		assertImageEqualsCollection( imgShort, FlatCollections.doubleList( imgShort ), ( e, a ) -> e.getRealDouble() == a );
+	}
+
+	@Test
+	public void testFloatList()
+	{
+		assertImageEqualsCollection( imgByte, FlatCollections.floatList( imgByte ), ( e, a ) -> e.getRealFloat() == a );
+		assertImageEqualsCollection( imgDouble, FlatCollections.floatList( imgDouble ), ( e, a ) -> e.getRealFloat() == a );
+		assertImageEqualsCollection( imgShort, FlatCollections.floatList( imgShort ), ( e, a ) -> e.getRealFloat() == a );
+	}
+
+	@Test
+	public void testIntegerList()
+	{
+		assertImageEqualsCollection( imgByte, FlatCollections.integerList( imgByte ), ( e, a ) -> e.getInteger() == a );
+		assertImageEqualsCollection( imgInt, FlatCollections.integerList( imgInt ), ( e, a ) -> e.get() == a );
+		assertImageEqualsCollection( imgLong, FlatCollections.integerList( imgLong ), ( e, a ) -> e.getInteger() == a ); // lossy
+		assertImageEqualsCollection( imgShort, FlatCollections.integerList( imgShort ), ( e, a ) -> e.getInteger() == a );
+		assertImageEqualsCollection( imgBig, FlatCollections.integerList( imgBig ), ( e, a ) -> e.getInteger() == a ); // lossy
+	}
+
+	@Test
+	public void testLongList()
+	{
+		assertImageEqualsCollection( imgByte, FlatCollections.longList( imgByte ), ( e, a ) -> e.getIntegerLong() == a );
+		assertImageEqualsCollection( imgLong, FlatCollections.longList( imgLong ), ( e, a ) -> e.get() == a );
+		assertImageEqualsCollection( imgShort, FlatCollections.longList( imgShort ), ( e, a ) -> e.getIntegerLong() == a );
+		assertImageEqualsCollection( imgBig, FlatCollections.longList( imgBig ), ( e, a ) -> e.getIntegerLong() == a ); // lossy
+	}
+
+	@Test
+	public void testShortList()
+	{
+		assertImageEqualsCollection( imgShort, FlatCollections.shortList( imgShort ), ( e, a ) -> e.get() == a );
+	}
+
+	@Test
+	public void testBigIntegerList()
+	{
+		assertImageEqualsCollection( imgBig, FlatCollections.bigIntegerList( imgBig ), ( e, a ) -> Objects.equals( e.getBigInteger(), a ) );
+	}
+
+	private < T, E > void assertImageEqualsCollection( final Img< T > image, final Collection< E > collection, final BiPredicate< T, E > equality )
+	{
+		assertIterationsEqual( image, collection, equality );
+		assertEquals( Intervals.numElements( image ), collection.size() );
+		if ( collection instanceof List )
+			assertRandomAccessEqual( image, ( List< E > ) collection, equality );
+	}
+
+	private < E, A > void assertIterationsEqual( final Iterable< E > expected, final Iterable< A > actual, final BiPredicate< E, A > equality )
+	{
+		final Iterator< E > e = expected.iterator();
+		final Iterator< A > a = actual.iterator();
+		while ( e.hasNext() )
+		{
+			assertTrue( "Fewer elements than expected", a.hasNext() );
+			final E ev = e.next();
+			final A av = a.next();
+			assertTrue( "Unequal elements: expected=" + ev + ", actual=" + av, equality.test( ev, av ) );
+		}
+		assertFalse( "More elements than expected", a.hasNext() );
+	}
+
+	private < T, E > void assertRandomAccessEqual( final Img< T > image, final List< E > list, final BiPredicate< T, E > equality )
+	{
+		final List< Integer > range = IntStream.range( 0, list.size() ).boxed().collect( Collectors.toList() );
+		Collections.shuffle( range, new Random( 0xdeadbeef ) );
+		final RandomAccess< T > access = image.randomAccess();
+		for ( int i = 0; i < list.size(); i++ )
+		{
+			final int index = range.get( i );
+			IntervalIndexer.indexToPosition( index, image, access );
+			final T iv = access.get();
+			final E lv = list.get( index );
+			assertTrue( "Unequal elements: index=" + index + ", image=" + iv + ", list=" + lv, equality.test( iv, lv ) );
+		}
+	}
+}

--- a/src/test/java/net/imglib2/util/FlatCollectionsTest.java
+++ b/src/test/java/net/imglib2/util/FlatCollectionsTest.java
@@ -100,12 +100,6 @@ public final class FlatCollectionsTest
 	}
 
 	@Test
-	public void testByteCollection()
-	{
-		assertImageEqualsCollection( imgByte, FlatCollections.byteCollection( imgByte ), ( e, a ) -> e.get() == a );
-	}
-
-	@Test
 	public void testDoubleCollection()
 	{
 		assertImageEqualsCollection( imgDouble, FlatCollections.doubleCollection( imgDouble ), ( e, a ) -> e.get() == a );
@@ -141,12 +135,6 @@ public final class FlatCollectionsTest
 	}
 
 	@Test
-	public void testShortCollection()
-	{
-		assertImageEqualsCollection( imgShort, FlatCollections.shortCollection( imgShort ), ( e, a ) -> e.get() == a );
-	}
-
-	@Test
 	public void testBigIntegerCollection()
 	{
 		assertImageEqualsCollection( imgBig, FlatCollections.bigIntegerCollection( imgBig ), ( e, a ) -> Objects.equals( e.getBigInteger(), a ) );
@@ -162,12 +150,6 @@ public final class FlatCollectionsTest
 	public void testBooleanList()
 	{
 		assertImageEqualsCollection( imgBoolean, FlatCollections.booleanList( imgBoolean ), ( e, a ) -> e.get() == a );
-	}
-
-	@Test
-	public void testByteList()
-	{
-		assertImageEqualsCollection( imgByte, FlatCollections.byteList( imgByte ), ( e, a ) -> e.get() == a );
 	}
 
 	@Test
@@ -203,12 +185,6 @@ public final class FlatCollectionsTest
 		assertImageEqualsCollection( imgLong, FlatCollections.longList( imgLong ), ( e, a ) -> e.get() == a );
 		assertImageEqualsCollection( imgShort, FlatCollections.longList( imgShort ), ( e, a ) -> e.getIntegerLong() == a );
 		assertImageEqualsCollection( imgBig, FlatCollections.longList( imgBig ), ( e, a ) -> e.getIntegerLong() == a ); // lossy
-	}
-
-	@Test
-	public void testShortList()
-	{
-		assertImageEqualsCollection( imgShort, FlatCollections.shortList( imgShort ), ( e, a ) -> e.get() == a );
 	}
 
 	@Test


### PR DESCRIPTION
This is useful to pass images to APIs that work with collections, such as Guava's `com.google.common.math.Quantiles`.

See also [this post on the Image.sc Forum](https://forum.image.sc/t/imglib2-development-a-question-about-img-t/23186/8).