### PR TITLE
Re-add equalDimensions signature with Interval

### DIFF
--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -846,7 +846,7 @@ public class Intervals
 	}
 
 	/**
-	 * Tests whether two intervals have equal dimensions (same size).
+	 * Tests whether two {@link Dimensions} have the same size.
 	 */
 	public static boolean equalDimensions( final Dimensions a, final Dimensions b )
 	{
@@ -858,6 +858,14 @@ public class Intervals
 				return false;
 
 		return true;
+	}
+
+	/**
+	 * Tests whether two intervals have equal dimensions (same size).
+	 */
+	public static boolean equalDimensions( final Interval a, final Interval b )
+	{
+		return equalDimensions((Dimensions) a, (Dimensions) b);
 	}
 
 	/**

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -865,7 +865,7 @@ public class Intervals
 	 */
 	public static boolean equalDimensions( final Interval a, final Interval b )
 	{
-		return equalDimensions((Dimensions) a, (Dimensions) b);
+		return equalDimensions( ( Dimensions ) a, ( Dimensions ) b );
 	}
 
 	/**


### PR DESCRIPTION
The signature was relaxed from `Interval` arguments to `Dimensions` arguments in commit 512423f. This commit re-introduces an `Interval`-based signature to avoid binary API breakage.