### PR TITLE
Checking the validity of input Cursors

### DIFF
--- a/src/test/java/net/imglib2/img/array/ArrayImgsTest.java
+++ b/src/test/java/net/imglib2/img/array/ArrayImgsTest.java
@@ -479,6 +479,10 @@ public class ArrayImgsTest
 		final ArrayCursor< T > r = ref.cursor();
 		for ( int s = start; s < stop; ++s )
 		{
+			if ( !c.hasNext() || !r.hasNext() )
+			{
+				Assert.fail( "Invalid iterators for test range" );
+			}
 			Assert.assertEquals( c.next().getInteger(), s );
 			Assert.assertEquals( r.next().getInteger(), s );
 		}

--- a/src/test/java/net/imglib2/img/cell/CopyTest.java
+++ b/src/test/java/net/imglib2/img/cell/CopyTest.java
@@ -133,7 +133,7 @@ public class CopyTest
 		{
 			if ( !dst.hasNext() )
 			{
-				throw new NoSuchElementException("Cursor does not have next element");
+				throw new NoSuchElementException(" Cursor dst does not have next element" );
 			}
 			dst.next().set( src.next().get() );
 		}

--- a/src/test/java/net/imglib2/img/cell/CopyTest.java
+++ b/src/test/java/net/imglib2/img/cell/CopyTest.java
@@ -36,6 +36,7 @@ package net.imglib2.img.cell;
 
 import static org.junit.Assert.assertArrayEquals;
 
+import java.util.NoSuchElementException;
 import java.util.Random;
 
 import org.junit.Before;
@@ -130,6 +131,10 @@ public class CopyTest
 		final Cursor< IntType > dst = dstImg.cursor();
 		while ( src.hasNext() )
 		{
+			if ( !dst.hasNext() )
+			{
+				throw new NoSuchElementException("Cursor does not have next element");
+			}
 			dst.next().set( src.next().get() );
 		}
 	}

--- a/src/test/java/net/imglib2/view/RandomAccessibleIntervalCursorTest.java
+++ b/src/test/java/net/imglib2/view/RandomAccessibleIntervalCursorTest.java
@@ -107,7 +107,7 @@ public class RandomAccessibleIntervalCursorTest
 		{
 			if ( !dst.hasNext() )
 			{
-				throw new NoSuchElementException("Cursor dst does not have next element");
+				throw new NoSuchElementException( "Cursor dst does not have next element" );
 			}
 			
 			dst.next().set( src.next().get() );

--- a/src/test/java/net/imglib2/view/RandomAccessibleIntervalCursorTest.java
+++ b/src/test/java/net/imglib2/view/RandomAccessibleIntervalCursorTest.java
@@ -37,6 +37,7 @@ package net.imglib2.view;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.util.NoSuchElementException;
 import java.util.Random;
 
 import org.junit.Before;
@@ -103,7 +104,14 @@ public class RandomAccessibleIntervalCursorTest
 	public void copy( final Cursor< IntType > src, final Cursor< IntType > dst )
 	{
 		while ( src.hasNext() )
+		{
+			if ( !dst.hasNext() )
+			{
+				throw new NoSuchElementException("Cursor dst does not have next element");
+			}
+			
 			dst.next().set( src.next().get() );
+		}
 	}
 
 	int[] getImgAsInts( final Img< IntType > img )


### PR DESCRIPTION
These tests calls of `Cursor.next()` without checking if there are any elements to iterate over. Because the method is public and the iterators are obtained from inputs, they could be invalid (e.g., an empty list). This could lead to an exception. This pull request adds a 'hasNext()' check.