### PR TITLE
Add method Intervals.positions( Interval ) to allow localizing LoopBuilder loops.

### DIFF
--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -40,6 +40,7 @@ import net.imglib2.FinalInterval;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.Localizable;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.transform.integer.Mixed;
@@ -1028,6 +1029,17 @@ public class Intervals
 		final double[] min = new double[ interval.numDimensions() ];
 		interval.realMin( min );
 		return min;
+	}
+
+	/**
+	 * Returns an image, where each pixel value is the position of the pixel
+	 * represented as {@link Localizable}.
+	 *
+	 * @param interval
+	 *            Interval of the returned image.
+	 */
+	public static RandomAccessibleInterval< Localizable > positions( final Interval interval ) {
+		return Localizables.randomAccessibleInterval( interval);
 	}
 
 	/**

--- a/src/main/java/net/imglib2/util/Localizables.java
+++ b/src/main/java/net/imglib2/util/Localizables.java
@@ -58,7 +58,7 @@ public class Localizables
 		return new LocationRandomAccessible( n );
 	}
 
-	public RandomAccessibleInterval< Localizable > randomAccessibleInterval( final Interval interval ) {
+	public static RandomAccessibleInterval< Localizable > randomAccessibleInterval( final Interval interval ) {
 		return Views.interval( randomAccessible( interval.numDimensions() ), interval );
 	}
 


### PR DESCRIPTION
It's hard to get pixel positions in a LoopBuilder loop. This PR implements the solution (1) suggested here https://github.com/imglib/imglib2/pull/273#issuecomment-551867178.

The method `Intervals.positions(Interval)` returns an image where each pixel value equals the position of the pixel. (The new method does the same as the existing method `Localizables.randomAccessibleInterval(Interval)`, but the name is much nicer.)

This allows the get pixel positions in `LoopBuilder`:
```java
LoopBuilder.setImages( Intervals.positions( image ), image ).forEachPixel(
    ( position, pixel ) -> {
        int x = position.getIntPosition( 0 );
        int y = position.getIntPosition( 1 );
        pixel.set( x * x + y * y );
    }
)
```