### PR TITLE
Throw exception when trying to create Img with non-positive dimension

### DIFF
--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -98,6 +98,18 @@ public interface Dimensions extends EuclideanSpace
 		return dimensions;
 	}
 
+	/**
+	 * Verify that {@code dimensions} is not null or empty, and that all
+	 * dimensions are positive. Throw {@link InvalidDimensions} otherwise.
+	 *
+	 * @param dimensions
+	 *            to be verified.
+	 * @return {@code dimensions} if successfully verified.
+	 * @throws IllegalArgumentException
+	 *             if {@code dimensions == null} or
+	 *             {@code dimensions.length == 0} or any dimensions is zero or
+	 *             negative.
+	 */
 	public static long[] verify( final long... dimensions ) throws InvalidDimensions
 	{
 		if ( dimensions == null )

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -66,6 +66,14 @@ public interface Dimensions extends EuclideanSpace
 	 */
 	public long dimension( int d );
 
+	/*
+	 * -----------------------------------------------------------------------
+	 *
+	 * Static methods
+	 *
+	 * -----------------------------------------------------------------------
+	 */
+
 	/**
 	 * Check whether all entries in {@code dimensions} are positive
 	 *
@@ -73,9 +81,24 @@ public interface Dimensions extends EuclideanSpace
 	 * @return true if all entries in {@code dimension} are positive, false
 	 *         otherwise
 	 */
-	public static boolean allPositive( final long... dimensions )
+	static boolean allPositive( final long... dimensions )
 	{
 		for ( final long d : dimensions )
+			if ( d < 1 )
+				return false;
+		return true;
+	}
+
+	/**
+	 * Check whether all entries in {@code dimensions} are positive
+	 *
+	 * @param dimensions
+	 * @return true if all entries in {@code dimension} are positive, false
+	 *         otherwise
+	 */
+	static boolean allPositive( final int... dimensions )
+	{
+		for ( final int d : dimensions )
 			if ( d < 1 )
 				return false;
 		return true;
@@ -90,7 +113,25 @@ public interface Dimensions extends EuclideanSpace
 	 *             if any of {@code dimensions} is not positive (zero or
 	 *             negative).
 	 */
-	public static long[] verifyAllPositive( final long... dimensions ) throws InvalidDimensionsException
+	static long[] verifyAllPositive( final long... dimensions ) throws InvalidDimensionsException
+	{
+		if ( !Dimensions.allPositive( dimensions ) )
+			throw new InvalidDimensionsException(
+					dimensions,
+					"Expected only positive dimensions but got: " + Arrays.toString( dimensions ) );
+		return dimensions;
+	}
+
+	/**
+	 * Check that all entries in {@code dimensions} are positive
+	 *
+	 * @param dimensions
+	 * @return {@code dimensions}
+	 * @throws InvalidDimensionsException
+	 *             if any of {@code dimensions} is not positive (zero or
+	 *             negative).
+	 */
+	static int[] verifyAllPositive( final int... dimensions ) throws InvalidDimensionsException
 	{
 		if ( !Dimensions.allPositive( dimensions ) )
 			throw new InvalidDimensionsException(
@@ -111,7 +152,30 @@ public interface Dimensions extends EuclideanSpace
 	 *             {@code dimensions.length == 0} or any dimensions is zero or
 	 *             negative.
 	 */
-	public static long[] verify( final long... dimensions ) throws InvalidDimensionsException
+	static long[] verify( final long... dimensions ) throws InvalidDimensionsException
+	{
+		if ( dimensions == null )
+			throw new InvalidDimensionsException( dimensions, "Dimensions are null." );
+
+		if ( dimensions.length == 0 )
+			throw new InvalidDimensionsException( dimensions, "Dimensions are zero length." );
+
+		return verifyAllPositive( dimensions );
+	}
+
+	/**
+	 * Verify that {@code dimensions} is not null or empty, and that all
+	 * dimensions are positive. Throw {@link InvalidDimensionsException} otherwise.
+	 *
+	 * @param dimensions
+	 *            to be verified.
+	 * @return {@code dimensions} if successfully verified.
+	 * @throws IllegalArgumentException
+	 *             if {@code dimensions == null} or
+	 *             {@code dimensions.length == 0} or any dimensions is zero or
+	 *             negative.
+	 */
+	static int[] verify( final int... dimensions ) throws InvalidDimensionsException
 	{
 		if ( dimensions == null )
 			throw new InvalidDimensionsException( dimensions, "Dimensions are null." );

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -35,6 +35,7 @@
 package net.imglib2;
 
 import java.util.Arrays;
+import net.imglib2.exception.InvalidDimensionsException;
 
 /**
  * Defines an extent in <em>n</em>-dimensional discrete space.
@@ -119,23 +120,5 @@ public interface Dimensions extends EuclideanSpace
 			throw new InvalidDimensionsException( dimensions, "Dimensions are zero length." );
 
 		return verifyAllPositive( dimensions );
-	}
-
-	public static class InvalidDimensionsException extends IllegalArgumentException
-	{
-
-		private final long[] dimensions;
-
-		public InvalidDimensionsException( final long[] dimensions, final String message )
-		{
-			super( message );
-			this.dimensions = dimensions.clone();
-		}
-
-		public long[] getDimenionsCopy()
-		{
-			return this.dimensions.clone();
-		}
-
 	}
 }

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -66,12 +66,13 @@ public interface Dimensions extends EuclideanSpace
 	public long dimension( int d );
 
 	/**
-	 * Check that all entries in dimensions are positive
+	 * Check that all entries in {@code dimensions} are positive
 	 *
 	 * @param dimensions
-	 * @return true if all entries in dimension are positive, false otherwise
+	 * @return true if all entries in {@code dimension} are positive, false
+	 *         otherwise
 	 */
-	public static boolean dimensionsCheckAllPositive( final long[] dimensions )
+	public static boolean allPositive( final long... dimensions )
 	{
 		for ( final long d : dimensions )
 			if ( d < 1 )
@@ -79,7 +80,25 @@ public interface Dimensions extends EuclideanSpace
 		return true;
 	}
 
-	public static class InvalidDimensions extends RuntimeException
+	/**
+	 * Check that all entries in {@code dimensions} are positive
+	 *
+	 * @param dimensions
+	 * @return {@code dimensions}
+	 * @throws InvalidDimensions
+	 *             if any of {@code dimensions} is not positive (zero or
+	 *             negative).
+	 */
+	public static long[] verifyAllPositive( final long... dimensions ) throws InvalidDimensions
+	{
+		if ( !Dimensions.allPositive( dimensions ) )
+			throw new InvalidDimensions(
+					dimensions,
+					"Expected only positive dimensions but got: " + Arrays.toString( dimensions ) );
+		return dimensions;
+	}
+
+	public static class InvalidDimensions extends IllegalArgumentException
 	{
 
 		private final long[] dimensions;
@@ -93,12 +112,6 @@ public interface Dimensions extends EuclideanSpace
 		public long[] getDimenionsCopy()
 		{
 			return this.dimensions.clone();
-		}
-
-		public static void checkAllPositiveOrElseThrow( final long[] dimensions )
-		{
-			if ( !Dimensions.dimensionsCheckAllPositive( dimensions ) )
-				throw ( new InvalidDimensions( dimensions, "Expected only positive dimensions but got: " + Arrays.toString( dimensions ) ) );
 		}
 
 	}

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -98,6 +98,17 @@ public interface Dimensions extends EuclideanSpace
 		return dimensions;
 	}
 
+	public static long[] verify( final long... dimensions ) throws InvalidDimensions
+	{
+		if ( dimensions == null )
+			throw new InvalidDimensions( dimensions, "Dimensions are null." );
+
+		if ( dimensions.length == 0 )
+			throw new InvalidDimensions( dimensions, "Dimensions are zero length." );
+
+		return verifyAllPositive( dimensions );
+	}
+
 	public static class InvalidDimensions extends IllegalArgumentException
 	{
 

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -34,12 +34,15 @@
 
 package net.imglib2;
 
+import java.util.Arrays;
+
 /**
  * Defines an extent in <em>n</em>-dimensional discrete space.
  * 
  * @author Tobias Pietzsch
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
+ * @author Philipp Hanslovsky
  */
 public interface Dimensions extends EuclideanSpace
 {
@@ -61,4 +64,42 @@ public interface Dimensions extends EuclideanSpace
 	 * @param d
 	 */
 	public long dimension( int d );
+
+	/**
+	 * Check that all entries in dimensions are positive
+	 *
+	 * @param dimensions
+	 * @return true if all entries in dimension are positive, false otherwise
+	 */
+	public static boolean dimensionsCheckAllPositive( final long[] dimensions )
+	{
+		for ( final long d : dimensions )
+			if ( d < 1 )
+				return false;
+		return true;
+	}
+
+	public static class InvalidDimensions extends RuntimeException
+	{
+
+		private final long[] dimensions;
+
+		public InvalidDimensions( final long[] dimensions, final String message )
+		{
+			super( message );
+			this.dimensions = dimensions.clone();
+		}
+
+		public long[] getDimenionsCopy()
+		{
+			return this.dimensions.clone();
+		}
+
+		public static void checkAllPositiveOrElseThrow( final long[] dimensions )
+		{
+			if ( !Dimensions.dimensionsCheckAllPositive( dimensions ) )
+				throw ( new InvalidDimensions( dimensions, "Expected only positive dimensions but got: " + Arrays.toString( dimensions ) ) );
+		}
+
+	}
 }

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -66,7 +66,7 @@ public interface Dimensions extends EuclideanSpace
 	public long dimension( int d );
 
 	/**
-	 * Check that all entries in {@code dimensions} are positive
+	 * Check whether all entries in {@code dimensions} are positive
 	 *
 	 * @param dimensions
 	 * @return true if all entries in {@code dimension} are positive, false
@@ -85,14 +85,14 @@ public interface Dimensions extends EuclideanSpace
 	 *
 	 * @param dimensions
 	 * @return {@code dimensions}
-	 * @throws InvalidDimensions
+	 * @throws InvalidDimensionsException
 	 *             if any of {@code dimensions} is not positive (zero or
 	 *             negative).
 	 */
-	public static long[] verifyAllPositive( final long... dimensions ) throws InvalidDimensions
+	public static long[] verifyAllPositive( final long... dimensions ) throws InvalidDimensionsException
 	{
 		if ( !Dimensions.allPositive( dimensions ) )
-			throw new InvalidDimensions(
+			throw new InvalidDimensionsException(
 					dimensions,
 					"Expected only positive dimensions but got: " + Arrays.toString( dimensions ) );
 		return dimensions;
@@ -100,7 +100,7 @@ public interface Dimensions extends EuclideanSpace
 
 	/**
 	 * Verify that {@code dimensions} is not null or empty, and that all
-	 * dimensions are positive. Throw {@link InvalidDimensions} otherwise.
+	 * dimensions are positive. Throw {@link InvalidDimensionsException} otherwise.
 	 *
 	 * @param dimensions
 	 *            to be verified.
@@ -110,23 +110,23 @@ public interface Dimensions extends EuclideanSpace
 	 *             {@code dimensions.length == 0} or any dimensions is zero or
 	 *             negative.
 	 */
-	public static long[] verify( final long... dimensions ) throws InvalidDimensions
+	public static long[] verify( final long... dimensions ) throws InvalidDimensionsException
 	{
 		if ( dimensions == null )
-			throw new InvalidDimensions( dimensions, "Dimensions are null." );
+			throw new InvalidDimensionsException( dimensions, "Dimensions are null." );
 
 		if ( dimensions.length == 0 )
-			throw new InvalidDimensions( dimensions, "Dimensions are zero length." );
+			throw new InvalidDimensionsException( dimensions, "Dimensions are zero length." );
 
 		return verifyAllPositive( dimensions );
 	}
 
-	public static class InvalidDimensions extends IllegalArgumentException
+	public static class InvalidDimensionsException extends IllegalArgumentException
 	{
 
 		private final long[] dimensions;
 
-		public InvalidDimensions( final long[] dimensions, final String message )
+		public InvalidDimensionsException( final long[] dimensions, final String message )
 		{
 			super( message );
 			this.dimensions = dimensions.clone();

--- a/src/main/java/net/imglib2/exception/InvalidDimensionsException.java
+++ b/src/main/java/net/imglib2/exception/InvalidDimensionsException.java
@@ -1,5 +1,7 @@
 package net.imglib2.exception;
 
+import net.imglib2.util.Util;
+
 public class InvalidDimensionsException extends IllegalArgumentException
 {
 	private final long[] dimensions;
@@ -8,6 +10,11 @@ public class InvalidDimensionsException extends IllegalArgumentException
 	{
 		super( message );
 		this.dimensions = dimensions.clone();
+	}
+
+	public InvalidDimensionsException( final int[] dimensions, final String message )
+	{
+		this( Util.int2long( dimensions ), message );
 	}
 
 	public long[] getDimenionsCopy()

--- a/src/main/java/net/imglib2/exception/InvalidDimensionsException.java
+++ b/src/main/java/net/imglib2/exception/InvalidDimensionsException.java
@@ -1,0 +1,17 @@
+package net.imglib2.exception;
+
+public class InvalidDimensionsException extends IllegalArgumentException
+{
+	private final long[] dimensions;
+
+	public InvalidDimensionsException( final long[] dimensions, final String message )
+	{
+		super( message );
+		this.dimensions = dimensions.clone();
+	}
+
+	public long[] getDimenionsCopy()
+	{
+		return this.dimensions.clone();
+	}
+}

--- a/src/main/java/net/imglib2/img/AbstractImg.java
+++ b/src/main/java/net/imglib2/img/AbstractImg.java
@@ -36,7 +36,6 @@ package net.imglib2.img;
 
 import java.util.Iterator;
 
-import net.imglib2.Dimensions;
 import net.imglib2.Interval;
 import net.imglib2.Positionable;
 import net.imglib2.RandomAccess;
@@ -47,7 +46,6 @@ import net.imglib2.RealPositionable;
  * 
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
- * @author Philipp Hanslovsky
  */
 public abstract class AbstractImg< T > implements Img< T >
 {
@@ -61,9 +59,6 @@ public abstract class AbstractImg< T > implements Img< T >
 
 	public AbstractImg( final long[] size )
 	{
-
-		Dimensions.verify( size );
-
 		this.n = size.length;
 
 		this.numPixels = numElements( size );

--- a/src/main/java/net/imglib2/img/AbstractImg.java
+++ b/src/main/java/net/imglib2/img/AbstractImg.java
@@ -36,6 +36,7 @@ package net.imglib2.img;
 
 import java.util.Iterator;
 
+import net.imglib2.Dimensions;
 import net.imglib2.Interval;
 import net.imglib2.Positionable;
 import net.imglib2.RandomAccess;
@@ -46,6 +47,7 @@ import net.imglib2.RealPositionable;
  * 
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
+ * @author Philipp Hanslovsky
  */
 public abstract class AbstractImg< T > implements Img< T >
 {
@@ -59,6 +61,9 @@ public abstract class AbstractImg< T > implements Img< T >
 
 	public AbstractImg( final long[] size )
 	{
+
+		Dimensions.InvalidDimensions.checkAllPositiveOrElseThrow( size );
+
 		this.n = size.length;
 
 		this.numPixels = numElements( size );

--- a/src/main/java/net/imglib2/img/AbstractImg.java
+++ b/src/main/java/net/imglib2/img/AbstractImg.java
@@ -62,7 +62,7 @@ public abstract class AbstractImg< T > implements Img< T >
 	public AbstractImg( final long[] size )
 	{
 
-		Dimensions.InvalidDimensions.checkAllPositiveOrElseThrow( size );
+		Dimensions.verifyAllPositive( size );
 
 		this.n = size.length;
 

--- a/src/main/java/net/imglib2/img/AbstractImg.java
+++ b/src/main/java/net/imglib2/img/AbstractImg.java
@@ -62,7 +62,7 @@ public abstract class AbstractImg< T > implements Img< T >
 	public AbstractImg( final long[] size )
 	{
 
-		Dimensions.verifyAllPositive( size );
+		Dimensions.verify( size );
 
 		this.n = size.length;
 

--- a/src/main/java/net/imglib2/img/array/ArrayImgFactory.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImgFactory.java
@@ -87,7 +87,7 @@ public class ArrayImgFactory< T extends NativeType< T > > extends NativeImgFacto
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
-		Dimensions.InvalidDimensions.checkAllPositiveOrElseThrow( dimensions );
+		Dimensions.verifyAllPositive( dimensions );
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		final int numEntities = numEntitiesRangeCheck( dimensions, entitiesPerPixel );
 		final A data = ArrayDataAccessFactory.get( typeFactory ).createArray( numEntities );

--- a/src/main/java/net/imglib2/img/array/ArrayImgFactory.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImgFactory.java
@@ -87,7 +87,7 @@ public class ArrayImgFactory< T extends NativeType< T > > extends NativeImgFacto
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
-		Dimensions.verifyAllPositive( dimensions );
+		Dimensions.verify( dimensions );
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		final int numEntities = numEntitiesRangeCheck( dimensions, entitiesPerPixel );
 		final A data = ArrayDataAccessFactory.get( typeFactory ).createArray( numEntities );

--- a/src/main/java/net/imglib2/img/array/ArrayImgFactory.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImgFactory.java
@@ -53,6 +53,7 @@ import net.imglib2.util.Util;
  * @author Tobias Pietzsch
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
+ * @author Philipp Hanslovsky
  */
 public class ArrayImgFactory< T extends NativeType< T > > extends NativeImgFactory< T >
 {
@@ -86,6 +87,7 @@ public class ArrayImgFactory< T extends NativeType< T > > extends NativeImgFacto
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
+		Dimensions.InvalidDimensions.checkAllPositiveOrElseThrow( dimensions );
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		final int numEntities = numEntitiesRangeCheck( dimensions, entitiesPerPixel );
 		final A data = ArrayDataAccessFactory.get( typeFactory ).createArray( numEntities );

--- a/src/main/java/net/imglib2/img/cell/CellImgFactory.java
+++ b/src/main/java/net/imglib2/img/cell/CellImgFactory.java
@@ -68,46 +68,7 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 	public CellImgFactory( final T type, final int... cellDimensions )
 	{
 		super( type );
-		defaultCellDimensions = cellDimensions.clone();
-		verifyDimensions( defaultCellDimensions );
-	}
-
-	/**
-	 * Verify that {@code dimensions} is not null or empty, and that no
-	 * dimension is less than 1. Throw {@link IllegalArgumentException}
-	 * otherwise.
-	 *
-	 * @param dimensions
-	 * @throws IllegalArgumentException
-	 */
-	public static void verifyDimensions( final int[] dimensions ) throws IllegalArgumentException
-	{
-		if ( dimensions == null )
-			throw new IllegalArgumentException( "dimensions == null" );
-
-		if ( dimensions.length == 0 )
-			throw new IllegalArgumentException( "dimensions.length == 0" );
-
-		for ( int d = 0; d < dimensions.length; d++ )
-			if ( dimensions[ d ] <= 0 )
-				throw new IllegalArgumentException( "dimensions[ " + d + " ] <= 0" );
-	}
-
-	/**
-	 * Verify that {@code dimensions} is not null or empty, and that no
-	 * dimension is less than 1. Throw {@link IllegalArgumentException}
-	 * otherwise.
-	 *
-	 * This method has been deprecated in favor of
-	 * {@link Dimensions#verify(long...)}.
-	 *
-	 * @param dimensions
-	 * @throws IllegalArgumentException
-	 */
-	@Deprecated
-	public static void verifyDimensions( final long dimensions[] ) throws IllegalArgumentException
-	{
-		Dimensions.verify( dimensions );
+		defaultCellDimensions = Dimensions.verify( cellDimensions ).clone();
 	}
 
 	/**
@@ -160,7 +121,7 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
-		verifyDimensions( dimensions );
+		Dimensions.verify( dimensions );
 
 		final int n = dimensions.length;
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
@@ -220,8 +181,7 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 	@Deprecated
 	public CellImgFactory( final int... cellDimensions )
 	{
-		defaultCellDimensions = cellDimensions.clone();
-		verifyDimensions( defaultCellDimensions );
+		defaultCellDimensions = Dimensions.verify( cellDimensions ).clone();
 	}
 
 	@Deprecated
@@ -232,5 +192,33 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 		@SuppressWarnings( { "unchecked", "rawtypes" } )
 		final CellImg< T, ? > img = create( dimensions, type, ( NativeTypeFactory ) type.getNativeTypeFactory() );
 		return img;
+	}
+
+	/*
+	 * -----------------------------------------------------------------------
+	 *
+	 * Deprecated API.
+	 *
+	 * -----------------------------------------------------------------------
+	 */
+
+	/**
+	 * @deprecated This method has been deprecated in favor of
+	 * {@link Dimensions#verify(int...)}.
+	 */
+	@Deprecated
+	public static void verifyDimensions( final int[] dimensions ) throws IllegalArgumentException
+	{
+		Dimensions.verify( dimensions );
+	}
+
+	/**
+	 * @deprecated This method has been deprecated in favor of
+	 * {@link Dimensions#verify(long...)}.
+	 */
+	@Deprecated
+	public static void verifyDimensions( final long dimensions[] ) throws IllegalArgumentException
+	{
+		Dimensions.verify( dimensions );
 	}
 }

--- a/src/main/java/net/imglib2/img/cell/CellImgFactory.java
+++ b/src/main/java/net/imglib2/img/cell/CellImgFactory.java
@@ -164,6 +164,7 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
+		Dimensions.InvalidDimensions.checkAllPositiveOrElseThrow( dimensions );
 		verifyDimensions( dimensions );
 
 		final int n = dimensions.length;

--- a/src/main/java/net/imglib2/img/cell/CellImgFactory.java
+++ b/src/main/java/net/imglib2/img/cell/CellImgFactory.java
@@ -98,18 +98,16 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 	 * dimension is less than 1. Throw {@link IllegalArgumentException}
 	 * otherwise.
 	 *
+	 * This method has been deprecated in favor of
+	 * {@link Dimensions#verify(long...)}.
+	 *
 	 * @param dimensions
 	 * @throws IllegalArgumentException
 	 */
+	@Deprecated
 	public static void verifyDimensions( final long dimensions[] ) throws IllegalArgumentException
 	{
-		if ( dimensions == null )
-			throw new IllegalArgumentException( "dimensions == null" );
-
-		if ( dimensions.length == 0 )
-			throw new IllegalArgumentException( "dimensions.length == 0" );
-
-		Dimensions.verifyAllPositive( dimensions );
+		Dimensions.verify( dimensions );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/cell/CellImgFactory.java
+++ b/src/main/java/net/imglib2/img/cell/CellImgFactory.java
@@ -164,7 +164,7 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
-		Dimensions.InvalidDimensions.checkAllPositiveOrElseThrow( dimensions );
+		Dimensions.verifyAllPositive( dimensions );
 		verifyDimensions( dimensions );
 
 		final int n = dimensions.length;

--- a/src/main/java/net/imglib2/img/cell/CellImgFactory.java
+++ b/src/main/java/net/imglib2/img/cell/CellImgFactory.java
@@ -109,9 +109,7 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 		if ( dimensions.length == 0 )
 			throw new IllegalArgumentException( "dimensions.length == 0" );
 
-		for ( int d = 0; d < dimensions.length; d++ )
-			if ( dimensions[ d ] <= 0 )
-				throw new IllegalArgumentException( "dimensions[ " + d + " ] <= 0" );
+		Dimensions.verifyAllPositive( dimensions );
 	}
 
 	/**
@@ -164,7 +162,6 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
-		Dimensions.verifyAllPositive( dimensions );
 		verifyDimensions( dimensions );
 
 		final int n = dimensions.length;
@@ -204,7 +201,6 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 			return new CellImgFactory( ( NativeType ) type, defaultCellDimensions );
 		throw new IncompatibleTypeException( this, type.getClass().getCanonicalName() + " does not implement NativeType." );
 	}
-
 
 	/*
 	 * -----------------------------------------------------------------------

--- a/src/main/java/net/imglib2/img/list/ListImgFactory.java
+++ b/src/main/java/net/imglib2/img/list/ListImgFactory.java
@@ -68,7 +68,7 @@ public class ListImgFactory< T > extends ImgFactory< T >
 	@Override
 	public ListImg< T > create( final long... dimensions )
 	{
-		return new ListImg<>( dimensions, type() );
+		return new ListImg<>( Dimensions.verify( dimensions ), type() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/planar/PlanarImgFactory.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImgFactory.java
@@ -54,6 +54,7 @@ import net.imglib2.util.Util;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  * @author Johannes Schindelin
+ * @author Philipp Hanslovsky
  */
 public class PlanarImgFactory< T extends NativeType< T > > extends NativeImgFactory< T >
 {
@@ -87,6 +88,7 @@ public class PlanarImgFactory< T extends NativeType< T > > extends NativeImgFact
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
+		Dimensions.InvalidDimensions.checkAllPositiveOrElseThrow( dimensions );
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		final PlanarImg< T, A > img = new PlanarImg<>( ArrayDataAccessFactory.get( typeFactory ), dimensions, entitiesPerPixel );
 		img.setLinkedType( typeFactory.createLinkedType( img ) );
@@ -101,7 +103,6 @@ public class PlanarImgFactory< T extends NativeType< T > > extends NativeImgFact
 			return new PlanarImgFactory( ( NativeType ) type );
 		throw new IncompatibleTypeException( this, type.getClass().getCanonicalName() + " does not implement NativeType." );
 	}
-
 
 	/*
 	 * -----------------------------------------------------------------------

--- a/src/main/java/net/imglib2/img/planar/PlanarImgFactory.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImgFactory.java
@@ -88,7 +88,7 @@ public class PlanarImgFactory< T extends NativeType< T > > extends NativeImgFact
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
-		Dimensions.InvalidDimensions.checkAllPositiveOrElseThrow( dimensions );
+		Dimensions.verifyAllPositive( dimensions );
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		final PlanarImg< T, A > img = new PlanarImg<>( ArrayDataAccessFactory.get( typeFactory ), dimensions, entitiesPerPixel );
 		img.setLinkedType( typeFactory.createLinkedType( img ) );

--- a/src/main/java/net/imglib2/img/planar/PlanarImgFactory.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImgFactory.java
@@ -88,7 +88,7 @@ public class PlanarImgFactory< T extends NativeType< T > > extends NativeImgFact
 			final T type,
 			final NativeTypeFactory< T, A > typeFactory )
 	{
-		Dimensions.verifyAllPositive( dimensions );
+		Dimensions.verify( dimensions );
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		final PlanarImg< T, A > img = new PlanarImg<>( ArrayDataAccessFactory.get( typeFactory ), dimensions, entitiesPerPixel );
 		img.setLinkedType( typeFactory.createLinkedType( img ) );

--- a/src/main/java/net/imglib2/img/sparse/NtreeImgFactory.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeImgFactory.java
@@ -75,6 +75,8 @@ public class NtreeImgFactory< T extends NativeType< T > > extends NativeImgFacto
 
 	private < A > NtreeImg< T, ? > create( final long[] dimensions, final T type, final NativeTypeFactory< T, A > typeFactory )
 	{
+		Dimensions.verify( dimensions );
+
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		if ( entitiesPerPixel.getNumerator() != entitiesPerPixel.getDenominator() )
 			throw new RuntimeException( "not implemented" );

--- a/src/test/java/net/imglib2/img/array/ArrayImgTest.java
+++ b/src/test/java/net/imglib2/img/array/ArrayImgTest.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -50,10 +50,12 @@ import org.junit.Test;
 
 /**
  * Unit tests for {@link ArrayImg}.
- * 
+ *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  * @author Curtis Rueden
+ * @author Matthias Arzt
+ * @author Philipp Hanslovsky
  */
 public class ArrayImgTest
 {
@@ -88,5 +90,11 @@ public class ArrayImgTest
 		assertEquals( 2, lastPixel.get() );
 		assertFalse( cursor.hasNext() );
 		cursor.jumpFwd( -1 );
+	}
+
+	@Test
+	public void testArrayImgInvalidDimensions()
+	{
+		ImgTestHelper.assertInvalidDims( new ArrayImgFactory<>( new FloatType() ) );
 	}
 }

--- a/src/test/java/net/imglib2/img/array/ArrayImgsTest.java
+++ b/src/test/java/net/imglib2/img/array/ArrayImgsTest.java
@@ -72,6 +72,7 @@ import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.ImgTestHelper;
 import net.imglib2.util.IntervalIndexer;
 import net.imglib2.util.Intervals;
 
@@ -460,15 +461,15 @@ public class ArrayImgsTest
 			final boolean[] data = new boolean[] { true, false, false, false, true, true, false, true };
 			final ArrayImg< NativeBoolType, BooleanArray > b = ArrayImgs.booleans( new BooleanArray( data ), 4, 2 );
 			final ArrayCursor< NativeBoolType > c = b.cursor();
-			Assert.assertEquals(true, c.next().get());
-			Assert.assertEquals(false, c.next().get());
-			Assert.assertEquals(false, c.next().get());
-			Assert.assertEquals(false, c.next().get());
-			Assert.assertEquals(true, c.next().get());
-			Assert.assertEquals(true, c.next().get());
-			Assert.assertEquals(false, c.next().get());
-			Assert.assertEquals(true, c.next().get());
-			Assert.assertFalse(c.hasNext());
+			Assert.assertEquals( true, c.next().get() );
+			Assert.assertEquals( false, c.next().get() );
+			Assert.assertEquals( false, c.next().get() );
+			Assert.assertEquals( false, c.next().get() );
+			Assert.assertEquals( true, c.next().get() );
+			Assert.assertEquals( true, c.next().get() );
+			Assert.assertEquals( false, c.next().get() );
+			Assert.assertEquals( true, c.next().get() );
+			Assert.assertFalse( c.hasNext() );
 		}
 
 	}
@@ -512,6 +513,31 @@ public class ArrayImgsTest
 			IntervalIndexer.indexToPosition( i, img, access );
 			Assert.assertEquals( array[ i ], access.get().getRealDouble(), 0.0 );
 		}
+	}
+
+	@Test
+	public void testInvalidDimensions()
+	{
+		ImgTestHelper.assertInvalidDims( ArrayImgs::argbs );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::bits );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::booleans );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::bytes );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::complexDoubles );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::complexFloats );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::doubles );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::floats );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::ints );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::longs );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::shorts );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::unsigned2Bits );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::unsigned4Bits );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::unsigned12Bits );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::unsigned128Bits );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::unsignedBytes );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::unsignedInts );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::unsignedLongs );
+		ImgTestHelper.assertInvalidDims( ArrayImgs::unsignedShorts );
+		ImgTestHelper.assertInvalidDims( dim -> ArrayImgs.unsignedVariableBitLengths( 13, dim ) );
 	}
 
 }

--- a/src/test/java/net/imglib2/img/cell/CellImgTest.java
+++ b/src/test/java/net/imglib2/img/cell/CellImgTest.java
@@ -36,6 +36,7 @@ package net.imglib2.img.cell;
 
 import static org.junit.Assert.assertTrue;
 import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.planar.PlanarImgFactory;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.ImgTestHelper;
 import net.imglib2.util.Util;
@@ -48,6 +49,7 @@ import org.junit.Test;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  * @author Curtis Rueden
+ * @author Philipp Hanslovsky
  */
 public class CellImgTest
 {
@@ -67,5 +69,10 @@ public class CellImgTest
 						ImgTestHelper.testImg( dim[ i ], new CellImgFactory<>( new FloatType(), 5 ), new CellImgFactory<>( new FloatType() ) ) );
 			}
 		}
+	}
+
+	@Test
+	public void testCellImgInvalidDimensions() {
+		ImgTestHelper.assertInvalidDims( new CellImgFactory<>( new FloatType(), 100 ) );
 	}
 }

--- a/src/test/java/net/imglib2/img/planar/PlanarImgTest.java
+++ b/src/test/java/net/imglib2/img/planar/PlanarImgTest.java
@@ -48,6 +48,7 @@ import org.junit.Test;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  * @author Curtis Rueden
+ * @author Philipp Hanslovsky
  */
 public class PlanarImgTest
 {
@@ -64,5 +65,10 @@ public class PlanarImgTest
 			assertTrue( "PlanarImg vs PlanarImg failed for dim = " + Util.printCoordinates( dim[ i ] ),
 					ImgTestHelper.testImg( dim[ i ], new PlanarImgFactory<>( new FloatType() ), new PlanarImgFactory<>( new FloatType() ) ) );
 		}
+	}
+
+	@Test
+	public void testPlanarImgInvalidDimensions() {
+		ImgTestHelper.assertInvalidDims( new PlanarImgFactory<>( new FloatType() ) );
 	}
 }

--- a/src/test/java/net/imglib2/util/ImgTestHelper.java
+++ b/src/test/java/net/imglib2/util/ImgTestHelper.java
@@ -37,9 +37,9 @@ package net.imglib2.util;
 import java.util.Random;
 import java.util.function.Function;
 
+import net.imglib2.exception.InvalidDimensionsException;
 import org.junit.Assert;
 import net.imglib2.Cursor;
-import net.imglib2.Dimensions;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
@@ -109,7 +109,7 @@ public class ImgTestHelper
 		{
 			factory.apply( dims );
 		}
-		catch ( final Dimensions.InvalidDimensionsException exception )
+		catch ( final InvalidDimensionsException exception )
 		{
 			Assert.assertArrayEquals( dims, exception.getDimenionsCopy() );
 			return;
@@ -119,13 +119,13 @@ public class ImgTestHelper
 
 			Assert.fail( String.format(
 					"Expected exception of type %s but %s was thrown.",
-					Dimensions.InvalidDimensionsException.class.getName(),
+					InvalidDimensionsException.class.getName(),
 					exception.getClass().getName() ) );
 		}
 
 		Assert.fail( String.format(
 				"Expected exception of type %s but no exception was thrown.",
-				Dimensions.InvalidDimensionsException.class.getName() ) );
+				InvalidDimensionsException.class.getName() ) );
 	}
 
 	public static boolean testImg( final long[] size, final ImgFactory< FloatType > factory1, final ImgFactory< FloatType > factory2 )

--- a/src/test/java/net/imglib2/util/ImgTestHelper.java
+++ b/src/test/java/net/imglib2/util/ImgTestHelper.java
@@ -109,7 +109,7 @@ public class ImgTestHelper
 		{
 			factory.apply( dims );
 		}
-		catch ( final Dimensions.InvalidDimensions exception )
+		catch ( final Dimensions.InvalidDimensionsException exception )
 		{
 			Assert.assertArrayEquals( dims, exception.getDimenionsCopy() );
 			return;
@@ -119,13 +119,13 @@ public class ImgTestHelper
 
 			Assert.fail( String.format(
 					"Expected exception of type %s but %s was thrown.",
-					Dimensions.InvalidDimensions.class.getName(),
+					Dimensions.InvalidDimensionsException.class.getName(),
 					exception.getClass().getName() ) );
 		}
 
 		Assert.fail( String.format(
 				"Expected exception of type %s but no exception was thrown.",
-				Dimensions.InvalidDimensions.class.getName() ) );
+				Dimensions.InvalidDimensionsException.class.getName() ) );
 	}
 
 	public static boolean testImg( final long[] size, final ImgFactory< FloatType > factory1, final ImgFactory< FloatType > factory2 )

--- a/src/test/java/net/imglib2/util/ImgTestHelper.java
+++ b/src/test/java/net/imglib2/util/ImgTestHelper.java
@@ -35,8 +35,11 @@
 package net.imglib2.util;
 
 import java.util.Random;
+import java.util.function.Function;
 
+import org.junit.Assert;
 import net.imglib2.Cursor;
+import net.imglib2.Dimensions;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
@@ -50,6 +53,7 @@ import net.imglib2.view.ExtendedRandomAccessibleInterval;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  * @author Curtis Rueden
+ * @author Philipp Hanslovsky
  */
 public class ImgTestHelper
 {
@@ -72,6 +76,56 @@ public class ImgTestHelper
 	public static long[][] dims()
 	{
 		return DIM.clone();
+	}
+
+	private static final long[][] INVALID_DIM = {
+			{ -127 },
+			{ 0 },
+			{ -1, 0 },
+			{ -1, 1 },
+			{ -3, -2 },
+			{ 0, 0, 0 },
+			{ -1, 2, 3 },
+			{ 4, -2, 100 },
+			{ 3151, -235, 8341 },
+			{ 34, 5135, 35163, 0 },
+			{ 35135, 3531, -2, 1 },
+	};
+
+	public static void assertInvalidDims( final ImgFactory< ? > factory )
+	{
+		assertInvalidDims( factory::create );
+	}
+
+	public static void assertInvalidDims( final Function< long[], Img< ? > > factory )
+	{
+		for ( final long[] dims : INVALID_DIM )
+			assertInvalidDims( dims, factory );
+	}
+
+	private static void assertInvalidDims( final long[] dims, final Function< long[], Img< ? > > factory )
+	{
+		try
+		{
+			factory.apply( dims );
+		}
+		catch ( final Dimensions.InvalidDimensions exception )
+		{
+			Assert.assertArrayEquals( dims, exception.getDimenionsCopy() );
+			return;
+		}
+		catch ( final Throwable exception )
+		{
+
+			Assert.fail( String.format(
+					"Expected exception of type %s but %s was thrown.",
+					Dimensions.InvalidDimensions.class.getName(),
+					exception.getClass().getName() ) );
+		}
+
+		Assert.fail( String.format(
+				"Expected exception of type %s but no exception was thrown.",
+				Dimensions.InvalidDimensions.class.getName() ) );
 	}
 
 	public static boolean testImg( final long[] size, final ImgFactory< FloatType > factory1, final ImgFactory< FloatType > factory2 )


### PR DESCRIPTION
Fixes #276

I tried to fix it not only in `ArrayImg` but in other `Img` implementations as well. I am currently enforcing all dimensions to be positive, but zero-size dimensions may make sense, as well.

cc @ctrueden 