### PR TITLE
LoopBuilder Improve Performance For Small Images

### DIFF
--- a/src/main/java/net/imglib2/converter/RealTypeConverters.java
+++ b/src/main/java/net/imglib2/converter/RealTypeConverters.java
@@ -43,6 +43,7 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
@@ -76,7 +77,8 @@ public final class RealTypeConverters
 		RealType< ? > s = Util.getTypeFromInterval( sourceInterval );
 		RealType< ? > d = Util.getTypeFromInterval( destination );
 		Converter< RealType< ? >, RealType< ? > > copy = getConverter( s, d );
-		LoopBuilder.setImages( sourceInterval, destination ).multiThreaded().forEachPixel( copy::convert );
+		boolean useMultiThreading = Intervals.numElements(destination) >= 20_000;
+		LoopBuilder.setImages( sourceInterval, destination ).multiThreaded( useMultiThreading ).forEachPixel( copy::convert );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/loops/BindActionToSamplers.java
+++ b/src/main/java/net/imglib2/loops/BindActionToSamplers.java
@@ -40,8 +40,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Package-private utility class that's used by {@link LoopBuilder}.
@@ -98,14 +96,10 @@ final class BindActionToSamplers
 	 */
 	public static Runnable bindActionToSamplers( final Object action, final List< ? extends Sampler< ? > > samplers )
 	{
-		final Object[] arguments = Stream.concat( Stream.of( action ), samplers.stream() ).toArray();
-		for ( final ClassCopyProvider< Runnable > factory : factories )
-			if ( factory.matches( arguments ) )
-			{
-				final List< Class< ? extends Object > > key = Stream.of( arguments ).map( Object::getClass ).collect( Collectors.toList() );
-				return factory.newInstanceForKey( key, arguments );
-			}
-		throw new IllegalArgumentException();
+		final Object[] arguments = ListUtils.concatAsArray( action, samplers );
+		final ClassCopyProvider< Runnable > factory = factories.get( samplers.size() - 1 );
+		final List< Class< ? extends Object > > key = ListUtils.map( Object::getClass, arguments );
+		return factory.newInstanceForKey( key, arguments );
 	}
 
 	public static class ConsumerRunnable< A > implements Runnable

--- a/src/main/java/net/imglib2/loops/ClassCopyProvider.java
+++ b/src/main/java/net/imglib2/loops/ClassCopyProvider.java
@@ -36,7 +36,6 @@ package net.imglib2.loops;
 import java.lang.reflect.Constructor;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 
 /**
  * Helper to create multiple copies of a class.
@@ -85,8 +84,7 @@ public class ClassCopyProvider< T >
 
 	private static boolean hasDefaultConstructor( final Class< ? > clazz )
 	{
-		return Stream.of( clazz.getConstructors() )
-				.anyMatch( constructor -> constructor.getParameterCount() == 0 );
+		return ListUtils.anyMatch( constructor -> constructor.getParameterCount() == 0, clazz.getConstructors() );
 	}
 
 	private Class< ? extends T > classForKey( final Object key )

--- a/src/main/java/net/imglib2/loops/FastCursorLoops.java
+++ b/src/main/java/net/imglib2/loops/FastCursorLoops.java
@@ -45,15 +45,13 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A package-private utility class that's used by {@link LoopBuilder}.
  *
  * @see FastCursorLoops#createLoop(Object, List)
  */
-final class FastCursorLoops
+public final class FastCursorLoops
 {
 	private FastCursorLoops()
 	{
@@ -102,14 +100,10 @@ final class FastCursorLoops
 	 */
 	public static LongConsumer createLoop( final Object action, final List< ? extends Cursor< ? > > cursors )
 	{
-		final Object[] arguments = Stream.concat( Stream.of( action ), cursors.stream() ).toArray();
-		for ( final ClassCopyProvider< LongConsumer > factory : factories )
-			if ( factory.matches( arguments ) )
-			{
-				final List< Class< ? > > key = Stream.of( arguments ).map( Object::getClass ).collect( Collectors.toList() );
-				return factory.newInstanceForKey( key, arguments );
-			}
-		throw new IllegalArgumentException();
+		final Object[] arguments = ListUtils.concatAsArray( action, cursors );
+		ClassCopyProvider< LongConsumer > factory = factories.get( cursors.size() - 1 );
+		final List< Class< ? > > key = ListUtils.map( Object::getClass, arguments );
+		return factory.newInstanceForKey( key, arguments );
 	}
 
 	public static class OneCursorLoop< A > implements LongConsumer

--- a/src/main/java/net/imglib2/loops/IntervalChunks.java
+++ b/src/main/java/net/imglib2/loops/IntervalChunks.java
@@ -40,8 +40,8 @@ import net.imglib2.util.IntervalIndexer;
 import net.imglib2.util.Intervals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.stream.IntStream;
 
 public class IntervalChunks
 {
@@ -86,9 +86,8 @@ public class IntervalChunks
 		long[] totalMin = Intervals.minAsLongArray( interval );
 		long[] totalMax = Intervals.maxAsLongArray( interval );
 		long[] dimensions = Intervals.dimensionsAsLongArray( interval );
-		long[] cellNumbers = IntStream.range( 0, dimensions.length )
-				.mapToLong( d -> divideAndRoundUp( dimensions[ d ], cellDimensions[ d ] ) )
-				.toArray();
+		long[] cellNumbers = new long[ dimensions.length ];
+		Arrays.setAll(cellNumbers, d -> divideAndRoundUp( dimensions[ d ], cellDimensions[ d ] ) );
 		long elements = Intervals.numElements( cellNumbers );
 		long[] cellIndicies = new long[ n ];
 		long[] min = new long[ n ];

--- a/src/main/java/net/imglib2/loops/ListUtils.java
+++ b/src/main/java/net/imglib2/loops/ListUtils.java
@@ -1,0 +1,56 @@
+package net.imglib2.loops;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class ListUtils
+{
+	static Object[] concatAsArray( Object action, List< ? > samplers )
+	{
+		Object[] result = new Object[ samplers.size() + 1 ];
+		result[0] = action;
+		for ( int i = 0; i < samplers.size(); i++ )
+			result[ i + 1 ] = samplers.get( i );
+		return result;
+	}
+
+	public static <T, R> List<R> map( final Function< T, R > function, final List< T > list ) {
+		List<R> result = new ArrayList<>( list.size() );
+		for ( T entry : list )
+			result.add( function.apply( entry ) );
+		return result;
+	}
+
+	public static <T> boolean allMatch( Predicate<T> predicate, List<T> list )
+	{
+		for ( T entry : list )
+			if( !predicate.test( entry ) )
+				return false;
+		return true;
+	}
+
+	public static <T, R> List<R> map( final Function< T, R > function, final T[] list ) {
+		List<R> result = new ArrayList<>( list.length );
+		for ( T entry : list )
+			result.add( function.apply( entry ) );
+		return result;
+	}
+
+	public static <T> boolean allMatch( Predicate<T> predicate, T[] list )
+	{
+		for ( T entry : list )
+			if( !predicate.test( entry ) )
+				return false;
+		return true;
+	}
+
+	public static <T> boolean anyMatch( Predicate<T> predicate, T[] list )
+	{
+		for ( T entry : list )
+			if( predicate.test( entry ) )
+				return true;
+		return false;
+	}
+}

--- a/src/main/java/net/imglib2/loops/LoopBuilder.java
+++ b/src/main/java/net/imglib2/loops/LoopBuilder.java
@@ -42,8 +42,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import net.imglib2.Cursor;
 import net.imglib2.Dimensions;
@@ -203,7 +201,7 @@ public class LoopBuilder< T >
 
 	private boolean allCursorsAreFast( List< IterableInterval< ? > > iterableIntervals )
 	{
-		return iterableIntervals.stream().allMatch( this::cursorIsFast );
+		return ListUtils.allMatch( this::cursorIsFast, iterableIntervals );
 	}
 
 	private boolean cursorIsFast( IterableInterval< ? > image )
@@ -253,6 +251,11 @@ public class LoopBuilder< T >
 	public LoopBuilder< T > multiThreaded()
 	{
 		return multiThreaded( Parallelization.getTaskExecutor() );
+	}
+
+	public LoopBuilder< T > multiThreaded( boolean multiThreaded )
+	{
+		return multiThreaded( multiThreaded ? Parallelization.getTaskExecutor() : TaskExecutors.singleThreaded() );
 	}
 
 	/**
@@ -335,7 +338,7 @@ public class LoopBuilder< T >
 	private void checkDimensions()
 	{
 		final long[] dims = Intervals.dimensionsAsLongArray( dimensions );
-		final boolean equal = Stream.of( images ).allMatch( image -> Arrays.equals( dims, Intervals.dimensionsAsLongArray( image ) ) );
+		final boolean equal = ListUtils.allMatch( image -> Arrays.equals( dims, Intervals.dimensionsAsLongArray( image ) ), images );
 		if ( !equal )
 		{
 			StringJoiner joiner = new StringJoiner( ", " );
@@ -355,7 +358,7 @@ public class LoopBuilder< T >
 
 	static < T, R > R runOnChunkUsingRandomAccesses( RandomAccessibleInterval[] images, Function< Chunk< T >, R > chunkAction, Interval subInterval )
 	{
-		final List< RandomAccess< ? > > samplers = Stream.of( images ).map( LoopBuilder::initRandomAccess ).collect( Collectors.toList() );
+		final List< RandomAccess< ? > > samplers = ListUtils.map( LoopBuilder::initRandomAccess, images );
 		final Positionable synced = SyncedPositionables.create( samplers );
 		if ( !Views.isZeroMin( subInterval ) )
 			synced.move( Intervals.minAsLongArray( subInterval ) );
@@ -390,7 +393,7 @@ public class LoopBuilder< T >
 
 	static < T, R > R runOnChunkUsingCursors( List< IterableInterval< ? > > iterableIntervals, Function< Chunk< T >, R > chunkAction, long offset, long numElements )
 	{
-		final List< Cursor< ? > > cursors = iterableIntervals.stream().map( IterableInterval::cursor ).collect( Collectors.toList() );
+		final List< Cursor< ? > > cursors = ListUtils.map( IterableInterval::cursor, iterableIntervals );
 		if ( offset != 0 )
 			jumpFwd( cursors, offset );
 		return chunkAction.apply( pixelAction -> {
@@ -407,8 +410,8 @@ public class LoopBuilder< T >
 
 	private List< IterableInterval< ? > > equalIterationOrderIterableIntervals()
 	{
-		List< IterableInterval< ? > > iterableIntervals = Stream.of( images ).map( Views::iterable ).collect( Collectors.toList() );
-		List< Object > iterationOrders = iterableIntervals.stream().map( IterableInterval::iterationOrder ).collect( Collectors.toList() );
+		List< IterableInterval< ? > > iterableIntervals = ListUtils.map( Views::iterable, images );
+		List< Object > iterationOrders = ListUtils.map( IterableInterval::iterationOrder, iterableIntervals );
 		if ( allEqual( iterationOrders ) )
 			return iterableIntervals;
 		return flatIterableIntervals();
@@ -416,12 +419,12 @@ public class LoopBuilder< T >
 
 	private List< IterableInterval< ? > > flatIterableIntervals()
 	{
-		return Stream.of( images ).map( Views::flatIterable ).collect( Collectors.toList() );
+		return ListUtils.map( Views::flatIterable, images );
 	}
 
 	private static boolean allEqual( List< Object > values )
 	{
 		Object first = values.get( 0 );
-		return values.stream().allMatch( first::equals );
+		return ListUtils.allMatch( first::equals, values );
 	}
 }

--- a/src/main/java/net/imglib2/loops/SyncedPositionables.java
+++ b/src/main/java/net/imglib2/loops/SyncedPositionables.java
@@ -35,7 +35,6 @@ package net.imglib2.loops;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import net.imglib2.Localizable;
 import net.imglib2.Positionable;
@@ -84,7 +83,7 @@ public final class SyncedPositionables
 
 	public static Positionable create( final List< ? extends Positionable > positionables )
 	{
-		List< Class< ? > > key = positionables.stream().map( Object::getClass ).collect( Collectors.toList() );
+		List< Class< ? > > key = ListUtils.map( Object::getClass, positionables );
 		int i = positionables.size();
 		return forwarderFactories.get( i >= forwarderFactories.size() ? 0 : i ).newInstanceForKey( key, positionables );
 	}

--- a/src/test/java/net/imglib2/converter/RealTypeConvertersImageSizeBenchmark.java
+++ b/src/test/java/net/imglib2/converter/RealTypeConvertersImageSizeBenchmark.java
@@ -1,0 +1,142 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.parallel.Parallelization;
+import net.imglib2.test.RandomImgs;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.Collection;
+import java.util.HashMap;
+
+/**
+ * Compare execution time between single threaded and multi threaded
+ * execution of {@link RealTypeConverters#copyFromTo(RandomAccessible, RandomAccessibleInterval)}.
+ */
+@State(Scope.Benchmark)
+public class RealTypeConvertersImageSizeBenchmark {
+
+	@Param({ "ImageSize" })
+	public String imageSize;
+
+	private Img< FloatType > in;
+
+	private Img< FloatType > out;
+
+	@Setup(Level.Trial)
+	public void setup()
+	{
+		int size = Integer.valueOf(imageSize);
+		in = RandomImgs.seed(42).nextImage(new FloatType(), 100, size / 100);
+		out = ArrayImgs.floats(100, size / 100);
+	}
+
+	@Benchmark
+	public void singleThreaded()
+	{
+		Parallelization.runSingleThreaded(
+				() -> RealTypeConverters.copyFromTo(in, out)
+		);
+	}
+
+	@Benchmark
+	public void multiThreaded()
+	{
+		Parallelization.runMultiThreaded(
+				() -> RealTypeConverters.copyFromTo(in, out)
+		);
+	}
+
+	public static void main(final String... args) throws RunnerException
+	{
+		String[] imageSizes = { "100", "1000", "10000", "100000", "1000000", "10000000", "100000000" };
+		String simpleName =
+				RealTypeConvertersImageSizeBenchmark.class.getName();
+		final Options opt = new OptionsBuilder().include(simpleName).forks(1)
+				.warmupIterations(5).measurementIterations(10)
+				.warmupTime(TimeValue.milliseconds(500))
+				.measurementTime(TimeValue.milliseconds(500))
+				.param("imageSize", imageSizes)
+				.build();
+		Collection< RunResult > results = new Runner(opt).run();
+		HashMap< Pair< String, String >, Double > map = asMap(results);
+		for (String imageSize : imageSizes) {
+			double s = map.get(new ValuePair<>(simpleName + ".singleThreaded",
+					imageSize));
+			double m = map.get(new ValuePair<>(simpleName + ".multiThreaded",
+					imageSize));
+			System.out.println(
+					"Multi-threading speedup: " + m / s + " for image size: " +
+							imageSize);
+		}
+	}
+
+	public static HashMap< Pair< String, String >, Double > asMap(
+			Collection< RunResult > results)
+	{
+		HashMap< Pair< String, String >, Double > map = new HashMap<>();
+		for (RunResult result : results) {
+			BenchmarkResult aggregatedResult = result.getAggregatedResult();
+			BenchmarkParams params = aggregatedResult.getParams();
+			double score = aggregatedResult.getPrimaryResult().getScore();
+			String benchmark = params.getBenchmark();
+			String size = params.getParam("imageSize");
+			map.put(new ValuePair<>(benchmark, size), score);
+		}
+		return map;
+	}
+
+}


### PR DESCRIPTION
I recently changed RealTypeConverters to use multi-threading. But this adds multi-threading overhead. The multi-threading overhead has a big impact when processing very small images. This PR changes `RealTypeConverters.copyFromTo(...)` to only use multi-threading if the image has more than 20k pixel.

When benchmarking this I additionally noticed, that not using java streams in LoopBuilder additionally improves performance for very small images by around 30%.