### PR TITLE
Add Method for Unchecked Casts

### DIFF
--- a/src/main/java/net/imglib2/util/Cast.java
+++ b/src/main/java/net/imglib2/util/Cast.java
@@ -1,0 +1,40 @@
+package net.imglib2.util;
+
+/**
+ * Utility class for type casts.
+ *
+ * @author Matthais Arzt
+ */
+public final class Cast
+{
+
+	private Cast()
+	{
+		// prevent from instantiation
+	}
+
+	/**
+	 * Performs an unchecked cast.
+	 * <p>
+	 * For example this code snipped:
+	 * <pre>
+	 * {@code @SuppressWarnings("unchecked") }
+	 * {@code Img<T> image = (Img<T>) ArrayImgs.ints(100, 100); }
+	 * </pre>
+	 * Can be rewritten as:
+	 * <pre>
+	 * {@code Img<T> image = Casts.unchecked( ArrayImgs.ints(100, 100) );}
+	 * </pre>
+	 * It's possible to explicitly specify the return type:
+	 * <pre>
+	 * {@code Img<T> image = Casts.<Img<T>>unchecked( ArrayImgs.ints(100, 100) );}
+	 * </pre>
+	 * @throws ClassCastException during runtime, if the cast is not possible.
+	 */
+	public static < T > T unchecked( final Object value )
+	{
+		@SuppressWarnings( "unchecked" )
+		T t = ( T ) value;
+		return t;
+	}
+}


### PR DESCRIPTION
I suggest to add a method for unchecked casts, that allows to beautifully write:
```java
Img< T > image = Cast.unchecked( ArrayImgs.ints( 100, 100 ) );
```
instead of the more cumbersome:
```java
@SurpressWarnings( "unchecked" )
Img< T > image = ( Img<T> ) ArrayImgs.ints( 100, 100 );
```