### PR TITLE
Remove generic bounds for constant out of bounds

### DIFF
--- a/src/main/java/net/imglib2/outofbounds/AbstractOutOfBoundsValue.java
+++ b/src/main/java/net/imglib2/outofbounds/AbstractOutOfBoundsValue.java
@@ -39,7 +39,6 @@ import net.imglib2.Interval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
-import net.imglib2.type.Type;
 
 /**
  * 
@@ -48,8 +47,9 @@ import net.imglib2.type.Type;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch
+ * @author Philipp Hanslovsky
  */
-public abstract class AbstractOutOfBoundsValue< T extends Type< T > > extends AbstractLocalizable implements OutOfBounds< T >
+public abstract class AbstractOutOfBoundsValue< T > extends AbstractLocalizable implements OutOfBounds< T >
 {
 	final protected RandomAccess< T > sampler;
 

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
@@ -98,8 +98,10 @@ public class OutOfBoundsConstantValue< T > extends AbstractOutOfBoundsValue< T >
 		return copy();
 	}
 
-	private static < T > Supplier< T > makeSupplierFrom( final T t ) {
-		if ( t instanceof Type< ? > ) {
+	private static < T > Supplier< T > makeSupplierFrom( final T t )
+	{
+		if ( t instanceof Type< ? > )
+		{
 			final Type< ? > type = ( Type< ? > ) t;
 			return () -> ( T ) type.copy();
 		}

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
@@ -88,12 +88,14 @@ public class OutOfBoundsConstantValue< T > extends AbstractOutOfBoundsValue< T >
 		return copy();
 	}
 
-	private static < T > T copyIfType( final T t )
+	static < T > T copyIfType( final T t )
 	{
 		if ( t instanceof Type< ? > )
 		{
 			final Type< ? > type = ( Type< ? > ) t;
-			return ( T ) type.copy();
+			@SuppressWarnings( "unchecked" )
+			final T copy = ( T ) type.copy();
+			return copy;
 		}
 		return t;
 	}

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
@@ -60,7 +60,7 @@ public class OutOfBoundsConstantValue< T > extends AbstractOutOfBoundsValue< T >
 	public < F extends Interval & RandomAccessible< T > > OutOfBoundsConstantValue( final F f, final T value )
 	{
 		super( f );
-		this.value = copyIfType( value );
+		this.value = value;
 	}
 
 	/* Sampler */

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
@@ -52,9 +52,9 @@ public class OutOfBoundsConstantValue< T > extends AbstractOutOfBoundsValue< T >
 {
 	private final Supplier< T > valueSupplier;
 
-	final protected T value;
+	private final T value;
 
-	protected OutOfBoundsConstantValue( final OutOfBoundsConstantValue< T > outOfBounds )
+	private OutOfBoundsConstantValue( final OutOfBoundsConstantValue< T > outOfBounds )
 	{
 		super( outOfBounds );
 		this.valueSupplier = outOfBounds.valueSupplier;

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValue.java
@@ -34,8 +34,6 @@
 
 package net.imglib2.outofbounds;
 
-import java.util.function.Supplier;
-
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.type.Type;
@@ -50,27 +48,19 @@ import net.imglib2.type.Type;
  */
 public class OutOfBoundsConstantValue< T > extends AbstractOutOfBoundsValue< T >
 {
-	private final Supplier< T > valueSupplier;
 
-	private final T value;
+	final protected T value;
 
-	private OutOfBoundsConstantValue( final OutOfBoundsConstantValue< T > outOfBounds )
+	protected OutOfBoundsConstantValue( final OutOfBoundsConstantValue< T > outOfBounds )
 	{
 		super( outOfBounds );
-		this.valueSupplier = outOfBounds.valueSupplier;
-		this.value = this.valueSupplier.get();
-	}
-
-	public < F extends Interval & RandomAccessible< T > > OutOfBoundsConstantValue( final F f, final Supplier< T > valueSupplier )
-	{
-		super( f );
-		this.valueSupplier = valueSupplier;
-		this.value = this.valueSupplier.get();
+		this.value = copyIfType( outOfBounds.value );
 	}
 
 	public < F extends Interval & RandomAccessible< T > > OutOfBoundsConstantValue( final F f, final T value )
 	{
-		this( f, makeSupplierFrom( value ) );
+		super( f );
+		this.value = copyIfType( value );
 	}
 
 	/* Sampler */
@@ -98,13 +88,13 @@ public class OutOfBoundsConstantValue< T > extends AbstractOutOfBoundsValue< T >
 		return copy();
 	}
 
-	private static < T > Supplier< T > makeSupplierFrom( final T t )
+	private static < T > T copyIfType( final T t )
 	{
 		if ( t instanceof Type< ? > )
 		{
 			final Type< ? > type = ( Type< ? > ) t;
-			return () -> ( T ) type.copy();
+			return ( T ) type.copy();
 		}
-		return () -> t;
+		return t;
 	}
 }

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
@@ -84,8 +84,10 @@ public class OutOfBoundsConstantValueFactory< T, F extends Interval & RandomAcce
 		return new OutOfBoundsConstantValue<>( f, valueSupplier );
 	}
 
-	private static < T > Supplier< T > makeSupplierFrom( final T t ) {
-		if ( t instanceof Type< ? > ) {
+	private static < T > Supplier< T > makeSupplierFrom( final T t )
+	{
+		if ( t instanceof Type< ? > )
+		{
 			final Type< ? > type = ( Type< ? > ) t;
 			return () -> ( T ) type.copy();
 		}

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.outofbounds;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.type.Type;
@@ -44,30 +46,49 @@ import net.imglib2.type.Type;
  * 
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
+ * @author Philipp Hanslovsky
  */
-public class OutOfBoundsConstantValueFactory< T extends Type< T >, F extends Interval & RandomAccessible< T > >
+public class OutOfBoundsConstantValueFactory< T, F extends Interval & RandomAccessible< T > >
 		implements OutOfBoundsFactory< T, F >
 {
-	protected T value;
+	protected Supplier< T > valueSupplier;
+
+	public OutOfBoundsConstantValueFactory( final Supplier< T > valueSupplier )
+	{
+		this.valueSupplier = valueSupplier;
+	}
 
 	public OutOfBoundsConstantValueFactory( final T value )
 	{
-		this.value = value;
+		this( makeSupplierFrom( value ) );
+	}
+
+	public void setValueSupplier( final Supplier< T > valueSupplier )
+	{
+		this.valueSupplier = valueSupplier;
 	}
 
 	public void setValue( final T value )
 	{
-		this.value = value;
+		setValueSupplier( makeSupplierFrom( value ) );
 	}
 
 	public T getValue()
 	{
-		return value;
+		return valueSupplier.get();
 	}
 
 	@Override
 	public OutOfBoundsConstantValue< T > create( final F f )
 	{
-		return new OutOfBoundsConstantValue< T >( f, value.copy() );
+		return new OutOfBoundsConstantValue<>( f, valueSupplier );
+	}
+
+	private static < T > Supplier< T > makeSupplierFrom( final T t ) {
+		if ( t instanceof Type< ? > ) {
+			final Type< ? > type = ( Type< ? > ) t;
+			return () -> ( T ) type.copy();
+		}
+		return () -> t;
 	}
 }

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
@@ -36,7 +36,6 @@ package net.imglib2.outofbounds;
 
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
-import net.imglib2.type.Type;
 
 /**
  * 
@@ -69,16 +68,6 @@ public class OutOfBoundsConstantValueFactory< T, F extends Interval & RandomAcce
 	@Override
 	public OutOfBoundsConstantValue< T > create( final F f )
 	{
-		return new OutOfBoundsConstantValue<>( f, copyIfType( value ) );
-	}
-
-	private static < T > T copyIfType( final T t )
-	{
-		if ( t instanceof Type )
-		{
-			final Type< ? > type = ( Type< ? > ) t;
-			return ( T ) type.copy();
-		}
-		return t;
+		return new OutOfBoundsConstantValue<>( f, OutOfBoundsConstantValue.copyIfType( value ) );
 	}
 }

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
@@ -34,8 +34,6 @@
 
 package net.imglib2.outofbounds;
 
-import java.util.function.Supplier;
-
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.type.Type;
@@ -51,46 +49,36 @@ import net.imglib2.type.Type;
 public class OutOfBoundsConstantValueFactory< T, F extends Interval & RandomAccessible< T > >
 		implements OutOfBoundsFactory< T, F >
 {
-	private Supplier< T > valueSupplier;
-
-	public OutOfBoundsConstantValueFactory( final Supplier< T > valueSupplier )
-	{
-		this.valueSupplier = valueSupplier;
-	}
+	private T value;
 
 	public OutOfBoundsConstantValueFactory( final T value )
 	{
-		this( makeSupplierFrom( value ) );
-	}
-
-	public void setValueSupplier( final Supplier< T > valueSupplier )
-	{
-		this.valueSupplier = valueSupplier;
+		this.value = copyIfType( value );
 	}
 
 	public void setValue( final T value )
 	{
-		setValueSupplier( makeSupplierFrom( value ) );
+		this.value = copyIfType( value );
 	}
 
 	public T getValue()
 	{
-		return valueSupplier.get();
+		return value;
 	}
 
 	@Override
 	public OutOfBoundsConstantValue< T > create( final F f )
 	{
-		return new OutOfBoundsConstantValue<>( f, valueSupplier );
+		return new OutOfBoundsConstantValue<>( f, value );
 	}
 
-	private static < T > Supplier< T > makeSupplierFrom( final T t )
+	private static < T > T copyIfType( final T t )
 	{
-		if ( t instanceof Type< ? > )
+		if ( t instanceof Type )
 		{
 			final Type< ? > type = ( Type< ? > ) t;
-			return () -> ( T ) type.copy();
+			return ( T ) type.copy();
 		}
-		return () -> t;
+		return t;
 	}
 }

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
@@ -51,7 +51,7 @@ import net.imglib2.type.Type;
 public class OutOfBoundsConstantValueFactory< T, F extends Interval & RandomAccessible< T > >
 		implements OutOfBoundsFactory< T, F >
 {
-	protected Supplier< T > valueSupplier;
+	private Supplier< T > valueSupplier;
 
 	public OutOfBoundsConstantValueFactory( final Supplier< T > valueSupplier )
 	{

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsConstantValueFactory.java
@@ -49,16 +49,16 @@ import net.imglib2.type.Type;
 public class OutOfBoundsConstantValueFactory< T, F extends Interval & RandomAccessible< T > >
 		implements OutOfBoundsFactory< T, F >
 {
-	private T value;
+	protected T value;
 
 	public OutOfBoundsConstantValueFactory( final T value )
 	{
-		this.value = copyIfType( value );
+		this.value = value;
 	}
 
 	public void setValue( final T value )
 	{
-		this.value = copyIfType( value );
+		this.value = value;
 	}
 
 	public T getValue()
@@ -69,7 +69,7 @@ public class OutOfBoundsConstantValueFactory< T, F extends Interval & RandomAcce
 	@Override
 	public OutOfBoundsConstantValue< T > create( final F f )
 	{
-		return new OutOfBoundsConstantValue<>( f, value );
+		return new OutOfBoundsConstantValue<>( f, copyIfType( value ) );
 	}
 
 	private static < T > T copyIfType( final T t )

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -65,7 +65,6 @@ import net.imglib2.transform.integer.permutation.SingleDimensionPermutationTrans
 import net.imglib2.transform.integer.shear.InverseShearTransform;
 import net.imglib2.transform.integer.shear.ShearTransform;
 import net.imglib2.type.BooleanType;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
@@ -182,7 +181,7 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T extends Type< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final T value )
+	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final T value )
 	{
 		return new ExtendedRandomAccessibleInterval<>( source, new OutOfBoundsConstantValueFactory<>( value ) );
 	}
@@ -1352,7 +1351,7 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by t and border.
 	 */
-	public static < T extends Type< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final T t, final long... border )
+	public static < T > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final T t, final long... border )
 	{
 		return interval( extendValue( source, t ), Intervals.expand( source, border ) );
 	}


### PR DESCRIPTION
Addresses #210 (at least reagarding `Views.extend/expand`; if these changes are OK, I will adapt the respective methods in `Views` as well before this PR is merged).
Replaces #194

As far as I can tell, this does not break any interface wrt the constructors and the `setValue` method.

However, this technically breaks public interface of `OutOfBoundsConstantValueFactory`:
 1. The protected member `OutOfBoundsConstantValueFactory.value` is replaced with `OutOfBoundsConstantValueFactory.valueSupplier`.
 2. `OutOfBoundsConstantValueFactory.getValue().set(...)` does not have any effect on the internal state (not an actual interface break)

TODO:
 - [x] Use raw `Type` for `t instanceof Type` [check](https://github.com/imglib/imglib2/pull/268#discussion_r321126026).
 - [x] Update `Views.extendValue` and `Views.expandValue`.