### PR TITLE
Add support for localizing LoopBuilders

### DIFF
--- a/src/main/java/net/imglib2/loops/BindActionToSamplers.java
+++ b/src/main/java/net/imglib2/loops/BindActionToSamplers.java
@@ -56,7 +56,11 @@ final class BindActionToSamplers
 			new ClassCopyProvider<>( TriConsumerLocalizingRunnable.class, Runnable.class ),
 			new ClassCopyProvider<>( FourConsumerLocalizingRunnable.class, Runnable.class ),
 			new ClassCopyProvider<>( FiveConsumerLocalizingRunnable.class, Runnable.class ),
-			new ClassCopyProvider<>( SixConsumerLocalizingRunnable.class, Runnable.class ));
+			new ClassCopyProvider<>( SixConsumerLocalizingRunnable.class, Runnable.class ),
+			new ClassCopyProvider<>( SevenConsumerLocalizingRunnable.class, Runnable.class ),
+			new ClassCopyProvider<>( EightConsumerLocalizingRunnable.class, Runnable.class ),
+			new ClassCopyProvider<>( NineConsumerLocalizingRunnable.class, Runnable.class ),
+			new ClassCopyProvider<>( TenConsumerLocalizingRunnable.class, Runnable.class ));
 
 	private static final List< ClassCopyProvider< Runnable > > FACTORIES = Arrays.asList(
 			new ClassCopyProvider<>( ConsumerRunnable.class, Runnable.class ),
@@ -64,7 +68,11 @@ final class BindActionToSamplers
 			new ClassCopyProvider<>( TriConsumerRunnable.class, Runnable.class ),
 			new ClassCopyProvider<>( FourConsumerRunnable.class, Runnable.class ),
 			new ClassCopyProvider<>( FiveConsumerRunnable.class, Runnable.class ),
-			new ClassCopyProvider<>( SixConsumerRunnable.class, Runnable.class ));
+			new ClassCopyProvider<>( SixConsumerRunnable.class, Runnable.class ),
+			new ClassCopyProvider<>( SevenConsumerRunnable.class, Runnable.class ),
+			new ClassCopyProvider<>( EightConsumerRunnable.class, Runnable.class ),
+			new ClassCopyProvider<>( NineConsumerRunnable.class, Runnable.class ),
+			new ClassCopyProvider<>( TenConsumerRunnable.class, Runnable.class ));
 
 	/**
 	 * For example.: Given a BiConsumer and two Samplers:
@@ -297,6 +305,176 @@ final class BindActionToSamplers
 		}
 	}
 
+	public static class SevenConsumerRunnable< A, B, C, D, E, F, G > implements Runnable
+	{
+
+		private final LoopBuilder.SevenConsumer< A, B, C, D, E, F, G > action;
+
+		private final Sampler< A > samplerA;
+
+		private final Sampler< B > samplerB;
+
+		private final Sampler< C > samplerC;
+
+		private final Sampler< D > samplerD;
+
+		private final Sampler< E > samplerE;
+
+		private final Sampler< F > samplerF;
+
+		private final Sampler< G > samplerG;
+
+		public SevenConsumerRunnable( final LoopBuilder.SevenConsumer< A, B, C, D, E, F, G > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, final Sampler< E > samplerE, final Sampler< F > samplerF, final Sampler< G > samplerG )
+		{
+			this.action = action;
+			this.samplerA = samplerA;
+			this.samplerB = samplerB;
+			this.samplerC = samplerC;
+			this.samplerD = samplerD;
+			this.samplerE = samplerE;
+			this.samplerF = samplerF;
+			this.samplerG = samplerG;
+		}
+
+		@Override
+		public void run()
+		{
+			action.accept( samplerA.get(), samplerB.get(), samplerC.get(), samplerD.get(), samplerE.get(), samplerF.get(), samplerG.get() );
+		}
+	}
+
+	public static class EightConsumerRunnable< A, B, C, D, E, F, G, H > implements Runnable
+	{
+
+		private final LoopBuilder.EightConsumer< A, B, C, D, E, F, G, H > action;
+
+		private final Sampler< A > samplerA;
+
+		private final Sampler< B > samplerB;
+
+		private final Sampler< C > samplerC;
+
+		private final Sampler< D > samplerD;
+
+		private final Sampler< E > samplerE;
+
+		private final Sampler< F > samplerF;
+
+		private final Sampler< G > samplerG;
+
+		private final Sampler< H > samplerH;
+
+		public EightConsumerRunnable( final LoopBuilder.EightConsumer< A, B, C, D, E, F, G, H > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, final Sampler< E > samplerE, final Sampler< F > samplerF, final Sampler< G > samplerG, final Sampler< H > samplerH )
+		{
+			this.action = action;
+			this.samplerA = samplerA;
+			this.samplerB = samplerB;
+			this.samplerC = samplerC;
+			this.samplerD = samplerD;
+			this.samplerE = samplerE;
+			this.samplerF = samplerF;
+			this.samplerG = samplerG;
+			this.samplerH = samplerH;
+		}
+
+		@Override
+		public void run()
+		{
+			action.accept( samplerA.get(), samplerB.get(), samplerC.get(), samplerD.get(), samplerE.get(), samplerF.get(), samplerG.get(), samplerH.get() );
+		}
+	}
+
+	public static class NineConsumerRunnable< A, B, C, D, E, F, G, H, I > implements Runnable
+	{
+
+		private final LoopBuilder.NineConsumer< A, B, C, D, E, F, G, H, I > action;
+
+		private final Sampler< A > samplerA;
+
+		private final Sampler< B > samplerB;
+
+		private final Sampler< C > samplerC;
+
+		private final Sampler< D > samplerD;
+
+		private final Sampler< E > samplerE;
+
+		private final Sampler< F > samplerF;
+
+		private final Sampler< G > samplerG;
+
+		private final Sampler< H > samplerH;
+
+		private final Sampler< I > samplerI;
+
+		public NineConsumerRunnable( final LoopBuilder.NineConsumer< A, B, C, D, E, F, G, H, I > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, final Sampler< E > samplerE, final Sampler< F > samplerF, final Sampler< G > samplerG, final Sampler< H > samplerH, final Sampler< I > samplerI )
+		{
+			this.action = action;
+			this.samplerA = samplerA;
+			this.samplerB = samplerB;
+			this.samplerC = samplerC;
+			this.samplerD = samplerD;
+			this.samplerE = samplerE;
+			this.samplerF = samplerF;
+			this.samplerG = samplerG;
+			this.samplerH = samplerH;
+			this.samplerI = samplerI;
+		}
+
+		@Override
+		public void run()
+		{
+			action.accept( samplerA.get(), samplerB.get(), samplerC.get(), samplerD.get(), samplerE.get(), samplerF.get(), samplerG.get(), samplerH.get(), samplerI.get() );
+		}
+	}
+
+	public static class TenConsumerRunnable< A, B, C, D, E, F, G, H, I, J > implements Runnable
+	{
+
+		private final LoopBuilder.TenConsumer< A, B, C, D, E, F, G, H, I, J > action;
+
+		private final Sampler< A > samplerA;
+
+		private final Sampler< B > samplerB;
+
+		private final Sampler< C > samplerC;
+
+		private final Sampler< D > samplerD;
+
+		private final Sampler< E > samplerE;
+
+		private final Sampler< F > samplerF;
+
+		private final Sampler< G > samplerG;
+
+		private final Sampler< H > samplerH;
+
+		private final Sampler< I > samplerI;
+
+		private final Sampler< J > samplerJ;
+
+		public TenConsumerRunnable( final LoopBuilder.TenConsumer< A, B, C, D, E, F, G, H, I, J > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, final Sampler< E > samplerE, final Sampler< F > samplerF, final Sampler< G > samplerG, final Sampler< H > samplerH, final Sampler< I > samplerI, final Sampler< J > samplerJ )
+		{
+			this.action = action;
+			this.samplerA = samplerA;
+			this.samplerB = samplerB;
+			this.samplerC = samplerC;
+			this.samplerD = samplerD;
+			this.samplerE = samplerE;
+			this.samplerF = samplerF;
+			this.samplerG = samplerG;
+			this.samplerH = samplerH;
+			this.samplerI = samplerI;
+			this.samplerJ = samplerJ;
+		}
+
+		@Override
+		public void run()
+		{
+			action.accept( samplerA.get(), samplerB.get(), samplerC.get(), samplerD.get(), samplerE.get(), samplerF.get(), samplerG.get(), samplerH.get(), samplerI.get(), samplerJ.get() );
+		}
+	}
+
 	public static class ConsumerLocalizingRunnable< A > implements Runnable
 	{
 
@@ -459,6 +637,176 @@ final class BindActionToSamplers
 		public void run()
 		{
 			action.accept( accessA, accessB, accessC, accessD, accessE, accessF );
+		}
+	}
+
+	public static class SevenConsumerLocalizingRunnable< A, B, C, D, E, F, G > implements Runnable
+	{
+
+		private final LoopBuilder.SevenConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G > > action;
+
+		private final RandomAccess< A > accessA;
+
+		private final RandomAccess< B > accessB;
+
+		private final RandomAccess< C > accessC;
+
+		private final RandomAccess< D > accessD;
+
+		private final RandomAccess< E > accessE;
+
+		private final RandomAccess< F > accessF;
+
+		private final RandomAccess< G > accessG;
+
+		public SevenConsumerLocalizingRunnable( final LoopBuilder.SevenConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess < C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G > > action, final RandomAccess< A > accessA, final RandomAccess< B > accessB, final RandomAccess< C > accessC, final RandomAccess< D > accessD, final RandomAccess< E > accessE, final RandomAccess< F > accessF, final RandomAccess< G > accessG )
+		{
+			this.action = action;
+			this.accessA = accessA;
+			this.accessB = accessB;
+			this.accessC = accessC;
+			this.accessD = accessD;
+			this.accessE = accessE;
+			this.accessF = accessF;
+			this.accessG = accessG;
+		}
+
+		@Override
+		public void run()
+		{
+			action.accept( accessA, accessB, accessC, accessD, accessE, accessF, accessG );
+		}
+	}
+
+	public static class EightConsumerLocalizingRunnable< A, B, C, D, E, F, G, H > implements Runnable
+	{
+
+		private final LoopBuilder.EightConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H > > action;
+
+		private final RandomAccess< A > accessA;
+
+		private final RandomAccess< B > accessB;
+
+		private final RandomAccess< C > accessC;
+
+		private final RandomAccess< D > accessD;
+
+		private final RandomAccess< E > accessE;
+
+		private final RandomAccess< F > accessF;
+
+		private final RandomAccess< G > accessG;
+
+		private final RandomAccess< H > accessH;
+
+		public EightConsumerLocalizingRunnable( final LoopBuilder.EightConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess < C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H > > action, final RandomAccess< A > accessA, final RandomAccess< B > accessB, final RandomAccess< C > accessC, final RandomAccess< D > accessD, final RandomAccess< E > accessE, final RandomAccess< F > accessF, final RandomAccess< G > accessG, final RandomAccess< H > accessH )
+		{
+			this.action = action;
+			this.accessA = accessA;
+			this.accessB = accessB;
+			this.accessC = accessC;
+			this.accessD = accessD;
+			this.accessE = accessE;
+			this.accessF = accessF;
+			this.accessG = accessG;
+			this.accessH = accessH;
+		}
+
+		@Override
+		public void run()
+		{
+			action.accept( accessA, accessB, accessC, accessD, accessE, accessF, accessG, accessH );
+		}
+	}
+
+	public static class NineConsumerLocalizingRunnable< A, B, C, D, E, F, G, H, I > implements Runnable
+	{
+
+		private final LoopBuilder.NineConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H >, RandomAccess< I > > action;
+
+		private final RandomAccess< A > accessA;
+
+		private final RandomAccess< B > accessB;
+
+		private final RandomAccess< C > accessC;
+
+		private final RandomAccess< D > accessD;
+
+		private final RandomAccess< E > accessE;
+
+		private final RandomAccess< F > accessF;
+
+		private final RandomAccess< G > accessG;
+
+		private final RandomAccess< H > accessH;
+
+		private final RandomAccess< I > accessI;
+
+		public NineConsumerLocalizingRunnable( final LoopBuilder.NineConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess < C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H >, RandomAccess< I > > action, final RandomAccess< A > accessA, final RandomAccess< B > accessB, final RandomAccess< C > accessC, final RandomAccess< D > accessD, final RandomAccess< E > accessE, final RandomAccess< F > accessF, final RandomAccess< G > accessG, final RandomAccess< H > accessH, final RandomAccess< I > accessI )
+		{
+			this.action = action;
+			this.accessA = accessA;
+			this.accessB = accessB;
+			this.accessC = accessC;
+			this.accessD = accessD;
+			this.accessE = accessE;
+			this.accessF = accessF;
+			this.accessG = accessG;
+			this.accessH = accessH;
+			this.accessI = accessI;
+		}
+
+		@Override
+		public void run()
+		{
+			action.accept( accessA, accessB, accessC, accessD, accessE, accessF, accessG, accessH, accessI );
+		}
+	}
+
+	public static class TenConsumerLocalizingRunnable< A, B, C, D, E, F, G, H, I, J > implements Runnable
+	{
+
+		private final LoopBuilder.TenConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H >, RandomAccess< I >, RandomAccess< J > > action;
+
+		private final RandomAccess< A > accessA;
+
+		private final RandomAccess< B > accessB;
+
+		private final RandomAccess< C > accessC;
+
+		private final RandomAccess< D > accessD;
+
+		private final RandomAccess< E > accessE;
+
+		private final RandomAccess< F > accessF;
+
+		private final RandomAccess< G > accessG;
+
+		private final RandomAccess< H > accessH;
+
+		private final RandomAccess< I > accessI;
+
+		private final RandomAccess< J > accessJ;
+
+		public TenConsumerLocalizingRunnable( final LoopBuilder.TenConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess < C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H >, RandomAccess< I >, RandomAccess< J > > action, final RandomAccess< A > accessA, final RandomAccess< B > accessB, final RandomAccess< C > accessC, final RandomAccess< D > accessD, final RandomAccess< E > accessE, final RandomAccess< F > accessF, final RandomAccess< G > accessG, final RandomAccess< H > accessH, final RandomAccess< I > accessI, final RandomAccess< J > accessJ )
+		{
+			this.action = action;
+			this.accessA = accessA;
+			this.accessB = accessB;
+			this.accessC = accessC;
+			this.accessD = accessD;
+			this.accessE = accessE;
+			this.accessF = accessF;
+			this.accessG = accessG;
+			this.accessH = accessH;
+			this.accessI = accessI;
+			this.accessJ = accessJ;
+		}
+
+		@Override
+		public void run()
+		{
+			action.accept( accessA, accessB, accessC, accessD, accessE, accessF, accessG, accessH, accessI, accessJ );
 		}
 	}
 }

--- a/src/main/java/net/imglib2/loops/LoopBuilder.java
+++ b/src/main/java/net/imglib2/loops/LoopBuilder.java
@@ -48,9 +48,11 @@ import net.imglib2.Dimensions;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
+import net.imglib2.Localizable;
 import net.imglib2.Positionable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.Sampler;
 import net.imglib2.img.array.AbstractArrayCursor;
 import net.imglib2.img.cell.CellCursor;
 import net.imglib2.img.planar.PlanarCursor;
@@ -103,7 +105,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A > LoopBuilder< Consumer< A >, Consumer< RandomAccess< A > > > setImages( final RandomAccessibleInterval< A > a )
+	public static < A, LA extends Localizable & Sampler< A > > LoopBuilder< Consumer< A >, Consumer< LA > > setImages( final RandomAccessibleInterval< A > a )
 	{
 		return new LoopBuilder<>( a );
 	}
@@ -111,7 +113,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B > LoopBuilder< BiConsumer< A, B >, BiConsumer< RandomAccess< A >, RandomAccess< B > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b )
+	public static < A, B, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B > > LoopBuilder< BiConsumer< A, B >, BiConsumer< LA, LB > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b )
 	{
 		return new LoopBuilder<>( a, b );
 	}
@@ -119,7 +121,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C > LoopBuilder< TriConsumer< A, B, C >, TriConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c )
+	public static < A, B, C, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B >, LC extends Localizable & Sampler< C > > LoopBuilder< TriConsumer< A, B, C >, TriConsumer< LA, LB, LC > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c )
 	{
 		return new LoopBuilder<>( a, b, c );
 	}
@@ -127,7 +129,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D > LoopBuilder< FourConsumer< A, B, C, D >, FourConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d )
+	public static < A, B, C, D, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B >, LC extends Localizable & Sampler< C >, LD extends Localizable & Sampler< D > > LoopBuilder< FourConsumer< A, B, C, D >, FourConsumer< LA, LB, LC, LD > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d )
 	{
 		return new LoopBuilder<>( a, b, c, d );
 	}
@@ -135,7 +137,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D, E > LoopBuilder< FiveConsumer< A, B, C, D, E >, FiveConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e )
+	public static < A, B, C, D, E, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B >, LC extends Localizable & Sampler< C >, LD extends Localizable & Sampler< D >, LE extends Localizable & Sampler< E > > LoopBuilder< FiveConsumer< A, B, C, D, E >, FiveConsumer< LA, LB, LC, LD, LE > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e )
 	{
 		return new LoopBuilder<>( a, b, c, d, e );
 	}
@@ -143,7 +145,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D, E, F > LoopBuilder< SixConsumer< A, B, C, D, E, F >, SixConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f )
+	public static < A, B, C, D, E, F, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B >, LC extends Localizable & Sampler< C >, LD extends Localizable & Sampler< D >, LE extends Localizable & Sampler< E >, LF extends Localizable & Sampler< F > > LoopBuilder< SixConsumer< A, B, C, D, E, F >, SixConsumer< LA, LB, LC, LD, LE, LF > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f )
 	{
 		return new LoopBuilder<>( a, b, c, d, e, f );
 	}
@@ -151,7 +153,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D, E, F, G > LoopBuilder< SevenConsumer< A, B, C, D, E, F, G >, SevenConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g )
+	public static < A, B, C, D, E, F, G, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B >, LC extends Localizable & Sampler< C >, LD extends Localizable & Sampler< D >, LE extends Localizable & Sampler< E >, LF extends Localizable & Sampler< F >, LG extends Localizable & Sampler< G > > LoopBuilder< SevenConsumer< A, B, C, D, E, F, G >, SevenConsumer< LA, LB, LC, LD, LE, LF, LG > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g )
 	{
 		return new LoopBuilder<>( a, b, c, d, e, f, g );
 	}
@@ -159,7 +161,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D, E, F, G, H > LoopBuilder< EightConsumer< A, B, C, D, E, F, G, H >, EightConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h )
+	public static < A, B, C, D, E, F, G, H, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B >, LC extends Localizable & Sampler< C >, LD extends Localizable & Sampler< D >, LE extends Localizable & Sampler< E >, LF extends Localizable & Sampler< F >, LG extends Localizable & Sampler< G >, LH extends Localizable & Sampler< H > > LoopBuilder< EightConsumer< A, B, C, D, E, F, G, H >, EightConsumer< LA, LB, LC, LD, LE, LF, LG, LH > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h )
 	{
 		return new LoopBuilder<>( a, b, c, d, e, f, g, h );
 	}
@@ -167,7 +169,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D, E, F, G, H, I > LoopBuilder< NineConsumer< A, B, C, D, E, F, G, H, I >, NineConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H >, RandomAccess< I > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h, final RandomAccessibleInterval< I > i )
+	public static < A, B, C, D, E, F, G, H, I, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B >, LC extends Localizable & Sampler< C >, LD extends Localizable & Sampler< D >, LE extends Localizable & Sampler< E >, LF extends Localizable & Sampler< F >, LG extends Localizable & Sampler< G >, LH extends Localizable & Sampler< H >, LI extends Localizable & Sampler< I > > LoopBuilder< NineConsumer< A, B, C, D, E, F, G, H, I >, NineConsumer< LA, LB, LC, LD, LE, LF, LG, LH, LI > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h, final RandomAccessibleInterval< I > i )
 	{
 		return new LoopBuilder<>( a, b, c, d, e, f, g, h, i );
 	}
@@ -175,7 +177,7 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D, E, F, G, H, I, J > LoopBuilder< TenConsumer< A, B, C, D, E, F, G, H, I, J >, TenConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H >, RandomAccess< I >, RandomAccess< J > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h, final RandomAccessibleInterval< I > i, final RandomAccessibleInterval< J > j )
+	public static < A, B, C, D, E, F, G, H, I, J, LA extends Localizable & Sampler< A >, LB extends Localizable & Sampler< B >, LC extends Localizable & Sampler< C >, LD extends Localizable & Sampler< D >, LE extends Localizable & Sampler< E >, LF extends Localizable & Sampler< F >, LG extends Localizable & Sampler< G >, LH extends Localizable & Sampler< H >, LI extends Localizable & Sampler< I >, LJ extends Localizable & Sampler< J > > LoopBuilder< TenConsumer< A, B, C, D, E, F, G, H, I, J >, TenConsumer< LA, LB, LC, LD, LE, LF, LG, LH, LI, LJ > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h, final RandomAccessibleInterval< I > i, final RandomAccessibleInterval< J > j )
 	{
 		return new LoopBuilder<>( a, b, c, d, e, f, g, h, i, j );
 	}

--- a/src/main/java/net/imglib2/loops/LoopBuilder.java
+++ b/src/main/java/net/imglib2/loops/LoopBuilder.java
@@ -151,6 +151,38 @@ public class LoopBuilder< T, LT >
 	/**
 	 * @see LoopBuilder
 	 */
+	public static < A, B, C, D, E, F, G > LoopBuilder< SevenConsumer< A, B, C, D, E, F, G >, SevenConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g )
+	{
+		return new LoopBuilder<>( a, b, c, d, e, f, g );
+	}
+
+	/**
+	 * @see LoopBuilder
+	 */
+	public static < A, B, C, D, E, F, G, H > LoopBuilder< EightConsumer< A, B, C, D, E, F, G, H >, EightConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h )
+	{
+		return new LoopBuilder<>( a, b, c, d, e, f, g, h );
+	}
+
+	/**
+	 * @see LoopBuilder
+	 */
+	public static < A, B, C, D, E, F, G, H, I > LoopBuilder< NineConsumer< A, B, C, D, E, F, G, H, I >, NineConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H >, RandomAccess< I > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h, final RandomAccessibleInterval< I > i )
+	{
+		return new LoopBuilder<>( a, b, c, d, e, f, g, h, i );
+	}
+
+	/**
+	 * @see LoopBuilder
+	 */
+	public static < A, B, C, D, E, F, G, H, I, J > LoopBuilder< TenConsumer< A, B, C, D, E, F, G, H, I, J >, TenConsumer< RandomAccess< A >, RandomAccess< B >, RandomAccess< C >, RandomAccess< D >, RandomAccess< E >, RandomAccess< F >, RandomAccess< G >, RandomAccess< H >, RandomAccess< I >, RandomAccess< J > > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f, final RandomAccessibleInterval< G > g, final RandomAccessibleInterval< H > h, final RandomAccessibleInterval< I > i, final RandomAccessibleInterval< J > j )
+	{
+		return new LoopBuilder<>( a, b, c, d, e, f, g, h, i, j );
+	}
+
+	/**
+	 * @see LoopBuilder
+	 */
 	public void forEachPixel( final T action )
 	{
 		Objects.requireNonNull( action );
@@ -246,6 +278,26 @@ public class LoopBuilder< T, LT >
 	public interface SixConsumer< A, B, C, D, E, F >
 	{
 		void accept( A a, B b, C c, D d, E e, F f );
+	}
+
+	public interface SevenConsumer< A, B, C, D, E, F, G >
+	{
+		void accept( A a, B b, C c, D d, E e, F f, G g );
+	}
+
+	public interface EightConsumer< A, B, C, D, E, F, G, H >
+	{
+		void accept( A a, B b, C c, D d, E e, F f, G g, H h );
+	}
+
+	public interface NineConsumer< A, B, C, D, E, F, G, H, I >
+	{
+		void accept( A a, B b, C c, D d, E e, F f, G g, H h, I i );
+	}
+
+	public interface TenConsumer< A, B, C, D, E, F, G, H, I, J >
+	{
+		void accept( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j );
 	}
 
 	// Helper methods


### PR DESCRIPTION
Following on to @etarena's question in the Gitter channel the other day ("Is there a way to use LoopBuilder (or something similar) to loop multiple things while knowing their position?"), I looked into what it would take to add support for `LoopBuilder` loops that include a `Localizable`.

Turns out it was pretty straightforward! Here is a very quick first cut. Comments:

* Two images only for now, as proof of concept, but adding the other arities would be trivial.
* I don't love the naming (`setImagesLocalizing`) but just picked something to move forward. I don't feel strongly about it.
* The unit tests are just to show it works—I expect @maarzt would want to do them differently.
* I didn't add support for cursor-based localization because localizing cursors never pass the `allCursorsAreFast` check and so `LoopBuilder` will fall back to random accesses anyway.
* Looking at the current `LoopBuilder` design, mostly it is quite elegant! But I got a bad feeling about the fact that the `*ConsumerRunnable` classes hardcode `Sampler` arguments and calls to `Sampler.get()` when they could potentially be either A) more general or B) more specifically named to indicate that.

Feedback on whether this is a thing we want to have? Did I miss an already existing way to do this? It would have been helpful on a recent project with @etarena where we had to loop several images in sync, while needing to localize them at each point...