### PR TITLE
Add a simpler ImgView.wrap method

### DIFF
--- a/src/main/java/net/imglib2/img/ImgView.java
+++ b/src/main/java/net/imglib2/img/ImgView.java
@@ -51,8 +51,7 @@ import net.imglib2.view.iteration.SubIntervalIterable;
  * @author Tobias Pietzsch
  * @author Christian Dietz
  */
-public class ImgView< T extends Type< T > > extends
-		IterableRandomAccessibleInterval< T > implements Img< T >, SubIntervalIterable< T >
+public class ImgView< T extends Type< T > > extends IterableRandomAccessibleInterval< T > implements Img< T >, SubIntervalIterable< T >
 {
 
 	// factory
@@ -65,8 +64,9 @@ public class ImgView< T extends Type< T > > extends
 	 * View on {@link Img} which is defined by a given Interval, but still is an
 	 * {@link Img}.
 	 *
-	 * Deprecation: Use {@link ImgView#wrap(RandomAccessibleInterval, ImgFactory)}
-	 * to represent a RandomAccessibleInterval as an Img
+	 * Deprecation: Use
+	 * {@link ImgView#wrap(RandomAccessibleInterval, ImgFactory)} to represent a
+	 * RandomAccessibleInterval as an Img
 	 *
 	 * @param in
 	 *            Source interval for the view
@@ -154,25 +154,23 @@ public class ImgView< T extends Type< T > > extends
 		if ( this.sourceInterval instanceof SubIntervalIterable )
 			return ( ( SubIntervalIterable< T > ) this.sourceInterval ).localizingCursor( interval );
 		else
-			return Views.interval( this.sourceInterval, interval )
-					.localizingCursor();
+			return Views.interval( this.sourceInterval, interval ).localizingCursor();
 	}
 
 	/**
 	 * Represent an arbitrary RandomAccessibleInterval as an Img
 	 *
 	 * @param accessible
-	 * 			RandomAccessibleInterval which will be wrapped with an ImgView
+	 *            RandomAccessibleInterval which will be wrapped with an ImgView
 	 * @param factory
-	 * 			ImgFactory returned by {@link ImgView#factory()}
-	 * @return
-	 * 			RandomAccessibleInterval represented as an Img
+	 *            ImgFactory returned by {@link ImgView#factory()}
+	 * @return RandomAccessibleInterval represented as an Img
 	 */
-	public static < T extends Type< T >> Img< T > wrap(final RandomAccessibleInterval< T > accessible, final ImgFactory< T > factory){
-		if(accessible instanceof Img){
-			return (Img<T>) accessible;
-		}else{
-			return new ImgView< T >(accessible, factory);
-		}
+	public static < T extends Type< T > > Img< T > wrap( final RandomAccessibleInterval< T > accessible, final ImgFactory< T > factory )
+	{
+		if ( accessible instanceof Img )
+			return ( Img< T > ) accessible;
+		else
+			return new ImgView<>( accessible, factory );
 	}
 }

--- a/src/main/java/net/imglib2/img/ImgView.java
+++ b/src/main/java/net/imglib2/img/ImgView.java
@@ -158,7 +158,8 @@ public class ImgView< T extends Type< T > > extends IterableRandomAccessibleInte
 	}
 
 	/**
-	 * Represent an arbitrary RandomAccessibleInterval as an Img
+	 * Represent an arbitrary {@link RandomAccessibleInterval} as an
+	 * {@link Img}.
 	 *
 	 * @param accessible
 	 *            RandomAccessibleInterval which will be wrapped with an ImgView

--- a/src/main/java/net/imglib2/img/ImgView.java
+++ b/src/main/java/net/imglib2/img/ImgView.java
@@ -41,6 +41,7 @@ import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.Type;
+import net.imglib2.util.Util;
 import net.imglib2.view.IterableRandomAccessibleInterval;
 import net.imglib2.view.Views;
 import net.imglib2.view.iteration.SubIntervalIterable;
@@ -50,6 +51,7 @@ import net.imglib2.view.iteration.SubIntervalIterable;
  *
  * @author Tobias Pietzsch
  * @author Christian Dietz
+ * @author Curtis Rueden
  */
 public class ImgView< T extends Type< T > > extends IterableRandomAccessibleInterval< T > implements Img< T >, SubIntervalIterable< T >
 {
@@ -155,6 +157,29 @@ public class ImgView< T extends Type< T > > extends IterableRandomAccessibleInte
 			return ( ( SubIntervalIterable< T > ) this.sourceInterval ).localizingCursor( interval );
 		else
 			return Views.interval( this.sourceInterval, interval ).localizingCursor();
+	}
+
+	/**
+	 * Represent an arbitrary {@link RandomAccessibleInterval} as an
+	 * {@link Img}, with a suitable {@link ImgFactory} for its size and type,
+	 * created by
+	 * {@link Util#getSuitableImgFactory(net.imglib2.Dimensions, Object)}.
+	 *
+	 * @param accessible
+	 *            RandomAccessibleInterval which will be wrapped with an ImgView
+	 * @return RandomAccessibleInterval represented as an Img
+	 * @see Util#getSuitableImgFactory(net.imglib2.Dimensions, Object)
+	 */
+	public static < T extends Type< T > > Img< T > wrap( final RandomAccessibleInterval< T > accessible )
+	{
+		if ( accessible instanceof Img )
+			return ( Img< T > ) accessible;
+		else
+		{
+			final T type = Util.getTypeFromInterval( accessible );
+			final ImgFactory< T > factory = Util.getSuitableImgFactory( accessible, type );
+			return wrap( accessible, factory );
+		}
 	}
 
 	/**

--- a/src/test/java/net/imglib2/img/ImgViewTest.java
+++ b/src/test/java/net/imglib2/img/ImgViewTest.java
@@ -58,6 +58,21 @@ import org.junit.Test;
 public class ImgViewTest
 {
 	/**
+	 * Tests {@link ImgView#wrap(RandomAccessibleInterval)}.
+	 */
+	@Test
+	public void testDefaultWrapping()
+	{
+		final ArrayImg< UnsignedByteType, ByteArray > img = ArrayImgs.unsignedBytes( 7, 11, 5 );
+		final RandomAccessible< UnsignedByteType > ra = Views.extendBorder( img );
+		final RandomAccessibleInterval< UnsignedByteType > rai = Views.interval( ra, FinalInterval.createMinSize( -3, 4, -2, 29, 37, 31 ) );
+		final Img< UnsignedByteType > result = ImgView.wrap( rai );
+		assertSame( ImgView.class, result.getClass() );
+		assertTrue( Intervals.equals( rai, result ) );
+		assertSame( img.factory().getClass(), result.factory().getClass() );
+	}
+
+	/**
 	 * Tests {@link ImgView#wrap(RandomAccessibleInterval, ImgFactory)}.
 	 */
 	@Test
@@ -78,6 +93,7 @@ public class ImgViewTest
 	public void testAvoidUnnecessaryWrapping()
 	{
 		final ArrayImg< UnsignedByteType, ByteArray > img = ArrayImgs.unsignedBytes( 5, 7, 11 );
+		assertSame( img, ImgView.wrap( img ) );
 		final Img< UnsignedByteType > result = ImgView.wrap( img, new PlanarImgFactory<>( img.firstElement() ) );
 		assertSame( img, result );
 		assertNotSame( PlanarImgFactory.class, img.factory().getClass() );

--- a/src/test/java/net/imglib2/img/ImgViewTest.java
+++ b/src/test/java/net/imglib2/img/ImgViewTest.java
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.planar.PlanarImgFactory;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ImgView}.
+ *
+ * @author Curtis Rueden
+ */
+public class ImgViewTest
+{
+	/**
+	 * Tests {@link ImgView#wrap(RandomAccessibleInterval, ImgFactory)}.
+	 */
+	@Test
+	public void testWrapWithFactory()
+	{
+		final ArrayImg< UnsignedByteType, ByteArray > img = ArrayImgs.unsignedBytes( 5, 7, 11 );
+		final RandomAccessible< UnsignedByteType > ra = Views.extendBorder( img );
+		final RandomAccessibleInterval< UnsignedByteType > rai = Views.interval( ra, FinalInterval.createMinSize( -2, 1, 3, 19, 17, 13 ) );
+		final Img< UnsignedByteType > result = ImgView.wrap( rai, img.factory() );
+		assertSame( ImgView.class, result.getClass() );
+		assertTrue( Intervals.equals( rai, result ) );
+		assertSame( img.factory().getClass(), result.factory().getClass() );
+	}
+
+	/**
+	 * Tests {@link ImgView#wrap(RandomAccessibleInterval, ImgFactory)} with {@link Img} argument.
+	 */
+	public void testAvoidUnnecessaryWrapping()
+	{
+		final ArrayImg< UnsignedByteType, ByteArray > img = ArrayImgs.unsignedBytes( 5, 7, 11 );
+		final Img< UnsignedByteType > result = ImgView.wrap( img, new PlanarImgFactory<>( img.firstElement() ) );
+		assertSame( img, result );
+		assertNotSame( PlanarImgFactory.class, img.factory().getClass() );
+	}
+}


### PR DESCRIPTION
This PR adds a new method that leans on `Util.getSuitableImgFactory` and `Util.getTypeFromInterval` to wrap the RAI with sensible defaults. It also adds basic unit tests for the `ImgView` class.

Wrapping a `RandomAccessibleInterval` to an `Img` previously required specifying an `ImgFactory`.