### PR TITLE
getSuitableImgFactory - when targetSize is an Img, return its ImgFactory

### DIFF
--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -877,9 +877,10 @@ public class Util
 
 	/**
 	 * Create an appropriate {@link ImgFactory} for the requested
-	 * {@code targetSize} and {@code type}. If the type is a {@link NativeType},
-	 * then {@link #getArrayOrCellImgFactory(Dimensions, NativeType)} is used;
-	 * if not, a {@link ListImgFactory} is returned.
+	 * {@code targetSize} and {@code type}. If the target size is a {@link Img},
+	 * return its {@link ImgFactory}. If the type is a {@link NativeType}, then
+	 * {@link #getArrayOrCellImgFactory(Dimensions, NativeType)} is used; if
+	 * not, a {@link ListImgFactory} is returned.
 	 * 
 	 * @param targetSize
 	 *            size of image that the factory should be able to create.
@@ -890,6 +891,11 @@ public class Util
 	 */
 	public static < T > ImgFactory< T > getSuitableImgFactory( final Dimensions targetSize, final T type )
 	{
+		if ( targetSize instanceof Img )
+		{
+			Img< ? > targetImg = ( Img< ? > ) targetSize;
+			return targetImg.factory().imgFactory( type );
+		}
 		if ( type instanceof NativeType )
 		{
 			// NB: Eclipse does not demand the cast to ImgFactory< T >, but javac does.

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -45,6 +45,7 @@ import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealRandomAccess;
 import net.imglib2.RealRandomAccessible;
+import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.array.ArrayImg;
@@ -893,8 +894,18 @@ public class Util
 	{
 		if ( targetSize instanceof Img )
 		{
-			Img< ? > targetImg = ( Img< ? > ) targetSize;
-			return targetImg.factory().imgFactory( type );
+			final Img< ? > targetImg = ( Img< ? > ) targetSize;
+			final ImgFactory< ? > factory = targetImg.factory();
+			if ( factory != null )
+			{
+				try
+				{
+					return factory.imgFactory( type );
+				}
+				catch ( IncompatibleTypeException e )
+				{
+				}
+			}
 		}
 		if ( type instanceof NativeType )
 		{


### PR DESCRIPTION
`getSuitableImgFactory` operates on a `Dimensions targetSize` when determining which `ImgFactory` to return, however when `targetSize` is actually an `Img` we can just return the `ImgFactory` of that `Img`. 

This is nice from an Ops perspective when we ask Ops for a `create.img` Op that runs on `Dimensions` and a `RealType`, however we call that Op with `Img`s. With this change we can then be sure that the image types of the two images will be the same.