### PR TITLE
Add toString, equals and hashCode for Intervals, RealIntervals & Points

### DIFF
--- a/src/main/java/net/imglib2/AbstractInterval.java
+++ b/src/main/java/net/imglib2/AbstractInterval.java
@@ -34,6 +34,8 @@
 
 package net.imglib2;
 
+import net.imglib2.util.Intervals;
+
 /**
  * Implementation of the {@link Interval} interface.
  * 
@@ -246,34 +248,6 @@ public abstract class AbstractInterval extends AbstractEuclideanSpace implements
 	@Override
 	public String toString()
 	{
-		final StringBuilder sb = new StringBuilder();
-
-		final String className = this.getClass().getSimpleName();
-		sb.append( className );
-
-		sb.append( " [(" );
-		for ( int d = 0; d < n; d++ )
-		{
-			sb.append( min[ d ] );
-			if ( d < n - 1 )
-				sb.append( ", " );
-		}
-		sb.append( ") -- (" );
-		for ( int d = 0; d < n; d++ )
-		{
-			sb.append( max[ d ] );
-			if ( d < n - 1 )
-				sb.append( ", " );
-		}
-		sb.append( ") = " );
-		for ( int d = 0; d < n; d++ )
-		{
-			sb.append( dimension( d ) );
-			if ( d < n - 1 )
-				sb.append( "x" );
-		}
-		sb.append( "]" );
-
-		return sb.toString();
+		return this.getClass().getSimpleName() + " " + Intervals.toString( this );
 	}
 }

--- a/src/main/java/net/imglib2/AbstractRealInterval.java
+++ b/src/main/java/net/imglib2/AbstractRealInterval.java
@@ -34,6 +34,8 @@
 
 package net.imglib2;
 
+import net.imglib2.util.Intervals;
+
 /**
  * Implementation of the {@link RealInterval} interface.
  * 
@@ -125,4 +127,11 @@ public class AbstractRealInterval extends AbstractEuclideanSpace implements Real
 		for ( int d = 0; d < n; ++d )
 			realMax.setPosition( this.max[ d ], d );
 	}
+
+	@Override
+	public String toString()
+	{
+		return getClass().getSimpleName() + " " + Intervals.toString( this );
+	}
+
 }

--- a/src/main/java/net/imglib2/FinalDimensions.java
+++ b/src/main/java/net/imglib2/FinalDimensions.java
@@ -36,6 +36,8 @@ package net.imglib2;
 
 import net.imglib2.util.Intervals;
 
+import java.util.Arrays;
+
 /**
  * An implementation of dimensionality that can wrap a long[] array. The same
  * principle for wrapping as in Point is used.
@@ -115,6 +117,25 @@ public final class FinalDimensions implements Dimensions
 	public long dimension( final int d )
 	{
 		return dimensions[ d ];
+	}
+
+	@Override
+	public String toString()
+	{
+		return Intervals.toString( this );
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return obj instanceof FinalDimensions &&
+				Intervals.equalDimensions( this, (FinalDimensions) obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Arrays.hashCode( dimensions );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/FinalInterval.java
+++ b/src/main/java/net/imglib2/FinalInterval.java
@@ -34,6 +34,11 @@
 
 package net.imglib2;
 
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+
+import java.util.Arrays;
+
 /**
  * Implementation of the {@link Interval} interface.
  * 
@@ -87,6 +92,18 @@ public final class FinalInterval extends AbstractInterval
 	public FinalInterval( final long... dimensions )
 	{
 		super( dimensions );
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return obj instanceof FinalInterval && Intervals.equals( this, ( FinalInterval ) obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Util.combineHash( Arrays.hashCode( min ), Arrays.hashCode( max ) );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/FinalRealInterval.java
+++ b/src/main/java/net/imglib2/FinalRealInterval.java
@@ -34,6 +34,11 @@
 
 package net.imglib2;
 
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+
+import java.util.Arrays;
+
 /**
  * Implementation of the {@link RealInterval} interface.
  * 
@@ -119,5 +124,19 @@ public final class FinalRealInterval extends AbstractRealInterval
 			max[ d ] = minmax[ d + n ];
 		}
 		return new FinalRealInterval( min, max );
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return obj instanceof FinalRealInterval &&
+				Intervals.equals( this, ( RealInterval ) obj, 0.0 );
+
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Util.combineHash( Arrays.hashCode( min ), Arrays.hashCode( max ) );
 	}
 }

--- a/src/main/java/net/imglib2/Point.java
+++ b/src/main/java/net/imglib2/Point.java
@@ -34,6 +34,10 @@
 
 package net.imglib2;
 
+import net.imglib2.util.Localizables;
+
+import java.util.Arrays;
+
 /**
  * A Point is a position in Euclidean space specified in integer coordinates.
  *
@@ -188,34 +192,20 @@ public class Point extends AbstractLocalizable implements Positionable
 	@Override
 	public String toString()
 	{
-		final StringBuilder sb = new StringBuilder();
-		char c = '(';
-		for ( int i = 0; i < numDimensions(); i++ )
-		{
-			sb.append( c );
-			sb.append( position[ i ] );
-			c = ',';
-		}
-		sb.append( ")" );
-		return sb.toString();
+		return Localizables.toString( this );
 	}
 
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if ( obj instanceof RealLocalizable && ( ( RealLocalizable ) obj ).numDimensions() == numDimensions() )
-		{
-			final RealLocalizable asLocalizable = ( ( RealLocalizable ) obj );
+		return obj != null && obj.getClass() == getClass() &&
+				Localizables.equals( this, ( Point ) obj );
+	}
 
-			for ( int d = 0; d < numDimensions(); d++ )
-			{
-				if ( asLocalizable.getDoublePosition( d ) != getDoublePosition( d ) )
-					return false;
-			}
-			return true;
-		}
-
-		return false;
+	@Override
+	public int hashCode()
+	{
+		return Arrays.hashCode( position );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/RealPoint.java
+++ b/src/main/java/net/imglib2/RealPoint.java
@@ -34,6 +34,10 @@
 
 package net.imglib2;
 
+import net.imglib2.util.Localizables;
+
+import java.util.Arrays;
+
 /**
  * A point is a location in EuclideanSpace.
  *
@@ -255,16 +259,20 @@ public class RealPoint extends AbstractRealLocalizable implements RealPositionab
 	@Override
 	public String toString()
 	{
-		final StringBuilder sb = new StringBuilder();
-		char c = '(';
-		for ( int i = 0; i < numDimensions(); i++ )
-		{
-			sb.append( c );
-			sb.append( position[ i ] );
-			c = ',';
-		}
-		sb.append( ")" );
-		return sb.toString();
+		return Localizables.toString( this );
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return obj != null && obj.getClass() == getClass() &&
+				Localizables.equals( this, ( RealPoint ) obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Arrays.hashCode( position );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -45,6 +45,8 @@ import net.imglib2.RealLocalizable;
 import net.imglib2.transform.integer.Mixed;
 import net.imglib2.view.ViewTransforms;
 
+import java.util.StringJoiner;
+
 /**
  * Convenience methods for manipulating {@link Interval Intervals}.
  * 
@@ -809,7 +811,24 @@ public class Intervals
 	/**
 	 * Tests whether two {@link RealInterval}s are equal in their min / max.
 	 */
-	public static boolean equals( final RealInterval a, final RealInterval b, final double tolerance )
+	public static boolean equals( final RealInterval a, final RealInterval b )
+	{
+		if ( a.numDimensions() != b.numDimensions() )
+			return false;
+
+		for ( int d = 0; d < a.numDimensions(); ++d )
+			if ( a.realMin( d ) != b.realMin( d ) || a.realMax( d ) != b.realMax( d ) )
+				return false;
+
+		return true;
+	}
+
+	/**
+	 * Tests whether two {@link RealInterval}s are equal in their min / max.
+	 * With respect to the given tolerance.
+	 */
+	public static boolean equals( final RealInterval a, final RealInterval b,
+			final double tolerance)
 	{
 		if ( a.numDimensions() != b.numDimensions() )
 			return false;
@@ -1009,5 +1028,78 @@ public class Intervals
 		final double[] min = new double[ interval.numDimensions() ];
 		interval.realMin( min );
 		return min;
+	}
+
+	/**
+	 * Returns a string that contains min, max and the dimensions of the
+	 * {@link Interval}.
+	 */
+	public static String toString( final Interval value )
+	{
+		final StringBuilder sb = new StringBuilder();
+
+		sb.append( "[(" );
+		final int n = value.numDimensions();
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( value.min( d ) );
+			if ( d < n - 1 )
+				sb.append( ", " );
+		}
+		sb.append( ") -- (" );
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( value.max( d ) );
+			if ( d < n - 1 )
+				sb.append( ", " );
+		}
+		sb.append( ") = " );
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( value.dimension( d ) );
+			if ( d < n - 1 )
+				sb.append( "x" );
+		}
+		sb.append( "]" );
+
+		return sb.toString();
+	}
+
+	/**
+	 * Returns a string that contains min and max of the {@link RealInterval}.
+	 */
+	public static String toString( final RealInterval value )
+	{
+		final StringBuilder sb = new StringBuilder();
+
+		sb.append( "[(" );
+		final int n = value.numDimensions();
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( value.realMin( d ) );
+			if ( d < n - 1 )
+				sb.append( ", " );
+		}
+		sb.append( ") -- (" );
+		for ( int d = 0; d < n; d++ )
+		{
+			sb.append( value.realMax( d ) );
+			if ( d < n - 1 )
+				sb.append( ", " );
+		}
+		sb.append( ")]" );
+
+		return sb.toString();
+	}
+
+	/**
+	 * Converts the {@link Dimensions} into a string.
+	 */
+	public static String toString( final Dimensions value )
+	{
+		final StringJoiner joiner = new StringJoiner( "x" );
+		for ( int d = 0; d < value.numDimensions(); d++ )
+			joiner.add( Long.toString( value.dimension( d ) ) );
+		return joiner.toString();
 	}
 }

--- a/src/main/java/net/imglib2/util/Localizables.java
+++ b/src/main/java/net/imglib2/util/Localizables.java
@@ -41,31 +41,118 @@ import net.imglib2.Point;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealLocalizable;
 import net.imglib2.Sampler;
 import net.imglib2.view.Views;
 
 public class Localizables
 {
 
-	public static long[] asLongArray( Localizable localizable ) {
-		long[] result = new long[ localizable.numDimensions() ];
+	public static long[] asLongArray( final Localizable localizable ) {
+		final long[] result = new long[ localizable.numDimensions() ];
 		localizable.localize( result );
 		return result;
 	}
 
-	public static RandomAccessible< Localizable > randomAccessible( int n ) {
+	public static RandomAccessible< Localizable > randomAccessible( final int n ) {
 		return new LocationRandomAccessible( n );
 	}
 
-	public RandomAccessibleInterval< Localizable > randomAccessibleInterval( Interval interval ) {
+	public RandomAccessibleInterval< Localizable > randomAccessibleInterval( final Interval interval ) {
 		return Views.interval( randomAccessible( interval.numDimensions() ), interval );
+	}
+
+	/**
+	 * Return true if both {@link Localizable} refer to the same position.
+	 */
+	public static boolean equals( final Localizable a, final Localizable b )
+	{
+		final int n = a.numDimensions();
+		if ( n != b.numDimensions() )
+			return false;
+
+		for ( int d = 0; d < n; d++ )
+			if ( a.getLongPosition( d ) != b.getLongPosition( d ) )
+				return false;
+
+		return true;
+	}
+
+	/**
+	 * Return true if the two {@link RealLocalizable}s refer to the same
+	 * position.
+	 */
+	public static boolean equals( final RealLocalizable a, final RealLocalizable b )
+	{
+		final int n = a.numDimensions();
+
+		if ( n != b.numDimensions() )
+			return false;
+
+		for ( int d = 0; d < n; d++ )
+			if ( a.getDoublePosition( d ) != b.getDoublePosition( d ) )
+				return false;
+
+		return true;
+	}
+
+	/**
+	 * Return true if the two {@link RealLocalizable}s refer to the same
+	 * position up to a given tolerance.
+	 */
+	public static boolean equals( final RealLocalizable a, final RealLocalizable b, final double tolerance )
+	{
+		final int n = a.numDimensions();
+
+		if ( n != b.numDimensions() )
+			return false;
+
+		for ( int d = 0; d < n; d++ )
+			if ( Math.abs( a.getDoublePosition( d ) - b.getDoublePosition( d ) ) > tolerance )
+				return false;
+
+		return true;
+	}
+
+	/**
+	 * Return the current position as string.
+	 */
+	public static String toString( final Localizable value )
+	{
+		final StringBuilder sb = new StringBuilder();
+		char c = '(';
+		for ( int i = 0; i < value.numDimensions(); i++ )
+		{
+			sb.append( c );
+			sb.append( value.getLongPosition( i ) );
+			c = ',';
+		}
+		sb.append( ")" );
+		return sb.toString();
+	}
+
+	/**
+	 * Return the current position as string.
+	 */
+	public static String toString( final RealLocalizable value )
+	{
+		final StringBuilder sb = new StringBuilder();
+		char c = '(';
+		for ( int i = 0; i < value.numDimensions(); i++ )
+		{
+			sb.append( c );
+			sb.append( value.getDoublePosition( i ) );
+			c = ',';
+		}
+		sb.append( ")" );
+		return sb.toString();
 	}
 
 	// -- Helper classes --
 
 	private static class LocationRandomAccessible extends AbstractEuclideanSpace implements RandomAccessible< Localizable >
 	{
-		public LocationRandomAccessible( int n )
+		public LocationRandomAccessible( final int n )
 		{
 			super( n );
 		}
@@ -75,7 +162,7 @@ public class Localizables
 			return new LocationRandomAccess( n );
 		}
 
-		@Override public RandomAccess< Localizable > randomAccess( Interval interval )
+		@Override public RandomAccess< Localizable > randomAccess( final Interval interval )
 		{
 			return randomAccess();
 		}
@@ -86,12 +173,12 @@ public class Localizables
 	 */
 	private static class LocationRandomAccess extends Point implements RandomAccess< Localizable >
 	{
-		public LocationRandomAccess( int n )
+		public LocationRandomAccess( final int n )
 		{
 			super( n );
 		}
 
-		public LocationRandomAccess( Localizable initialPosition )
+		public LocationRandomAccess( final Localizable initialPosition )
 		{
 			super( initialPosition );
 		}

--- a/src/test/java/net/imglib2/FinalDimensionsTest.java
+++ b/src/test/java/net/imglib2/FinalDimensionsTest.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link FinalDimensions}
+ *
+ * @author Matthias Arzt
+ */
+public class FinalDimensionsTest
+{
+
+	@Test
+	public void testEquals()
+	{
+		final FinalDimensions dimensions = new FinalDimensions( 1, 2 );
+		final FinalDimensions sameDimensions = new FinalDimensions( 1, 2 );
+		final FinalDimensions differentDimensions = new FinalDimensions( 1, 2, 2 );
+		assertTrue( dimensions.equals( sameDimensions ) );
+		assertFalse( dimensions.equals( differentDimensions ) );
+	}
+
+	@Test
+	public void testHashCode()
+	{
+		final FinalDimensions dimensions = new FinalDimensions( 1, 2 );
+		final FinalDimensions sameDimensions = new FinalDimensions( 1, 2 );
+		assertEquals( dimensions.hashCode(), sameDimensions.hashCode() );
+	}
+
+	@Test
+	public void testToString()
+	{
+		final FinalDimensions dimensions = new FinalDimensions( 1, 2 );
+		assertEquals( "1x2", dimensions.toString() );
+	}
+}

--- a/src/test/java/net/imglib2/FinalIntervalTest.java
+++ b/src/test/java/net/imglib2/FinalIntervalTest.java
@@ -35,6 +35,9 @@
 package net.imglib2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -133,5 +136,33 @@ public class FinalIntervalTest
 		assertEquals( dim0, interval.dimension( 0 ) );
 		assertEquals( dim1, interval.dimension( 1 ) );
 		assertEquals( dim2, interval.dimension( 2 ) );
+	}
+
+	@Test
+	public void testEquals()
+	{
+		final FinalInterval interval = FinalInterval.createMinMax( 1, 2, 3, 4 );
+		final FinalInterval sameInterval = FinalInterval.createMinMax( 1, 2, 3, 4 );
+		final FinalInterval differentInterval = FinalInterval.createMinMax( 1, 2, 3, 0 );
+		assertTrue( interval.equals( interval ) );
+		assertTrue( interval.equals( sameInterval ) );
+		assertFalse( interval.equals( differentInterval ) );
+		assertFalse( interval.equals( null ) );
+	}
+
+	@Test
+	public void testHashCode()
+	{
+		final FinalInterval interval = FinalInterval.createMinMax( 1, 2, 3, 4 );
+		final FinalInterval sameInterval = FinalInterval.createMinMax( 1, 2, 3, 4 );
+		assertEquals( interval.hashCode(), interval.hashCode() );
+		assertEquals( interval.hashCode(), sameInterval.hashCode() );
+	}
+
+	@Test
+	public void testToString()
+	{
+		final FinalInterval interval = FinalInterval.createMinMax( 1, 2, 3, 4 );
+		assertEquals( "FinalInterval [(1, 2) -- (3, 4) = 3x3]", interval.toString() );
 	}
 }

--- a/src/test/java/net/imglib2/FinalRealIntervalTest.java
+++ b/src/test/java/net/imglib2/FinalRealIntervalTest.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *	Tests {@link FinalRealInterval}.
+ *
+ *  @author Matthias Arzt
+ */
+public class FinalRealIntervalTest
+{
+
+	@Test
+	public void testEquals()
+	{
+		FinalRealInterval interval = FinalRealInterval.createMinMax( 1.0, 2.5, 3.0, 4.0 );
+		FinalRealInterval same = FinalRealInterval.createMinMax( 1.0, 2.5, 3.0, 4.0 );
+		FinalRealInterval different = FinalRealInterval.createMinMax( 1.0, 2.5001, 3.0, 4.0 );
+		assertTrue( interval.equals( same ) );
+		assertFalse( interval.equals( different ) );
+	}
+
+	@Test
+	public void testHashCode()
+	{
+		FinalRealInterval interval = FinalRealInterval.createMinMax( 1.0, 2.5, 3.0, 4.0 );
+		FinalRealInterval same = FinalRealInterval.createMinMax( 1.0, 2.5, 3.0, 4.0 );
+		assertEquals( interval.hashCode(), same.hashCode() );
+	}
+
+	@Test
+	public void testToString()
+	{
+		final FinalRealInterval interval = FinalRealInterval.createMinMax( 1.0, 2.0, 3.0, 4.0 );
+		assertEquals( "FinalRealInterval [(1.0, 2.0) -- (3.0, 4.0)]", interval.toString() );
+	}
+}

--- a/src/test/java/net/imglib2/PointTest.java
+++ b/src/test/java/net/imglib2/PointTest.java
@@ -35,6 +35,9 @@
 package net.imglib2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -394,4 +397,28 @@ public class PointTest
 		assertEquals( p.getLongPosition( 1 ), initial[ 1 ] );
 	}
 
+	@Test
+	public void testEquals()
+	{
+		final Point point = new Point( 1, 2, 3 );
+		final Point same = new Point( 1, 2, 3 );
+		final Point different = new Point( 1, 2, 3, 4 );
+		assertTrue( point.equals( same ) );
+		assertFalse( point.equals( different ) );
+	}
+
+	@Test
+	public void testHashCode()
+	{
+		final Point point = new Point( 1, 2, 3 );
+		final Point same = new Point( 1, 2, 3 );
+		assertEquals( point.hashCode(), same.hashCode() );
+	}
+
+	@Test
+	public void testToString()
+	{
+		final Point point = new Point( 1, 2 );
+		assertEquals( "(1,2)", point.toString() );
+	}
 }

--- a/src/test/java/net/imglib2/RealPointTest.java
+++ b/src/test/java/net/imglib2/RealPointTest.java
@@ -35,6 +35,9 @@
 package net.imglib2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -568,4 +571,34 @@ public class RealPointTest
 		}
 	}
 
+	/**
+	 * Test method for {@link RealPoint#equals(Object)}
+	 */
+	@Test
+	public void testEquals()
+	{
+		final RealPoint point = new RealPoint( 1.0, 2.5 );
+		final RealPoint same = new RealPoint( 1.0, 2.5 );
+		final RealPoint different = new RealPoint( 1.0, 2.501 );
+		assertTrue( point.equals( same ) );
+		assertFalse( point.equals( different ) );
+	}
+
+	/**
+	 * Test method for {@link RealPoint#hashCode()}
+	 */
+	@Test
+	public void testHashCode()
+	{
+		final RealPoint point = new RealPoint( 1.0, 2.5 );
+		final RealPoint same = new RealPoint( 1.0, 2.5 );
+		assertEquals( point.hashCode(), same.hashCode() );
+	}
+
+	@Test
+	public void testToString()
+	{
+		final RealPoint point = new RealPoint( 1.0, 2.0 );
+		assertEquals( "(1.0,2.0)", point.toString() );
+	}
 }

--- a/src/test/java/net/imglib2/util/IntervalsTest.java
+++ b/src/test/java/net/imglib2/util/IntervalsTest.java
@@ -182,6 +182,16 @@ public class IntervalsTest
 	public void testEqualsForRealIntervals()
 	{
 		final RealInterval interval = FinalRealInterval.createMinMax( 1, 2, 3, 4 );
+		final RealInterval sameInterval = FinalRealInterval.createMinMax( 1, 2, 3, 4 );
+		final RealInterval differentInterval = FinalRealInterval.createMinMax( 1, 2, 3, 5 );
+		assertTrue( Intervals.equals( interval, sameInterval ) );
+		assertFalse( Intervals.equals( interval, differentInterval ) );
+	}
+
+	@Test
+	public void testEqualsForRealIntervalsWithTolerance()
+	{
+		final RealInterval interval = FinalRealInterval.createMinMax( 1, 2, 3, 4 );
 		final RealInterval similarInterval = FinalRealInterval.createMinMax( 1.1, 1.9, 3.0, 4.1 );
 		final RealInterval differentInterval = FinalRealInterval.createMinMax( 1, 2, 3, 5 );
 		assertTrue( Intervals.equals( interval, similarInterval, 0.2 ) );


### PR DESCRIPTION
It would be super useful for debugging and development, if we have suitable `toString`, `equals` and `hashCode` methods for `Intervals` and `Points`. This PR add methods:

* `toString()`, `hashCode()` and `equals(Object)` for `FinalInterval`, `FinalRealInterval`, `Point`, `RealPoint` and `FinalDimensions`, if missing.
* `Intervals.equals(RealInterval, RealInterval)`
* `Intervals.equals(RealInterval, RealInterval, double tolerance)`
* `Intervals.equalsDimensions(Dimensions, Dimensions)`
* `Intervals.toString(Interval)`
* `Intervals.toString(RealInterval)`
* `Intervals.toString(Dimensions)`
* `Localizables.equals(Localizable, Localizable)`
* `Localizables.equals(RealLocalizable, RealLocalizable)`
* `Localizables.equals(RealLocalizable, RealLocalizable, double tolerance)`
* `Localizables.toString(Localizable)`
* `Localizables.toString(RealLocalizable)`

Sorry, this PR is based on a previous PR https://github.com/imglib/imglib2/pull/265