### PR TITLE
Generalize acceptable types for image functions

### DIFF
--- a/src/main/java/net/imglib2/position/AbstractFunctionEuclideanSpace.java
+++ b/src/main/java/net/imglib2/position/AbstractFunctionEuclideanSpace.java
@@ -48,7 +48,7 @@ import net.imglib2.EuclideanSpace;
 public abstract class AbstractFunctionEuclideanSpace< P, T > implements EuclideanSpace
 {
 	protected final int n;
-	protected final Supplier< BiConsumer< P, T > > functionSupplier;
+	protected final Supplier< BiConsumer< P, ? super T > > functionSupplier;
 	protected final Supplier< T > typeSupplier;
 
 	/**
@@ -60,7 +60,7 @@ public abstract class AbstractFunctionEuclideanSpace< P, T > implements Euclidea
 	 */
 	public AbstractFunctionEuclideanSpace(
 			final int n,
-			final Supplier< BiConsumer< P, T > > functionSupplier,
+			final Supplier< BiConsumer< P, ? super T > > functionSupplier,
 			final Supplier< T > typeSupplier )
 	{
 		this.n = n;
@@ -78,7 +78,7 @@ public abstract class AbstractFunctionEuclideanSpace< P, T > implements Euclidea
 	 */
 	public AbstractFunctionEuclideanSpace(
 			final int n,
-			final BiConsumer< P, T > function,
+			final BiConsumer< P, ? super T > function,
 			final Supplier< T > typeSupplier )
 	{
 		this(n, () -> function, typeSupplier);

--- a/src/main/java/net/imglib2/position/FunctionRandomAccessible.java
+++ b/src/main/java/net/imglib2/position/FunctionRandomAccessible.java
@@ -54,7 +54,7 @@ public class FunctionRandomAccessible< T > extends AbstractFunctionEuclideanSpac
 {
 	public FunctionRandomAccessible(
 			final int n,
-			final BiConsumer< Localizable, T > function,
+			final BiConsumer< Localizable, ? super T > function,
 			final Supplier< T > typeSupplier )
 	{
 		super(n, function, typeSupplier);
@@ -62,7 +62,7 @@ public class FunctionRandomAccessible< T > extends AbstractFunctionEuclideanSpac
 
 	public FunctionRandomAccessible(
 			final int n,
-			final Supplier< BiConsumer< Localizable, T > > functionSupplier,
+			final Supplier< BiConsumer< Localizable, ? super T > > functionSupplier,
 			final Supplier< T > typeSupplier )
 	{
 		super(n, functionSupplier, typeSupplier);
@@ -71,7 +71,7 @@ public class FunctionRandomAccessible< T > extends AbstractFunctionEuclideanSpac
 	public class FunctionRandomAccess extends Point implements RandomAccess< T >
 	{
 		private final T t = typeSupplier.get();
-		private final BiConsumer< Localizable, T > function = functionSupplier.get();
+		private final BiConsumer< Localizable, ? super T > function = functionSupplier.get();
 
 		public FunctionRandomAccess()
 		{

--- a/src/main/java/net/imglib2/position/FunctionRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/position/FunctionRealRandomAccessible.java
@@ -53,7 +53,7 @@ public class FunctionRealRandomAccessible< T > extends AbstractFunctionEuclidean
 {
 	public FunctionRealRandomAccessible(
 			final int n,
-			final BiConsumer< RealLocalizable, T > function,
+			final BiConsumer< RealLocalizable, ? super T > function,
 			final Supplier< T > typeSupplier )
 	{
 		super( n, function, typeSupplier );
@@ -61,7 +61,7 @@ public class FunctionRealRandomAccessible< T > extends AbstractFunctionEuclidean
 
 	public FunctionRealRandomAccessible(
 			final int n,
-			final Supplier< BiConsumer< RealLocalizable, T > > function,
+			final Supplier< BiConsumer< RealLocalizable, ? super T > > function,
 			final Supplier< T > typeSupplier )
 	{
 		super( n, function, typeSupplier );
@@ -70,7 +70,7 @@ public class FunctionRealRandomAccessible< T > extends AbstractFunctionEuclidean
 	public class RealFunctionRealRandomAccess extends RealPoint implements RealRandomAccess< T >
 	{
 		private final T t = typeSupplier.get();
-		private final BiConsumer< RealLocalizable, T > function = functionSupplier.get();
+		private final BiConsumer< RealLocalizable, ? super T > function = functionSupplier.get();
 
 		public RealFunctionRealRandomAccess()
 		{


### PR DESCRIPTION
Since the function populates values by side effect, a `BiConsumer` that works with some more general type than `T` is OK. For example, a function that works on `RealType<?>` could be defined, and then used to create a `FunctionRandomAccessible` with a type creator that is restricted to producing `UnsignedByteType`.

See also [this discussion on Gitter](https://gitter.im/imglib/imglib2?at=5d091817bb789747fb350da9).