### PR TITLE
Re-add type-bounded signatures of Views.extendValue and Views.expandValue

### DIFF
--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -65,6 +65,7 @@ import net.imglib2.transform.integer.permutation.SingleDimensionPermutationTrans
 import net.imglib2.transform.integer.shear.InverseShearTransform;
 import net.imglib2.transform.integer.shear.ShearTransform;
 import net.imglib2.type.BooleanType;
+import net.imglib2.type.Type;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
@@ -184,6 +185,24 @@ public class Views
 	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final T value )
 	{
 		return new ExtendedRandomAccessibleInterval<>( source, new OutOfBoundsConstantValueFactory<>( value ) );
+	}
+
+	/**
+	 * Extend a RandomAccessibleInterval with a constant-value out-of-bounds
+	 * strategy.
+	 *
+	 * @param source
+	 *            the interval to extend.
+	 * @return (unbounded) RandomAccessible which extends the input interval to
+	 *         infinity.
+	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
+	 * @deprecated use {@code extendValue} with unbounded type parameter T
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes", "cast" })
+	@Deprecated
+	public static < T extends Type< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final T value )
+	{
+		return ( ExtendedRandomAccessibleInterval< T, F > ) Views.extendValue( ( RandomAccessibleInterval ) source, ( Object ) value );
 	}
 
 	/**
@@ -1354,6 +1373,25 @@ public class Views
 	public static < T > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final T t, final long... border )
 	{
 		return interval( extendValue( source, t ), Intervals.expand( source, border ) );
+	}
+
+	/**
+	 * Expand a RandomAccessibleInterval as specified by border. source will be
+	 * extended with a constant value specified by the caller.
+	 *
+	 * @param source
+	 *            the interval to expand.
+	 * @param t
+	 *            Constant extension of source.
+	 * @return Expansion of the {@link RandomAccessibleInterval} source as
+	 *         specified by t and border.
+	 * @deprecated use {@code expandValue} with unbounded type parameter T
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Deprecated
+	public static < T extends Type< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final T t, final long... border )
+	{
+		return expandValue( ( RandomAccessibleInterval ) source, ( Object ) t, border );
 	}
 
 	/**


### PR DESCRIPTION
See [this discussion](https://gitter.im/imglib/imglib2?at=5e2abf31e177666195bd4689) on gitter.