### PR TITLE
Biconverter

### DIFF
--- a/src/main/java/net/imglib2/converter/BiConverter.java
+++ b/src/main/java/net/imglib2/converter/BiConverter.java
@@ -34,17 +34,14 @@
 
 package net.imglib2.converter;
 
-import java.util.function.BiConsumer;
-
 /**
- * This interface is equivalent to the {@link BiConsumer} interface and exists
- * for historical reasons only.  Its main use is for functions with one input
- * variable and one pre-allocated output on individual pixels.
+ * This interface would be a TriConsumer if such an interface existed in the
+ * JDK.  Its main use is for functions with two input variables and one
+ * pre-allocated output on individual pixels.
  *
- * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface Converter< A, B >
+public interface BiConverter< A, B, C >
 {
-	public void convert( A input, B output );
+	public void convert( A inputA, B outputB, C output );
 }

--- a/src/main/java/net/imglib2/converter/Converters.java
+++ b/src/main/java/net/imglib2/converter/Converters.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -48,6 +48,11 @@ import net.imglib2.RealRandomAccess;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.RealRandomAccessibleRealInterval;
 import net.imglib2.Sampler;
+import net.imglib2.converter.read.BiConvertedIterableInterval;
+import net.imglib2.converter.read.BiConvertedRandomAccessible;
+import net.imglib2.converter.read.BiConvertedRandomAccessibleInterval;
+import net.imglib2.converter.read.BiConvertedRealRandomAccessible;
+import net.imglib2.converter.read.BiConvertedRealRandomAccessibleRealInterval;
 import net.imglib2.converter.read.ConvertedIterableInterval;
 import net.imglib2.converter.read.ConvertedRandomAccessible;
 import net.imglib2.converter.read.ConvertedRandomAccessibleInterval;
@@ -143,7 +148,7 @@ public class Converters
 			return ( RandomAccessibleInterval< B > ) source;
 		return new ConvertedRandomAccessibleInterval<>( source, converter, b );
 	}
-	
+
 	/**
 	 * Create a {@link RandomAccessibleInterval} whose {@link RandomAccess
 	 * RandomAccesses} {@link RandomAccess#get()} you a converted sample.
@@ -188,12 +193,12 @@ public class Converters
 	{
 		return new WriteConvertedRandomAccessibleInterval<>( source, converter );
 	}
-	
+
 	/**
 	 * Create a {@link RandomAccessibleInterval} whose {@link RandomAccess
 	 * RandomAccesses} {@link RandomAccess#get()} you a converted sample.
 	 * Conversion is done on-the-fly both when reading and writing values.
-	 * 
+	 *
 	 * Delegates to {@link Converters#convert(RandomAccessibleInterval, SamplerConverter)}.
 	 * The different name avoids situations where the compiler
 	 * or a scripting language interpreter picks the undesired method
@@ -420,7 +425,7 @@ public class Converters
 	 * @param channelOrder Order of the color channels.
 	 * @return Color view to the source image that can be used for reading and writing.
 	 */
-	final static public RandomAccessible< ARGBType > mergeARGB( final RandomAccessible< UnsignedByteType > source, ColorChannelOrder channelOrder ) {
+	final static public RandomAccessible< ARGBType > mergeARGB( final RandomAccessible< UnsignedByteType > source, final ColorChannelOrder channelOrder ) {
 		return Converters.convert( Views.collapse( source ), new CompositeARGBSamplerConverter( channelOrder ) );
 	}
 
@@ -433,7 +438,7 @@ public class Converters
 	 * @param channelOrder Order of the color channels.
 	 * @return Color view to the source image that can be used for reading and writing.
 	 */
-	final static public RandomAccessibleInterval< ARGBType > mergeARGB( final RandomAccessibleInterval< UnsignedByteType > source, ColorChannelOrder channelOrder ) {
+	final static public RandomAccessibleInterval< ARGBType > mergeARGB( final RandomAccessibleInterval< UnsignedByteType > source, final ColorChannelOrder channelOrder ) {
 		final int channelAxis = source.numDimensions() - 1;
 		if ( source.min( channelAxis ) > 0 || source.max( channelAxis ) < channelOrder.channelCount() - 1 )
 			throw new IllegalArgumentException();
@@ -561,5 +566,154 @@ public class Converters
 			final Supplier< B > targetTypeSupplier )
 	{
 		return compose( components, composer, targetTypeSupplier.get() );
+	}
+
+	/**
+	 * Create a {@link RandomAccessible} whose {@link RandomAccess
+	 * RandomAccesses} {@link RandomAccess#get()} you a converted sample.
+	 * Conversion is done on-the-fly when reading values. Writing to the
+	 * converted {@link RandomAccessibleInterval} has no effect.
+	 *
+	 * @param sourceA
+	 * @param sourceB
+	 * @param converter a two variable function into a preallocated output, e.g.
+	 *     <code>(a, b, c) -> c.set(a.get() + b.get())</code>
+	 * @param c
+	 * @return a converted {@link RandomAccessible} whose {@link RandomAccess
+	 *         RandomAccesses} perform on-the-fly value conversion using the
+	 *         provided converter.
+	 */
+	final static public < A, B, C extends Type< C > > RandomAccessible< C > convert(
+			final RandomAccessible< A > sourceA,
+			final RandomAccessible< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		return new BiConvertedRandomAccessible<>( sourceA, sourceB, converter, c );
+	}
+
+	/**
+	 * Create a {@link RandomAccessibleInterval} whose {@link RandomAccess
+	 * RandomAccesses} {@link RandomAccess#get()} you a converted sample.
+	 * Conversion is done on-the-fly when reading values. Writing to the
+	 * converted {@link RandomAccessibleInterval} has no effect.
+	 *
+	 * @param sourceA
+	 * @param sourceB
+	 * @param converter a two variable function into a preallocated output, e.g.
+	 *     <code>(a, b, c) -> c.set(a.get() + b.get())</code>
+	 * @param c
+	 * @return a converted {@link RandomAccessibleInterval} whose
+	 *         {@link RandomAccess RandomAccesses} perform on-the-fly value
+	 *         conversion using the provided {@link BiConverter}.
+	 */
+	final static public < A, B, C extends Type< C > > RandomAccessibleInterval< C > convert(
+			final RandomAccessibleInterval< A > sourceA,
+			final RandomAccessibleInterval< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		return new BiConvertedRandomAccessibleInterval<>( sourceA, sourceB, converter, c );
+	}
+
+	/**
+	 * Create a {@link RandomAccessibleInterval} whose {@link RandomAccess
+	 * RandomAccesses} {@link RandomAccess#get()} you a converted sample.
+	 * Conversion is done on-the-fly when reading values. Writing to the
+	 * converted {@link RandomAccessibleInterval} has no effect.
+	 *
+	 * Delegates to {@link Converters#convert(RandomAccessibleInterval, Converter, Type)}.
+	 * The different method name avoids situations where the compiler
+	 * or a scripting language interpreter picks the undesired method
+	 * for an object that implements both {@link RandomAccessibleInterval}
+	 * and {@link IterableInterval}.
+	 *
+	 * @param sourceA
+	 * @param sourceB
+	 * @param converter a two variable function into a preallocated output, e.g.
+	 *     <code>(a, b, c) -> c.set(a.get() + b.get())</code>
+	 * @param c
+	 * @return a converted {@link RandomAccessibleInterval} whose
+	 *         {@link RandomAccess RandomAccesses} perform on-the-fly value
+	 *         conversion using the provided converter.
+	 */
+	final static public < A, B, C extends Type< C > > RandomAccessibleInterval< C > convertRAI(
+			final RandomAccessibleInterval< A > sourceA,
+			final RandomAccessibleInterval< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		return Converters.convert( sourceA, sourceB, converter, c );
+	}
+
+	/**
+	 * Create a {@link IterableInterval} whose {@link Cursor Cursors}
+	 * {@link Cursor#get()} you a converted sample. Conversion is done
+	 * on-the-fly when reading values. Writing to the converted
+	 * {@link IterableInterval} has no effect.
+	 *
+	 * @param sourceA
+	 * @param sourceB
+	 * @param converter a two variable function into a preallocated output, e.g.
+	 *     <code>(a, b, c) -> c.set(a.get() + b.get())</code>
+	 * @param c
+	 * @return a converted {@link IterableInterval} whose {@link Cursor Cursors}
+	 *         perform on-the-fly value conversion using the provided converter.
+	 */
+	final static public < A, B, C extends Type< C > > IterableInterval< C > convert(
+			final IterableInterval< A > sourceA,
+			final IterableInterval< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		return new BiConvertedIterableInterval<>( sourceA, sourceB, converter, c );
+	}
+
+	/**
+	 * Create a {@link RealRandomAccessibleRealInterval} whose {@link RealRandomAccess
+	 * RealRandomAccesses} {@link RealRandomAccess#get()} you a converted sample.
+	 * Conversion is done on-the-fly when reading values. Writing to the
+	 * converted {@link RealRandomAccessibleRealInterval} has no effect.
+	 *
+	 * @param sourceA
+	 * @param sourceB
+	 * @param converter a two variable function into a preallocated output, e.g.
+	 *     <code>(a, b, c) -> c.set(a.get() + b.get())</code>
+	 * @param c
+	 * @return a converted {@link RealRandomAccessibleRealInterval} whose
+	 *         {@link RealRandomAccess RealRandomAccesses} perform on-the-fly value
+	 *         conversion using the provided converter.
+	 */
+	final static public < A, B, C extends Type< C > > RealRandomAccessibleRealInterval< C > convert(
+			final RealRandomAccessibleRealInterval< A > sourceA,
+			final RealRandomAccessibleRealInterval< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		return new BiConvertedRealRandomAccessibleRealInterval<>( sourceA, sourceB, converter, c );
+	}
+
+	/**
+	 * Create a {@link RealRandomAccessible} whose {@link RealRandomAccess
+	 * RealRandomAccesses} {@link RealRandomAccess#get()} you a converted sample.
+	 * Conversion is done on-the-fly when reading values. Writing to the
+	 * converted {@link RandomAccessibleInterval} has no effect.
+	 *
+	 * @param sourceA
+	 * @param sourceB
+	 * @param converter a two variable function into a preallocated output, e.g.
+	 *     <code>(a, b, c) -> c.set(a.get() + b.get())</code>
+	 * @param c
+	 * @return a converted {@link RealRandomAccessible} whose {@link RealRandomAccess
+	 *         RealRandomAccesses} perform on-the-fly value conversion using the
+	 *         provided converter.
+	 */
+	final static public < A, B, C extends Type< C > > RealRandomAccessible< C > convert(
+			final RealRandomAccessible< A > sourceA,
+			final RealRandomAccessible< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		return new BiConvertedRealRandomAccessible<>( sourceA, sourceB, converter, c );
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedCursor.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedCursor.java
@@ -1,0 +1,131 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter.read;
+
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.converter.AbstractConvertedCursor;
+import net.imglib2.converter.BiConverter;
+import net.imglib2.type.Type;
+
+/**
+ * TODO
+ *
+ */
+public class BiConvertedCursor< A, B, C extends Type< C > > extends AbstractConvertedCursor< A, C >
+{
+	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+
+	final protected Cursor< B > sourceB;
+
+	protected final C converted;
+
+	/**
+	 * Creates a copy of c for conversion that can be accessed through
+	 * {@link #get()}.
+	 *
+	 * @param sourceA
+	 * @param sourceB
+	 * @param converter
+	 * @param c
+	 */
+	public BiConvertedCursor(
+			final Cursor< A > sourceA,
+			final Cursor< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceB = sourceB;
+		this.converter = converter;
+		this.converted = c.copy();
+	}
+
+	@Override
+	public C get()
+	{
+		converter.convert( source.get(), sourceB.get(), converted );
+		return converted;
+	}
+
+	@Override
+	public void jumpFwd( final long steps )
+	{
+		source.jumpFwd( steps );
+		sourceB.jumpFwd( steps );
+	}
+
+	@Override
+	public void fwd()
+	{
+		source.fwd();
+		sourceB.fwd();
+	}
+
+	@Override
+	public void reset()
+	{
+		source.reset();
+		sourceB.reset();
+	}
+
+	/**
+	 * The correct logic would be to return sourceA.hasNext() && sourceB.hasNext()
+	 * but we test only sourceA for efficiency.  Make sure that sourceA is the
+	 * smaller {@link IterableInterval}.
+	 */
+	@Override
+	public boolean hasNext()
+	{
+		return source.hasNext();
+	}
+
+	@Override
+	public void remove()
+	{
+		source.remove();
+		sourceB.remove();
+	}
+
+	@Override
+	public BiConvertedCursor< A, B, C > copy()
+	{
+		return new BiConvertedCursor< A, B, C >(
+				( Cursor< A > ) source.copy(),
+				( Cursor< B > ) sourceB.copy(),
+				converter,
+				converted );
+	}
+}

--- a/src/main/java/net/imglib2/converter/read/BiConvertedCursor.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedCursor.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.converter.AbstractConvertedCursor;
@@ -46,11 +48,35 @@ import net.imglib2.type.Type;
  */
 public class BiConvertedCursor< A, B, C extends Type< C > > extends AbstractConvertedCursor< A, C >
 {
+	protected final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier;
+
 	protected final BiConverter< ? super A, ? super B, ? super C > converter;
 
-	final protected Cursor< B > sourceB;
+	protected final Cursor< B > sourceB;
 
 	protected final C converted;
+
+	/**
+	 * Creates a copy of c for conversion that can be accessed through
+	 * {@link #get()}.
+	 *
+	 * @param sourceA
+	 * @param sourceB
+	 * @param converter
+	 * @param c
+	 */
+	public BiConvertedCursor(
+			final Cursor< A > sourceA,
+			final Cursor< B > sourceB,
+			final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceB = sourceB;
+		this.converterSupplier = converterSupplier;
+		this.converter = converterSupplier.get();
+		this.converted = c.copy();
+	}
 
 	/**
 	 * Creates a copy of c for conversion that can be accessed through
@@ -67,10 +93,7 @@ public class BiConvertedCursor< A, B, C extends Type< C > > extends AbstractConv
 			final BiConverter< ? super A, ? super B, ? super C > converter,
 			final C c )
 	{
-		super( sourceA );
-		this.sourceB = sourceB;
-		this.converter = converter;
-		this.converted = c.copy();
+		this( sourceA, sourceB, () -> converter, c );
 	}
 
 	@Override
@@ -125,7 +148,7 @@ public class BiConvertedCursor< A, B, C extends Type< C > > extends AbstractConv
 		return new BiConvertedCursor< A, B, C >(
 				( Cursor< A > ) source.copy(),
 				( Cursor< B > ) sourceB.copy(),
-				converter,
+				converterSupplier,
 				converted );
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedIterableInterval.java
@@ -1,0 +1,109 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter.read;
+
+import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
+import net.imglib2.converter.AbstractConvertedIterableInterval;
+import net.imglib2.converter.BiConverter;
+import net.imglib2.type.Type;
+
+/**
+ * TODO
+ *
+ */
+public class BiConvertedIterableInterval< A, B, C extends Type< C > > extends AbstractConvertedIterableInterval< A, C >
+{
+	protected final IterableInterval< B > sourceIntervalB;
+
+	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+
+	protected final C converted;
+
+	/**
+	 * Creates a copy of c for conversion.
+	 *
+	 * @param sourceA this {@link IterableInterval} is used for all
+	 * 			{@link Interval} related requests.  When using
+	 * 			{@link Interval Intervals} with different sizes, make sure
+	 * 			that this is the smaller {@link Interval}.
+	 * @param sourceB
+	 * @param converter
+	 * @param c
+	 */
+	public BiConvertedIterableInterval(
+			final IterableInterval< A > sourceA,
+			final IterableInterval< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		super( sourceA );
+
+		this.sourceIntervalB = sourceB;
+		this.converter = converter;
+		this.converted = c.copy();
+	}
+
+	@Override
+	public BiConvertedCursor< A, B, C > cursor()
+	{
+		return new BiConvertedCursor<>( sourceInterval.cursor(), sourceIntervalB.cursor(), converter, converted );
+	}
+
+	/**
+	 * Creates a localizing {@link Cursor) for sourceA only because this will
+	 * be used for localization.  Make sure that sourceA is the
+	 * {@link IterableInterval} that creates the {@link Cursor} that localizes
+	 * more efficiently.
+	 */
+	@Override
+	public BiConvertedCursor< A, B, C > localizingCursor()
+	{
+		return new BiConvertedCursor<>( sourceInterval.localizingCursor(), sourceIntervalB.cursor(), converter, converted );
+	}
+
+	/**
+	 * @return an instance of the destination {@link Type}.
+	 */
+	public C getDestinationType()
+	{
+		return converted.copy();
+	}
+
+	public BiConverter< ? super A, ? super B, ? super C > getConverter()
+	{
+		return converter;
+	}
+}

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccess.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccess.java
@@ -1,0 +1,163 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter.read;
+
+import net.imglib2.Localizable;
+import net.imglib2.RandomAccess;
+import net.imglib2.converter.AbstractConvertedRandomAccess;
+import net.imglib2.converter.BiConverter;
+import net.imglib2.type.Type;
+
+/**
+ * TODO
+ *
+ */
+final public class BiConvertedRandomAccess< A, B, C extends Type< C > > extends AbstractConvertedRandomAccess< A, C >
+{
+	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+
+	protected final RandomAccess< B > sourceB;
+
+	protected final C converted;
+
+	public BiConvertedRandomAccess(
+			final RandomAccess< A > sourceA,
+			final RandomAccess< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceB = sourceB;
+		this.converter = converter;
+		this.converted = c.copy();
+	}
+
+	@Override
+	public void fwd( final int d )
+	{
+		source.fwd( d );
+		sourceB.fwd( d );
+	}
+
+	@Override
+	public void bck( final int d )
+	{
+		source.bck( d );
+		sourceB.bck( d );
+	}
+
+	@Override
+	public void move( final int distance, final int d )
+	{
+		source.move( distance, d );
+		sourceB.move( distance, d );
+	}
+
+	@Override
+	public void move( final long distance, final int d )
+	{
+		source.move( distance, d );
+		sourceB.move( distance, d );
+	}
+
+	@Override
+	public void move( final Localizable localizable )
+	{
+		source.move( localizable );
+		sourceB.move( localizable );
+	}
+
+	@Override
+	public void move( final int[] distance )
+	{
+		source.move( distance );
+		sourceB.move( distance );
+	}
+
+	@Override
+	public void move( final long[] distance )
+	{
+		source.move( distance );
+		sourceB.move( distance );
+	}
+
+	@Override
+	public void setPosition( final Localizable localizable )
+	{
+		source.setPosition( localizable );
+		sourceB.setPosition( localizable );
+	}
+
+	@Override
+	public void setPosition( final int[] position )
+	{
+		source.setPosition( position );
+		sourceB.setPosition( position );
+	}
+
+	@Override
+	public void setPosition( final long[] position )
+	{
+		source.setPosition( position );
+		sourceB.setPosition( position );
+	}
+
+	@Override
+	public void setPosition( final int position, final int d )
+	{
+		source.setPosition( position, d );
+		sourceB.setPosition( position, d );
+	}
+
+	@Override
+	public void setPosition( final long position, final int d )
+	{
+		source.setPosition( position, d );
+		sourceB.setPosition( position, d );
+	}
+
+	@Override
+	public C get()
+	{
+		converter.convert( source.get(), sourceB.get(), converted );
+		return converted;
+	}
+
+	@Override
+	public BiConvertedRandomAccess< A, B, C > copy()
+	{
+		return new BiConvertedRandomAccess<>( source.copyRandomAccess(), sourceB.copyRandomAccess(), converter, converted );
+	}
+}

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccess.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccess.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
 import net.imglib2.converter.AbstractConvertedRandomAccess;
@@ -46,6 +48,8 @@ import net.imglib2.type.Type;
  */
 final public class BiConvertedRandomAccess< A, B, C extends Type< C > > extends AbstractConvertedRandomAccess< A, C >
 {
+	protected final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier;
+
 	protected final BiConverter< ? super A, ? super B, ? super C > converter;
 
 	protected final RandomAccess< B > sourceB;
@@ -55,13 +59,23 @@ final public class BiConvertedRandomAccess< A, B, C extends Type< C > > extends 
 	public BiConvertedRandomAccess(
 			final RandomAccess< A > sourceA,
 			final RandomAccess< B > sourceB,
-			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier,
 			final C c )
 	{
 		super( sourceA );
 		this.sourceB = sourceB;
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+		this.converter = converterSupplier.get();
 		this.converted = c.copy();
+	}
+
+	public BiConvertedRandomAccess(
+			final RandomAccess< A > sourceA,
+			final RandomAccess< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		this( sourceA, sourceB, () -> converter, c );
 	}
 
 	@Override
@@ -158,6 +172,10 @@ final public class BiConvertedRandomAccess< A, B, C extends Type< C > > extends 
 	@Override
 	public BiConvertedRandomAccess< A, B, C > copy()
 	{
-		return new BiConvertedRandomAccess<>( source.copyRandomAccess(), sourceB.copyRandomAccess(), converter, converted );
+		return new BiConvertedRandomAccess<>(
+				source.copyRandomAccess(),
+				sourceB.copyRandomAccess(),
+				converterSupplier,
+				converted );
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessible.java
@@ -32,19 +32,60 @@
  * #L%
  */
 
-package net.imglib2.converter;
+package net.imglib2.converter.read;
 
-import java.util.function.BiConsumer;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.converter.AbstractConvertedRandomAccessible;
+import net.imglib2.converter.BiConverter;
+import net.imglib2.type.Type;
 
 /**
- * This interface is equivalent to the {@link BiConsumer} interface and exists
- * for historical reasons only.  Its main use is for functions with one input
- * variable and one pre-allocated output on individual pixels.
+ * TODO
  *
- * @author Stephan Preibisch
- * @author Stephan Saalfeld
  */
-public interface Converter< A, B >
+public class BiConvertedRandomAccessible< A, B, C extends Type< C > > extends AbstractConvertedRandomAccessible< A, C >
 {
-	public void convert( A input, B output );
+	protected final RandomAccessible< B > sourceB;
+
+	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+
+	protected final C converted;
+
+	public BiConvertedRandomAccessible(
+			final RandomAccessible< A > sourceA,
+			final RandomAccessible< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceB = sourceB;
+		this.converter = converter;
+		this.converted = c.copy();
+	}
+
+	@Override
+	public BiConvertedRandomAccess< A, B, C > randomAccess()
+	{
+		return new BiConvertedRandomAccess<>( source.randomAccess(), sourceB.randomAccess(), converter, converted );
+	}
+
+	@Override
+	public BiConvertedRandomAccess< A, B, C > randomAccess( final Interval interval )
+	{
+		return new BiConvertedRandomAccess<>( source.randomAccess( interval ), sourceB.randomAccess( interval ), converter, converted );
+	}
+
+	/**
+	 * @return an instance of the destination {@link Type}.
+	 */
+	public C getDestinationType()
+	{
+		return converted.copy();
+	}
+
+	public BiConverter< ? super A, ? super B, ? super C > getConverter()
+	{
+		return converter;
+	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessibleInterval.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.AbstractWrappedInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
@@ -49,9 +51,21 @@ public class BiConvertedRandomAccessibleInterval< A, B, C extends Type< C > > ex
 {
 	protected final RandomAccessibleInterval< B > sourceIntervalB;
 
-	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+	protected final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier;
 
 	protected final C converted;
+
+	public BiConvertedRandomAccessibleInterval(
+			final RandomAccessibleInterval< A > sourceA,
+			final RandomAccessibleInterval< B > sourceB,
+			final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceIntervalB = sourceB;
+		this.converterSupplier = converterSupplier;
+		this.converted = c.copy();
+	}
 
 	public BiConvertedRandomAccessibleInterval(
 			final RandomAccessibleInterval< A > sourceA,
@@ -59,10 +73,7 @@ public class BiConvertedRandomAccessibleInterval< A, B, C extends Type< C > > ex
 			final BiConverter< ? super A, ? super B, ? super C > converter,
 			final C c )
 	{
-		super( sourceA );
-		this.sourceIntervalB = sourceB;
-		this.converter = converter;
-		this.converted = c.copy();
+		this( sourceA, sourceB, () -> converter, c );
 	}
 
 	@Override
@@ -71,7 +82,7 @@ public class BiConvertedRandomAccessibleInterval< A, B, C extends Type< C > > ex
 		return new BiConvertedRandomAccess<>(
 				sourceInterval.randomAccess(),
 				sourceIntervalB.randomAccess(),
-				converter,
+				converterSupplier,
 				converted );
 	}
 
@@ -81,7 +92,7 @@ public class BiConvertedRandomAccessibleInterval< A, B, C extends Type< C > > ex
 		return new BiConvertedRandomAccess<>(
 				sourceInterval.randomAccess( interval ),
 				sourceIntervalB.randomAccess( interval ),
-				converter,
+				converterSupplier,
 				converted );
 	}
 
@@ -93,8 +104,16 @@ public class BiConvertedRandomAccessibleInterval< A, B, C extends Type< C > > ex
 		return converted.copy();
 	}
 
+	/**
+	 * Returns an instance of the {@link BiConverter}.  If the
+	 * {@link BiConvertedIterableInterval} was created with a
+	 * {@link BiConverter} instead of a {@link Supplier}, then the returned
+	 * {@link BiConverter} will be this instance.
+	 *
+	 * @return
+	 */
 	public BiConverter< ? super A, ? super B, ? super C > getConverter()
 	{
-		return converter;
+		return converterSupplier.get();
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessibleInterval.java
@@ -32,19 +32,69 @@
  * #L%
  */
 
-package net.imglib2.converter;
+package net.imglib2.converter.read;
 
-import java.util.function.BiConsumer;
+import net.imglib2.AbstractWrappedInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.View;
+import net.imglib2.converter.BiConverter;
+import net.imglib2.type.Type;
 
 /**
- * This interface is equivalent to the {@link BiConsumer} interface and exists
- * for historical reasons only.  Its main use is for functions with one input
- * variable and one pre-allocated output on individual pixels.
+ * TODO
  *
- * @author Stephan Preibisch
- * @author Stephan Saalfeld
  */
-public interface Converter< A, B >
+public class BiConvertedRandomAccessibleInterval< A, B, C extends Type< C > > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< C >, View
 {
-	public void convert( A input, B output );
+	protected final RandomAccessibleInterval< B > sourceIntervalB;
+
+	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+
+	protected final C converted;
+
+	public BiConvertedRandomAccessibleInterval(
+			final RandomAccessibleInterval< A > sourceA,
+			final RandomAccessibleInterval< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceIntervalB = sourceB;
+		this.converter = converter;
+		this.converted = c.copy();
+	}
+
+	@Override
+	public BiConvertedRandomAccess< A, B, C > randomAccess()
+	{
+		return new BiConvertedRandomAccess<>(
+				sourceInterval.randomAccess(),
+				sourceIntervalB.randomAccess(),
+				converter,
+				converted );
+	}
+
+	@Override
+	public BiConvertedRandomAccess< A, B, C > randomAccess( final Interval interval )
+	{
+		return new BiConvertedRandomAccess<>(
+				sourceInterval.randomAccess( interval ),
+				sourceIntervalB.randomAccess( interval ),
+				converter,
+				converted );
+	}
+
+	/**
+	 * @return an instance of the destination {@link Type}.
+	 */
+	public C getDestinationType()
+	{
+		return converted.copy();
+	}
+
+	public BiConverter< ? super A, ? super B, ? super C > getConverter()
+	{
+		return converter;
+	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccess.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccess.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Localizable;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealRandomAccess;
@@ -49,6 +51,8 @@ final public class BiConvertedRealRandomAccess< A, B, C extends Type< C > > exte
 {
 	protected final RealRandomAccess< B > sourceB;
 
+	protected final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier;
+
 	protected final BiConverter< ? super A, ? super B, ? super C > converter;
 
 	protected final C converted;
@@ -56,13 +60,23 @@ final public class BiConvertedRealRandomAccess< A, B, C extends Type< C > > exte
 	public BiConvertedRealRandomAccess(
 			final RealRandomAccess< A > sourceA,
 			final RealRandomAccess< B > sourceB,
-			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier,
 			final C c )
 	{
 		super( sourceA );
 		this.sourceB = sourceB;
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+		this.converter = converterSupplier.get();
 		this.converted = c.copy();
+	}
+
+	public BiConvertedRealRandomAccess(
+			final RealRandomAccess< A > sourceA,
+			final RealRandomAccess< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		this( sourceA, sourceB, () -> converter, c );
 	}
 
 	@Override
@@ -232,7 +246,7 @@ final public class BiConvertedRealRandomAccess< A, B, C extends Type< C > > exte
 		return new BiConvertedRealRandomAccess<>(
 				source.copyRealRandomAccess(),
 				sourceB.copyRealRandomAccess(),
-				converter,
+				converterSupplier,
 				converted );
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccess.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccess.java
@@ -1,0 +1,238 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter.read;
+
+import net.imglib2.Localizable;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.converter.AbstractConvertedRealRandomAccess;
+import net.imglib2.converter.BiConverter;
+import net.imglib2.type.Type;
+
+/**
+ * TODO
+ *
+ */
+final public class BiConvertedRealRandomAccess< A, B, C extends Type< C > > extends AbstractConvertedRealRandomAccess< A, C >
+{
+	protected final RealRandomAccess< B > sourceB;
+
+	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+
+	protected final C converted;
+
+	public BiConvertedRealRandomAccess(
+			final RealRandomAccess< A > sourceA,
+			final RealRandomAccess< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceB = sourceB;
+		this.converter = converter;
+		this.converted = c.copy();
+	}
+
+	@Override
+	public C get()
+	{
+		converter.convert( source.get(), sourceB.get(), converted );
+		return converted;
+	}
+
+	@Override
+	public void fwd( final int d )
+	{
+		source.fwd( d );
+		sourceB.fwd( d );
+	}
+
+	@Override
+	public void bck( final int d )
+	{
+		source.bck( d );
+		sourceB.bck( d );
+	}
+
+	@Override
+	public void move( final int distance, final int d )
+	{
+		source.move( distance, d );
+		sourceB.move( distance, d );
+	}
+
+	@Override
+	public void move( final long distance, final int d )
+	{
+		source.move( distance, d );
+		sourceB.move( distance, d );
+	}
+
+	@Override
+	public void move( final Localizable localizable )
+	{
+		source.move( localizable );
+		sourceB.move( localizable );
+	}
+
+	@Override
+	public void move( final int[] distance )
+	{
+		source.move( distance );
+		sourceB.move( distance );
+	}
+
+	@Override
+	public void move( final long[] distance )
+	{
+		source.move( distance );
+		sourceB.move( distance );
+	}
+
+	@Override
+	public void setPosition( final Localizable localizable )
+	{
+		source.setPosition( localizable );
+		sourceB.setPosition( localizable );
+	}
+
+	@Override
+	public void setPosition( final int[] position )
+	{
+		source.setPosition( position );
+		sourceB.setPosition( position );
+	}
+
+	@Override
+	public void setPosition( final long[] position )
+	{
+		source.setPosition( position );
+		sourceB.setPosition( position );
+	}
+
+	@Override
+	public void setPosition( final int position, final int d )
+	{
+		source.setPosition( position, d );
+		sourceB.setPosition( position, d );
+	}
+
+	@Override
+	public void setPosition( final long position, final int d )
+	{
+		source.setPosition( position, d );
+		sourceB.setPosition( position, d );
+	}
+
+	@Override
+	public void move( final float distance, final int d )
+	{
+		source.move( distance, d );
+		sourceB.move( distance, d );
+	}
+
+	@Override
+	public void move( final double distance, final int d )
+	{
+		source.move( distance, d );
+		sourceB.move( distance, d );
+	}
+
+	@Override
+	public void move( final RealLocalizable localizable )
+	{
+		source.move( localizable );
+		sourceB.move( localizable );
+	}
+
+	@Override
+	public void move( final float[] distance )
+	{
+		source.move( distance );
+		sourceB.move( distance );
+	}
+
+	@Override
+	public void move( final double[] distance )
+	{
+		source.move( distance );
+		sourceB.move( distance );
+	}
+
+	@Override
+	public void setPosition( final RealLocalizable localizable )
+	{
+		source.setPosition( localizable );
+		sourceB.setPosition( localizable );
+	}
+
+	@Override
+	public void setPosition( final float[] position )
+	{
+		source.setPosition( position );
+		sourceB.setPosition( position );
+	}
+
+	@Override
+	public void setPosition( final double[] position )
+	{
+		source.setPosition( position );
+		sourceB.setPosition( position );
+	}
+
+	@Override
+	public void setPosition( final float position, final int d )
+	{
+		source.setPosition( position, d );
+		sourceB.setPosition( position, d );
+	}
+
+	@Override
+	public void setPosition( final double position, final int d )
+	{
+		source.setPosition( position, d );
+		sourceB.setPosition( position, d );
+	}
+
+	@Override
+	public BiConvertedRealRandomAccess< A, B, C > copy()
+	{
+		return new BiConvertedRealRandomAccess<>(
+				source.copyRealRandomAccess(),
+				sourceB.copyRealRandomAccess(),
+				converter,
+				converted );
+	}
+}

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessible.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.RealInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.converter.AbstractConvertedRealRandomAccessible;
@@ -48,9 +50,21 @@ public class BiConvertedRealRandomAccessible< A, B, C extends Type< C > > extend
 {
 	protected final RealRandomAccessible< B > sourceB;
 
-	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+	protected final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier;
 
 	final protected C converted;
+
+	public BiConvertedRealRandomAccessible(
+			final RealRandomAccessible< A > sourceA,
+			final RealRandomAccessible< B > sourceB,
+			final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceB = sourceB;
+		this.converterSupplier = converterSupplier;
+		this.converted = c.copy();
+	}
 
 	public BiConvertedRealRandomAccessible(
 			final RealRandomAccessible< A > sourceA,
@@ -58,10 +72,7 @@ public class BiConvertedRealRandomAccessible< A, B, C extends Type< C > > extend
 			final BiConverter< ? super A, ? super B, ? super C > converter,
 			final C c )
 	{
-		super( sourceA );
-		this.sourceB = sourceB;
-		this.converter = converter;
-		this.converted = c.copy();
+		this( sourceA, sourceB, () -> converter, c );
 	}
 
 	@Override
@@ -70,7 +81,7 @@ public class BiConvertedRealRandomAccessible< A, B, C extends Type< C > > extend
 		return new BiConvertedRealRandomAccess<>(
 				source.realRandomAccess(),
 				sourceB.realRandomAccess(),
-				converter,
+				converterSupplier,
 				converted );
 	}
 
@@ -80,7 +91,7 @@ public class BiConvertedRealRandomAccessible< A, B, C extends Type< C > > extend
 		return new BiConvertedRealRandomAccess<>(
 				source.realRandomAccess( interval ),
 				sourceB.realRandomAccess( interval ),
-				converter,
+				converterSupplier,
 				converted );
 	}
 
@@ -92,8 +103,16 @@ public class BiConvertedRealRandomAccessible< A, B, C extends Type< C > > extend
 		return converted.copy();
 	}
 
+	/**
+	 * Returns an instance of the {@link BiConverter}.  If the
+	 * {@link BiConvertedIterableInterval} was created with a
+	 * {@link BiConverter} instead of a {@link Supplier}, then the returned
+	 * {@link BiConverter} will be this instance.
+	 *
+	 * @return
+	 */
 	public BiConverter< ? super A, ? super B, ? super C > getConverter()
 	{
-		return converter;
+		return converterSupplier.get();
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessible.java
@@ -32,19 +32,68 @@
  * #L%
  */
 
-package net.imglib2.converter;
+package net.imglib2.converter.read;
 
-import java.util.function.BiConsumer;
+import net.imglib2.RealInterval;
+import net.imglib2.RealRandomAccessible;
+import net.imglib2.converter.AbstractConvertedRealRandomAccessible;
+import net.imglib2.converter.BiConverter;
+import net.imglib2.type.Type;
 
 /**
- * This interface is equivalent to the {@link BiConsumer} interface and exists
- * for historical reasons only.  Its main use is for functions with one input
- * variable and one pre-allocated output on individual pixels.
+ * TODO
  *
- * @author Stephan Preibisch
- * @author Stephan Saalfeld
  */
-public interface Converter< A, B >
+public class BiConvertedRealRandomAccessible< A, B, C extends Type< C > > extends AbstractConvertedRealRandomAccessible< A, C >
 {
-	public void convert( A input, B output );
+	protected final RealRandomAccessible< B > sourceB;
+
+	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+
+	final protected C converted;
+
+	public BiConvertedRealRandomAccessible(
+			final RealRandomAccessible< A > sourceA,
+			final RealRandomAccessible< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceB = sourceB;
+		this.converter = converter;
+		this.converted = c.copy();
+	}
+
+	@Override
+	public BiConvertedRealRandomAccess< A, B, C > realRandomAccess()
+	{
+		return new BiConvertedRealRandomAccess<>(
+				source.realRandomAccess(),
+				sourceB.realRandomAccess(),
+				converter,
+				converted );
+	}
+
+	@Override
+	public BiConvertedRealRandomAccess< A, B, C > realRandomAccess( final RealInterval interval )
+	{
+		return new BiConvertedRealRandomAccess<>(
+				source.realRandomAccess( interval ),
+				sourceB.realRandomAccess( interval ),
+				converter,
+				converted );
+	}
+
+	/**
+	 * @return an instance of the destination {@link Type}.
+	 */
+	public C getDestinationType()
+	{
+		return converted.copy();
+	}
+
+	public BiConverter< ? super A, ? super B, ? super C > getConverter()
+	{
+		return converter;
+	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessibleRealInterval.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.AbstractWrappedRealInterval;
 import net.imglib2.RealInterval;
 import net.imglib2.RealRandomAccessibleRealInterval;
@@ -49,9 +51,21 @@ public class BiConvertedRealRandomAccessibleRealInterval< A, B, C extends Type< 
 {
 	protected final RealRandomAccessibleRealInterval< B > sourceIntervalB;
 
-	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+	protected final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier;
 
 	protected final C converted;
+
+	public BiConvertedRealRandomAccessibleRealInterval(
+			final RealRandomAccessibleRealInterval< A > sourceA,
+			final RealRandomAccessibleRealInterval< B > sourceB,
+			final Supplier< BiConverter< ? super A, ? super B, ? super C > > converterSupplier,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceIntervalB = sourceB;
+		this.converterSupplier = converterSupplier;
+		this.converted = c.copy();
+	}
 
 	public BiConvertedRealRandomAccessibleRealInterval(
 			final RealRandomAccessibleRealInterval< A > sourceA,
@@ -59,10 +73,7 @@ public class BiConvertedRealRandomAccessibleRealInterval< A, B, C extends Type< 
 			final BiConverter< ? super A, ? super B, ? super C > converter,
 			final C c )
 	{
-		super( sourceA );
-		this.sourceIntervalB = sourceB;
-		this.converter = converter;
-		this.converted = c.copy();
+		this( sourceA, sourceB, () -> converter, c );
 	}
 
 	@Override
@@ -71,7 +82,7 @@ public class BiConvertedRealRandomAccessibleRealInterval< A, B, C extends Type< 
 		return new BiConvertedRealRandomAccess<>(
 				sourceInterval.realRandomAccess(),
 				sourceIntervalB.realRandomAccess(),
-				converter,
+				converterSupplier,
 				converted );
 	}
 
@@ -81,7 +92,7 @@ public class BiConvertedRealRandomAccessibleRealInterval< A, B, C extends Type< 
 		return new BiConvertedRealRandomAccess<>(
 				sourceInterval.realRandomAccess( interval ),
 				sourceIntervalB.realRandomAccess( interval ),
-				converter,
+				converterSupplier,
 				converted );
 	}
 
@@ -93,8 +104,16 @@ public class BiConvertedRealRandomAccessibleRealInterval< A, B, C extends Type< 
 		return converted.copy();
 	}
 
+	/**
+	 * Returns an instance of the {@link BiConverter}.  If the
+	 * {@link BiConvertedIterableInterval} was created with a
+	 * {@link BiConverter} instead of a {@link Supplier}, then the returned
+	 * {@link BiConverter} will be this instance.
+	 *
+	 * @return
+	 */
 	public BiConverter< ? super A, ? super B, ? super C > getConverter()
 	{
-		return converter;
+		return converterSupplier.get();
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessibleRealInterval.java
@@ -32,19 +32,69 @@
  * #L%
  */
 
-package net.imglib2.converter;
+package net.imglib2.converter.read;
 
-import java.util.function.BiConsumer;
+import net.imglib2.AbstractWrappedRealInterval;
+import net.imglib2.RealInterval;
+import net.imglib2.RealRandomAccessibleRealInterval;
+import net.imglib2.View;
+import net.imglib2.converter.BiConverter;
+import net.imglib2.type.Type;
 
 /**
- * This interface is equivalent to the {@link BiConsumer} interface and exists
- * for historical reasons only.  Its main use is for functions with one input
- * variable and one pre-allocated output on individual pixels.
+ * TODO
  *
- * @author Stephan Preibisch
- * @author Stephan Saalfeld
  */
-public interface Converter< A, B >
+public class BiConvertedRealRandomAccessibleRealInterval< A, B, C extends Type< C > > extends AbstractWrappedRealInterval< RealRandomAccessibleRealInterval< A > > implements RealRandomAccessibleRealInterval< C >, View
 {
-	public void convert( A input, B output );
+	protected final RealRandomAccessibleRealInterval< B > sourceIntervalB;
+
+	protected final BiConverter< ? super A, ? super B, ? super C > converter;
+
+	protected final C converted;
+
+	public BiConvertedRealRandomAccessibleRealInterval(
+			final RealRandomAccessibleRealInterval< A > sourceA,
+			final RealRandomAccessibleRealInterval< B > sourceB,
+			final BiConverter< ? super A, ? super B, ? super C > converter,
+			final C c )
+	{
+		super( sourceA );
+		this.sourceIntervalB = sourceB;
+		this.converter = converter;
+		this.converted = c.copy();
+	}
+
+	@Override
+	public BiConvertedRealRandomAccess< A, B, C > realRandomAccess()
+	{
+		return new BiConvertedRealRandomAccess<>(
+				sourceInterval.realRandomAccess(),
+				sourceIntervalB.realRandomAccess(),
+				converter,
+				converted );
+	}
+
+	@Override
+	public BiConvertedRealRandomAccess< A, B, C > realRandomAccess( final RealInterval interval )
+	{
+		return new BiConvertedRealRandomAccess<>(
+				sourceInterval.realRandomAccess( interval ),
+				sourceIntervalB.realRandomAccess( interval ),
+				converter,
+				converted );
+	}
+
+	/**
+	 * @return an instance of the destination {@link Type}.
+	 */
+	public C getDestinationType()
+	{
+		return converted.copy();
+	}
+
+	public BiConverter< ? super A, ? super B, ? super C > getConverter()
+	{
+		return converter;
+	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedCursor.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedCursor.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Cursor;
 import net.imglib2.converter.AbstractConvertedCursor;
 import net.imglib2.converter.Converter;
@@ -41,27 +43,49 @@ import net.imglib2.type.Type;
 
 /**
  * TODO
- * 
+ *
  */
 public class ConvertedCursor< A, B extends Type< B > > extends AbstractConvertedCursor< A, B >
 {
 	final protected Converter< ? super A, ? super B > converter;
+
+	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
 	final protected B converted;
 
 	/**
 	 * Creates a copy of b for conversion that can be accessed through
 	 * {@link #get()}.
-	 * 
+	 *
+	 * @param source
+	 * @param converterSupplier
+	 * @param b
+	 */
+	public ConvertedCursor(
+			final Cursor< A > source,
+			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
+			final B b )
+	{
+		super( source );
+		this.converterSupplier = converterSupplier;
+		this.converter = converterSupplier.get();
+		this.converted = b.copy();
+	}
+
+	/**
+	 * Creates a copy of b for conversion that can be accessed through
+	 * {@link #get()}.
+	 *
 	 * @param source
 	 * @param converter
 	 * @param b
 	 */
-	public ConvertedCursor( final Cursor< A > source, final Converter< ? super A, ? super B > converter, final B b )
+	public ConvertedCursor(
+			final Cursor< A > source,
+			final Converter< ? super A, ? super B > converter,
+			final B b )
 	{
-		super( source );
-		this.converter = converter;
-		this.converted = b.copy();
+		this( source, () -> converter, b );
 	}
 
 	@Override
@@ -74,6 +98,6 @@ public class ConvertedCursor< A, B extends Type< B > > extends AbstractConverted
 	@Override
 	public ConvertedCursor< A, B > copy()
 	{
-		return new ConvertedCursor< A, B >( ( Cursor< A > ) source.copy(), converter, converted );
+		return new ConvertedCursor< A, B >( ( Cursor< A > ) source.copy(), converterSupplier, converted );
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.IterableInterval;
 import net.imglib2.converter.AbstractConvertedIterableInterval;
 import net.imglib2.converter.Converter;
@@ -45,9 +47,26 @@ import net.imglib2.type.Type;
  */
 public class ConvertedIterableInterval< A, B extends Type< B > > extends AbstractConvertedIterableInterval< A, B >
 {
-	final protected Converter< ? super A, ? super B > converter;
+	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
 	final protected B converted;
+
+	/**
+	 * Creates a copy of b for conversion.
+	 *
+	 * @param source
+	 * @param converterSupplier
+	 * @param b
+	 */
+	public ConvertedIterableInterval(
+			final IterableInterval< A > source,
+			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
+			final B b )
+	{
+		super( source );
+		this.converterSupplier = converterSupplier;
+		this.converted = b.copy();
+	}
 
 	/**
 	 * Creates a copy of b for conversion.
@@ -56,23 +75,24 @@ public class ConvertedIterableInterval< A, B extends Type< B > > extends Abstrac
 	 * @param converter
 	 * @param b
 	 */
-	public ConvertedIterableInterval( final IterableInterval< A > source, final Converter< ? super A, ? super B > converter, final B b )
+	public ConvertedIterableInterval(
+			final IterableInterval< A > source,
+			final Converter< ? super A, ? super B > converter,
+			final B b )
 	{
-		super( source );
-		this.converter = converter;
-		this.converted = b.copy();
+		this( source, () -> converter, b );
 	}
 
 	@Override
 	public ConvertedCursor< A, B > cursor()
 	{
-		return new ConvertedCursor< A, B >( sourceInterval.cursor(), converter, converted );
+		return new ConvertedCursor< A, B >( sourceInterval.cursor(), converterSupplier, converted );
 	}
 
 	@Override
 	public ConvertedCursor< A, B > localizingCursor()
 	{
-		return new ConvertedCursor< A, B >( sourceInterval.localizingCursor(), converter, converted );
+		return new ConvertedCursor< A, B >( sourceInterval.localizingCursor(), converterSupplier, converted );
 	}
 
 	/**
@@ -83,8 +103,16 @@ public class ConvertedIterableInterval< A, B extends Type< B > > extends Abstrac
 		return converted.copy();
 	}
 
+	/**
+	 * Returns an instance of the {@link Converter}.  If the
+	 * {@link ConvertedIterableInterval} was created with a {@link Converter}
+	 * instead of a {@link Supplier}, then the returned converter will be this
+	 * instance.
+	 *
+	 * @return
+	 */
 	public Converter< ? super A, ? super B > getConverter()
 	{
-		return converter;
+		return converterSupplier.get();
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccess.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.RandomAccess;
 import net.imglib2.converter.AbstractConvertedRandomAccess;
 import net.imglib2.converter.Converter;
@@ -41,19 +43,47 @@ import net.imglib2.type.Type;
 
 /**
  * TODO
- * 
+ *
  */
 final public class ConvertedRandomAccess< A, B extends Type< B > > extends AbstractConvertedRandomAccess< A, B >
 {
+	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
+
 	final protected Converter< ? super A, ? super B > converter;
 
 	final protected B converted;
 
-	public ConvertedRandomAccess( final RandomAccess< A > source, final Converter< ? super A, ? super B > converter, final B b )
+	/**
+	 * Creates a copy of b for conversion that can be accessed through
+	 * {@link #get()}.
+	 *
+	 * @param source
+	 * @param converterSupplier
+	 * @param b
+	 */
+	public ConvertedRandomAccess(
+			final RandomAccess< A > source,
+			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
+			final B b )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+		this.converter = converterSupplier.get();
 		this.converted = b.copy();
+	}
+
+	/**
+	 * Use this constructor for stateless functions
+	 * @param source
+	 * @param converter
+	 * @param b
+	 */
+	public ConvertedRandomAccess(
+			final RandomAccess< A > source,
+			final Converter< ? super A, ? super B > converter,
+			final B b )
+	{
+		this( source, () -> converter, b );
 	}
 
 	@Override
@@ -66,6 +96,6 @@ final public class ConvertedRandomAccess< A, B extends Type< B > > extends Abstr
 	@Override
 	public ConvertedRandomAccess< A, B > copy()
 	{
-		return new ConvertedRandomAccess< A, B >( source.copyRandomAccess(), converter, converted );
+		return new ConvertedRandomAccess< A, B >( source.copyRandomAccess(), converterSupplier, converted );
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.converter.AbstractConvertedRandomAccessible;
@@ -42,31 +44,42 @@ import net.imglib2.type.Type;
 
 /**
  * TODO
- * 
+ *
  */
 public class ConvertedRandomAccessible< A, B extends Type< B > > extends AbstractConvertedRandomAccessible< A, B >
 {
-	final protected Converter< ? super A, ? super B > converter;
+	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
 	final protected B converted;
 
-	public ConvertedRandomAccessible( final RandomAccessible< A > source, final Converter< ? super A, ? super B > converter, final B b )
+	public ConvertedRandomAccessible(
+			final RandomAccessible< A > source,
+			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
+			final B b )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
 		this.converted = b.copy();
+	}
+
+	public ConvertedRandomAccessible(
+			final RandomAccessible< A > source,
+			final Converter< ? super A, ? super B > converter,
+			final B b )
+	{
+		this( source, () -> converter, b );
 	}
 
 	@Override
 	public ConvertedRandomAccess< A, B > randomAccess()
 	{
-		return new ConvertedRandomAccess< A, B >( source.randomAccess(), converter, converted );
+		return new ConvertedRandomAccess< A, B >( source.randomAccess(), converterSupplier, converted );
 	}
 
 	@Override
 	public ConvertedRandomAccess< A, B > randomAccess( final Interval interval )
 	{
-		return new ConvertedRandomAccess< A, B >( source.randomAccess( interval ), converter, converted );
+		return new ConvertedRandomAccess< A, B >( source.randomAccess( interval ), converterSupplier, converted );
 	}
 
 	/**
@@ -77,8 +90,16 @@ public class ConvertedRandomAccessible< A, B extends Type< B > > extends Abstrac
 		return converted.copy();
 	}
 
+	/**
+	 * Returns an instance of the {@link Converter}.  If the
+	 * {@link ConvertedIterableInterval} was created with a {@link Converter}
+	 * instead of a {@link Supplier}, then the returned converter will be this
+	 * instance.
+	 *
+	 * @return
+	 */
 	public Converter< ? super A, ? super B > getConverter()
 	{
-		return converter;
+		return converterSupplier.get();
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.AbstractWrappedInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
@@ -43,31 +45,42 @@ import net.imglib2.type.Type;
 
 /**
  * TODO
- * 
+ *
  */
 public class ConvertedRandomAccessibleInterval< A, B extends Type< B > > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >, View
 {
-	final protected Converter< ? super A, ? super B > converter;
+	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
 	final protected B converted;
 
-	public ConvertedRandomAccessibleInterval( final RandomAccessibleInterval< A > source, final Converter< ? super A, ? super B > converter, final B b )
+	public ConvertedRandomAccessibleInterval(
+			final RandomAccessibleInterval< A > source,
+			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
+			final B b )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
 		this.converted = b.copy();
+	}
+
+	public ConvertedRandomAccessibleInterval(
+			final RandomAccessibleInterval< A > source,
+			final Converter< ? super A, ? super B > converter,
+			final B b )
+	{
+		this( source, () -> converter, b );
 	}
 
 	@Override
 	public ConvertedRandomAccess< A, B > randomAccess()
 	{
-		return new ConvertedRandomAccess< A, B >( sourceInterval.randomAccess(), converter, converted );
+		return new ConvertedRandomAccess< A, B >( sourceInterval.randomAccess(), converterSupplier, converted );
 	}
 
 	@Override
 	public ConvertedRandomAccess< A, B > randomAccess( final Interval interval )
 	{
-		return new ConvertedRandomAccess< A, B >( sourceInterval.randomAccess( interval ), converter, converted );
+		return new ConvertedRandomAccess< A, B >( sourceInterval.randomAccess( interval ), converterSupplier, converted );
 	}
 
 	/**
@@ -78,8 +91,16 @@ public class ConvertedRandomAccessibleInterval< A, B extends Type< B > > extends
 		return converted.copy();
 	}
 
+	/**
+	 * Returns an instance of the {@link Converter}.  If the
+	 * {@link ConvertedIterableInterval} was created with a {@link Converter}
+	 * instead of a {@link Supplier}, then the returned converter will be this
+	 * instance.
+	 *
+	 * @return
+	 */
 	public Converter< ? super A, ? super B > getConverter()
 	{
-		return converter;
+		return converterSupplier.get();
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccess.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.RealRandomAccess;
 import net.imglib2.converter.AbstractConvertedRealRandomAccess;
 import net.imglib2.converter.Converter;
@@ -41,19 +43,41 @@ import net.imglib2.type.Type;
 
 /**
  * TODO
- * 
+ *
  */
 final public class ConvertedRealRandomAccess< A, B extends Type< B > > extends AbstractConvertedRealRandomAccess< A, B >
 {
+	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
+
 	final protected Converter< ? super A, ? super B > converter;
 
 	final protected B converted;
 
-	public ConvertedRealRandomAccess( final RealRandomAccess< A > source, final Converter< ? super A, ? super B > converter, final B b )
+	/**
+	 * Creates a copy of b for conversion that can be accessed through
+	 * {@link #get()}.
+	 *
+	 * @param source
+	 * @param converterSupplier
+	 * @param b
+	 */
+	public ConvertedRealRandomAccess(
+			final RealRandomAccess< A > source,
+			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
+			final B b )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+		this.converter = converterSupplier.get();
 		this.converted = b.copy();
+	}
+
+	public ConvertedRealRandomAccess(
+			final RealRandomAccess< A > source,
+			final Converter< ? super A, ? super B > converter,
+			final B b )
+	{
+		this( source, () -> converter, b );
 	}
 
 	@Override
@@ -66,6 +90,6 @@ final public class ConvertedRealRandomAccess< A, B extends Type< B > > extends A
 	@Override
 	public ConvertedRealRandomAccess< A, B > copy()
 	{
-		return new ConvertedRealRandomAccess< A, B >( source.copyRealRandomAccess(), converter, converted );
+		return new ConvertedRealRandomAccess< A, B >( source.copyRealRandomAccess(), converterSupplier, converted );
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccessible.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.RealInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.converter.AbstractConvertedRealRandomAccessible;
@@ -42,31 +44,42 @@ import net.imglib2.type.Type;
 
 /**
  * TODO
- * 
+ *
  */
 public class ConvertedRealRandomAccessible< A, B extends Type< B > > extends AbstractConvertedRealRandomAccessible< A, B >
 {
-	final protected Converter< ? super A, ? super B > converter;
+	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
 	final protected B converted;
 
-	public ConvertedRealRandomAccessible( final RealRandomAccessible< A > source, final Converter< ? super A, ? super B > converter, final B b )
+	public ConvertedRealRandomAccessible(
+			final RealRandomAccessible< A > source,
+			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
+			final B b )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
 		this.converted = b.copy();
+	}
+
+	public ConvertedRealRandomAccessible(
+			final RealRandomAccessible< A > source,
+			final Converter< ? super A, ? super B > converter,
+			final B b )
+	{
+		this( source, () -> converter, b );
 	}
 
 	@Override
 	public ConvertedRealRandomAccess< A, B > realRandomAccess()
 	{
-		return new ConvertedRealRandomAccess< A, B >( source.realRandomAccess(), converter, converted );
+		return new ConvertedRealRandomAccess< A, B >( source.realRandomAccess(), converterSupplier, converted );
 	}
 
 	@Override
 	public ConvertedRealRandomAccess< A, B > realRandomAccess( final RealInterval interval )
 	{
-		return new ConvertedRealRandomAccess< A, B >( source.realRandomAccess( interval ), converter, converted );
+		return new ConvertedRealRandomAccess< A, B >( source.realRandomAccess( interval ), converterSupplier, converted );
 	}
 
 	/**
@@ -77,8 +90,16 @@ public class ConvertedRealRandomAccessible< A, B extends Type< B > > extends Abs
 		return converted.copy();
 	}
 
+	/**
+	 * Returns an instance of the {@link Converter}.  If the
+	 * {@link ConvertedIterableInterval} was created with a {@link Converter}
+	 * instead of a {@link Supplier}, then the returned converter will be this
+	 * instance.
+	 *
+	 * @return
+	 */
 	public Converter< ? super A, ? super B > getConverter()
 	{
-		return converter;
+		return converterSupplier.get();
 	}
 }

--- a/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccessibleRealInterval.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.read;
 
+import java.util.function.Supplier;
+
 import net.imglib2.AbstractWrappedRealInterval;
 import net.imglib2.RealInterval;
 import net.imglib2.RealRandomAccessibleRealInterval;
@@ -43,31 +45,42 @@ import net.imglib2.type.Type;
 
 /**
  * TODO
- * 
+ *
  */
 public class ConvertedRealRandomAccessibleRealInterval< A, B extends Type< B > > extends AbstractWrappedRealInterval< RealRandomAccessibleRealInterval< A > > implements RealRandomAccessibleRealInterval< B >, View
 {
-	final protected Converter< ? super A, ? super B > converter;
+	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
 	final protected B converted;
 
-	public ConvertedRealRandomAccessibleRealInterval( final RealRandomAccessibleRealInterval< A > source, final Converter< ? super A, ? super B > converter, final B b )
+	public ConvertedRealRandomAccessibleRealInterval(
+			final RealRandomAccessibleRealInterval< A > source,
+			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
+			final B b )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
 		this.converted = b.copy();
+	}
+
+	public ConvertedRealRandomAccessibleRealInterval(
+			final RealRandomAccessibleRealInterval< A > source,
+			final Converter< ? super A, ? super B > converter,
+			final B b )
+	{
+		this( source, () -> converter, b );
 	}
 
 	@Override
 	public ConvertedRealRandomAccess< A, B > realRandomAccess()
 	{
-		return new ConvertedRealRandomAccess< A, B >( sourceInterval.realRandomAccess(), converter, converted );
+		return new ConvertedRealRandomAccess< A, B >( sourceInterval.realRandomAccess(), converterSupplier, converted );
 	}
 
 	@Override
 	public ConvertedRealRandomAccess< A, B > realRandomAccess( final RealInterval interval )
 	{
-		return new ConvertedRealRandomAccess< A, B >( sourceInterval.realRandomAccess( interval ), converter, converted );
+		return new ConvertedRealRandomAccess< A, B >( sourceInterval.realRandomAccess( interval ), converterSupplier, converted );
 	}
 
 	/**
@@ -78,8 +91,16 @@ public class ConvertedRealRandomAccessibleRealInterval< A, B extends Type< B > >
 		return converted.copy();
 	}
 
+	/**
+	 * Returns an instance of the {@link Converter}.  If the
+	 * {@link ConvertedIterableInterval} was created with a {@link Converter}
+	 * instead of a {@link Supplier}, then the returned converter will be this
+	 * instance.
+	 *
+	 * @return
+	 */
 	public Converter< ? super A, ? super B > getConverter()
 	{
-		return converter;
+		return converterSupplier.get();
 	}
 }

--- a/src/main/java/net/imglib2/converter/readwrite/WriteConvertedCursor.java
+++ b/src/main/java/net/imglib2/converter/readwrite/WriteConvertedCursor.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,24 +34,38 @@
 
 package net.imglib2.converter.readwrite;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Cursor;
 import net.imglib2.converter.AbstractConvertedCursor;
 
 /**
  * TODO
- * 
+ *
  */
 public class WriteConvertedCursor< A, B > extends AbstractConvertedCursor< A, B >
 {
+	private final Supplier< SamplerConverter< ? super A, B > > converterSupplier;
+
 	private final SamplerConverter< ? super A, B > converter;
 
 	private final B converted;
 
-	public WriteConvertedCursor( final Cursor< A > source, final SamplerConverter< ? super A, B > converter )
+	public WriteConvertedCursor(
+			final Cursor< A > source,
+			final Supplier< SamplerConverter< ? super A, B > > converterSupplier )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+		this.converter = converterSupplier.get();
 		this.converted = converter.convert( source );
+	}
+
+	public WriteConvertedCursor(
+			final Cursor< A > source,
+			final SamplerConverter< ? super A, B > converter )
+	{
+		this( source, () -> converter );
 	}
 
 	@Override
@@ -63,6 +77,6 @@ public class WriteConvertedCursor< A, B > extends AbstractConvertedCursor< A, B 
 	@Override
 	public WriteConvertedCursor< A, B > copy()
 	{
-		return new WriteConvertedCursor< A, B >( ( Cursor< A > ) source.copy(), converter );
+		return new WriteConvertedCursor< A, B >( ( Cursor< A > ) source.copy(), converterSupplier );
 	}
 }

--- a/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableInterval.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,32 +34,41 @@
 
 package net.imglib2.converter.readwrite;
 
+import java.util.function.Supplier;
+
 import net.imglib2.IterableInterval;
 import net.imglib2.converter.AbstractConvertedIterableInterval;
 
 /**
  * TODO
- * 
+ *
  */
 public class WriteConvertedIterableInterval< A, B > extends AbstractConvertedIterableInterval< A, B >
 {
-	private final SamplerConverter< ? super A, B > converter;
+	private final Supplier< SamplerConverter< ? super A, B > > converterSupplier;
+
+	public WriteConvertedIterableInterval(
+			final IterableInterval< A > source,
+			final Supplier< SamplerConverter< ? super A, B > > converterSupplier )
+	{
+		super( source );
+		this.converterSupplier = converterSupplier;
+	}
 
 	public WriteConvertedIterableInterval( final IterableInterval< A > source, final SamplerConverter< ? super A, B > converter )
 	{
-		super( source );
-		this.converter = converter;
+		this( source, () -> converter );
 	}
 
 	@Override
 	public WriteConvertedCursor< A, B > cursor()
 	{
-		return new WriteConvertedCursor< A, B >( sourceInterval.cursor(), converter );
+		return new WriteConvertedCursor< A, B >( sourceInterval.cursor(), converterSupplier );
 	}
 
 	@Override
 	public WriteConvertedCursor< A, B > localizingCursor()
 	{
-		return new WriteConvertedCursor< A, B >( sourceInterval.localizingCursor(), converter );
+		return new WriteConvertedCursor< A, B >( sourceInterval.localizingCursor(), converterSupplier );
 	}
 }

--- a/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableRandomAccessibleInterval.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,8 @@
 
 package net.imglib2.converter.readwrite;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessible;
@@ -41,39 +43,48 @@ import net.imglib2.converter.AbstractConvertedIterableRandomAccessibleInterval;
 
 /**
  * TODO
- * 
+ *
  */
 public class WriteConvertedIterableRandomAccessibleInterval< A, B, S extends RandomAccessible< A > & IterableInterval< A > > extends AbstractConvertedIterableRandomAccessibleInterval< A, B, S >
 {
-	private final SamplerConverter< ? super A, B > converter;
+	private final Supplier< SamplerConverter< ? super A, B > > converterSupplier;
 
-	public WriteConvertedIterableRandomAccessibleInterval( final S source, final SamplerConverter< ? super A, B > converter )
+	public WriteConvertedIterableRandomAccessibleInterval(
+			final S source,
+			final Supplier< SamplerConverter< ? super A, B > > converterSupplier )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+	}
+
+	public WriteConvertedIterableRandomAccessibleInterval(
+			final S source,
+			final SamplerConverter< ? super A, B > converter )
+	{
+		this( source, () -> converter );
 	}
 
 	@Override
 	public WriteConvertedRandomAccess< A, B > randomAccess()
 	{
-		return new WriteConvertedRandomAccess< A, B >( sourceInterval.randomAccess(), converter );
+		return new WriteConvertedRandomAccess< A, B >( sourceInterval.randomAccess(), converterSupplier );
 	}
 
 	@Override
 	public WriteConvertedRandomAccess< A, B > randomAccess( final Interval interval )
 	{
-		return new WriteConvertedRandomAccess< A, B >( sourceInterval.randomAccess( interval ), converter );
+		return new WriteConvertedRandomAccess< A, B >( sourceInterval.randomAccess( interval ), converterSupplier );
 	}
 
 	@Override
 	public WriteConvertedCursor< A, B > cursor()
 	{
-		return new WriteConvertedCursor< A, B >( sourceInterval.cursor(), converter );
+		return new WriteConvertedCursor< A, B >( sourceInterval.cursor(), converterSupplier );
 	}
 
 	@Override
 	public WriteConvertedCursor< A, B > localizingCursor()
 	{
-		return new WriteConvertedCursor< A, B >( sourceInterval.localizingCursor(), converter );
+		return new WriteConvertedCursor< A, B >( sourceInterval.localizingCursor(), converterSupplier );
 	}
 }

--- a/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccess.java
+++ b/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,24 +34,38 @@
 
 package net.imglib2.converter.readwrite;
 
+import java.util.function.Supplier;
+
 import net.imglib2.RandomAccess;
 import net.imglib2.converter.AbstractConvertedRandomAccess;
 
 /**
  * TODO
- * 
+ *
  */
 public final class WriteConvertedRandomAccess< A, B > extends AbstractConvertedRandomAccess< A, B >
 {
+	private final Supplier< SamplerConverter< ? super A, B > > converterSupplier;
+
 	private final SamplerConverter< ? super A, B > converter;
 
 	private final B converted;
 
-	public WriteConvertedRandomAccess( final RandomAccess< A > source, final SamplerConverter< ? super A, B > converter )
+	public WriteConvertedRandomAccess(
+			final RandomAccess< A > source,
+			final Supplier< SamplerConverter< ? super A, B > > converterSupplier )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+		this.converter = converterSupplier.get();
 		this.converted = converter.convert( source );
+	}
+
+	public WriteConvertedRandomAccess(
+			final RandomAccess< A > source,
+			final SamplerConverter< ? super A, B > converter )
+	{
+		this( source, () -> converter );
 	}
 
 	@Override
@@ -63,6 +77,6 @@ public final class WriteConvertedRandomAccess< A, B > extends AbstractConvertedR
 	@Override
 	public WriteConvertedRandomAccess< A, B > copy()
 	{
-		return new WriteConvertedRandomAccess< A, B >( ( RandomAccess< A > ) source.copy(), converter );
+		return new WriteConvertedRandomAccess< A, B >( ( RandomAccess< A > ) source.copy(), converterSupplier );
 	}
 }

--- a/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessible.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,33 +34,44 @@
 
 package net.imglib2.converter.readwrite;
 
+import java.util.function.Supplier;
+
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.converter.AbstractConvertedRandomAccessible;
 
 /**
  * TODO
- * 
+ *
  */
 public class WriteConvertedRandomAccessible< A, B > extends AbstractConvertedRandomAccessible< A, B >
 {
-	private final SamplerConverter< ? super A, B > converter;
+	private final Supplier< SamplerConverter< ? super A, B > > converterSupplier;
 
-	public WriteConvertedRandomAccessible( final RandomAccessible< A > source, final SamplerConverter< ? super A, B > converter )
+	public WriteConvertedRandomAccessible(
+			final RandomAccessible< A > source,
+			final Supplier< SamplerConverter< ? super A, B > > converterSupplier )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+	}
+
+	public WriteConvertedRandomAccessible(
+			final RandomAccessible< A > source,
+			final SamplerConverter< ? super A, B > converter )
+	{
+		this( source, () -> converter );
 	}
 
 	@Override
 	public WriteConvertedRandomAccess< A, B > randomAccess()
 	{
-		return new WriteConvertedRandomAccess< A, B >( source.randomAccess(), converter );
+		return new WriteConvertedRandomAccess< A, B >( source.randomAccess(), converterSupplier );
 	}
 
 	@Override
 	public WriteConvertedRandomAccess< A, B > randomAccess( final Interval interval )
 	{
-		return new WriteConvertedRandomAccess< A, B >( source.randomAccess( interval ), converter );
+		return new WriteConvertedRandomAccess< A, B >( source.randomAccess( interval ), converterSupplier );
 	}
 }

--- a/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessibleInterval.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,33 +34,44 @@
 
 package net.imglib2.converter.readwrite;
 
+import java.util.function.Supplier;
+
 import net.imglib2.AbstractWrappedInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 
 /**
  * TODO
- * 
+ *
  */
 public class WriteConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >
 {
-	private final SamplerConverter< ? super A, B > converter;
+	private final Supplier< SamplerConverter< ? super A, B > > converterSupplier;
 
-	public WriteConvertedRandomAccessibleInterval( final RandomAccessibleInterval< A > source, final SamplerConverter< ? super A, B > converter )
+	public WriteConvertedRandomAccessibleInterval(
+			final RandomAccessibleInterval< A > source,
+			final Supplier< SamplerConverter< ? super A, B > > converterSupplier )
 	{
 		super( source );
-		this.converter = converter;
+		this.converterSupplier = converterSupplier;
+	}
+
+	public WriteConvertedRandomAccessibleInterval(
+			final RandomAccessibleInterval< A > source,
+			final SamplerConverter< ? super A, B > converter )
+	{
+		this( source, () -> converter );
 	}
 
 	@Override
 	public WriteConvertedRandomAccess< A, B > randomAccess()
 	{
-		return new WriteConvertedRandomAccess< A, B >( sourceInterval.randomAccess(), converter );
+		return new WriteConvertedRandomAccess< A, B >( sourceInterval.randomAccess(), converterSupplier );
 	}
 
 	@Override
 	public WriteConvertedRandomAccess< A, B > randomAccess( final Interval interval )
 	{
-		return new WriteConvertedRandomAccess< A, B >( sourceInterval.randomAccess( interval ), converter );
+		return new WriteConvertedRandomAccess< A, B >( sourceInterval.randomAccess( interval ), converterSupplier );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/ARGBType.java
+++ b/src/main/java/net/imglib2/type/numeric/ARGBType.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/test/java/net/imglib2/converter/BiConvertersTest.java
+++ b/src/test/java/net/imglib2/converter/BiConvertersTest.java
@@ -1,0 +1,122 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.interpolation.randomaccess.NearestNeighborInterpolatorFactory;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.view.Views;
+
+/**
+ *
+ *
+ * @author Stephan Saalfeld
+ */
+public class BiConvertersTest
+{
+	final Random rnd = new Random();
+
+	final static byte[] testValues = new byte[ 20 * 30 * 4 ];
+	{
+		rnd.nextBytes( testValues );
+	}
+
+	final static int[] dataA = new int[ 20 * 30 ];
+
+	final static int[] dataB = new int[ 20 * 30 ];
+	{
+		for ( int i = 0; i < dataA.length; ++i )
+		{
+			dataA[ i ] = rnd.nextInt() / 2;
+			dataB[ i ] = rnd.nextInt() / 2;
+		}
+	}
+
+	@Test
+	public void testBiConverters()
+	{
+		final ArrayImg< IntType, ? > sourceA = ArrayImgs.ints( dataA, 20, 30 );
+		final ArrayImg< IntType, ? > sourceB = ArrayImgs.ints( dataB, 20, 30 );
+		final RandomAccessibleInterval< IntType > sumRAI = Converters.convertRAI(
+				sourceA,
+				sourceB,
+				( a, b, c ) -> c.set( a.get() + b.get() ),
+				new IntType() );
+		final IterableInterval< IntType > sumIterable = Converters.convert(
+				( IterableInterval< IntType > ) sourceA,
+				sourceB,
+				( a, b, c ) -> c.set( a.get() + b.get() ),
+				new IntType() );
+		final RandomAccessibleInterval< IntType > sumRA = Views.interval(
+				Converters.convert(
+						Views.extendBorder( sourceA ),
+						Views.extendBorder( sourceB ),
+						( a, b, c ) -> c.set( a.get() + b.get() ),
+						new IntType() ),
+				sourceA );
+		final RandomAccessibleInterval< IntType > sumRRA = Views.interval(
+				Views.raster(
+						Converters.convert(
+							Views.interpolate( Views.extendBorder( sourceA ), new NearestNeighborInterpolatorFactory<>() ),
+							Views.interpolate( Views.extendBorder( sourceB ), new NearestNeighborInterpolatorFactory<>() ),
+							( a, b, c ) -> c.set( a.get() + b.get() ),
+							new IntType() )),
+				sourceA );
+
+		final Cursor< IntType > sumCursorRAI = Views.iterable( sumRAI ).cursor();
+		final Cursor< IntType > sumCursorIterable = sumIterable.cursor();
+		final Cursor< IntType > sumCursorRA = Views.iterable( sumRA ).cursor();
+		final Cursor< IntType > sumCursorRRA = Views.iterable( sumRRA ).cursor();
+		int i = 0;
+		while ( sumCursorRAI.hasNext() )
+		{
+			assertEquals( sumCursorRAI.next().get(), dataA[ i ] + dataB[ i ] );
+			assertEquals( sumCursorIterable.next().get(), dataA[ i ] + dataB[ i ] );
+			assertEquals( sumCursorRA.next().get(), dataA[ i ] + dataB[ i ] );
+			assertEquals( sumCursorRRA.next().get(), dataA[ i ] + dataB[ i ] );
+			++i;
+		}
+	}
+}

--- a/src/test/java/net/imglib2/converter/ConvertersTest.java
+++ b/src/test/java/net/imglib2/converter/ConvertersTest.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,12 +36,12 @@ package net.imglib2.converter;
 
 import java.util.Random;
 
-import net.imglib2.img.Img;
 import org.junit.Assert;
 import org.junit.Test;
 
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.ARGBType;
@@ -126,8 +126,8 @@ public class ConvertersTest
 	@Test
 	public void testMergeARBGReading()
 	{
-		Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 3, 4 }, 4 );
-		RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.ARGB );
+		final Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 3, 4 }, 4 );
+		final RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.ARGB );
 		Assert.assertEquals( 0x01020304, argb.randomAccess().get().get() );
 	}
 
@@ -135,10 +135,10 @@ public class ConvertersTest
 	public void testMergeARBGWriting()
 	{
 		// setup
-		byte[] pixels = new byte[ 4 ];
-		Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( pixels, 4 );
+		final byte[] pixels = new byte[ 4 ];
+		final Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( pixels, 4 );
 		// process
-		RandomAccessibleInterval< ARGBType > arbg = Converters.mergeARGB( image, ColorChannelOrder.ARGB );
+		final RandomAccessibleInterval< ARGBType > arbg = Converters.mergeARGB( image, ColorChannelOrder.ARGB );
 		arbg.randomAccess().get().set( new ARGBType( 0x01020304 ) );
 		// test
 		Assert.assertArrayEquals( new byte[] { 1, 2, 3, 4 }, pixels );
@@ -147,8 +147,8 @@ public class ConvertersTest
 	@Test
 	public void testMergeRGBReading()
 	{
-		Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 3 }, 4 );
-		RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.RGB );
+		final Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 3 }, 4 );
+		final RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.RGB );
 		Assert.assertEquals( 0xff010203, argb.randomAccess().get().get() );
 	}
 
@@ -156,10 +156,10 @@ public class ConvertersTest
 	public void testMergbeRGBWriting()
 	{
 		// setup
-		byte[] pixels = new byte[ 3 ];
-		Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( pixels, 3 );
+		final byte[] pixels = new byte[ 3 ];
+		final Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( pixels, 3 );
 		// process
-		RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.RGB );
+		final RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.RGB );
 		// test
 		argb.randomAccess().get().set( new ARGBType( 0x00010203) );
 		Assert.assertArrayEquals( new byte[] { 1, 2, 3 }, pixels );


### PR DESCRIPTION
This branch implements simple two valued pixel algebra and type conversion similar to type conversion with converters.  There are multiple solutions to do this potentially more efficient in loops or for blocks in dedicated ops, but the pixel-wise lazy version was missing as far as I know.  This is the opposite of what one would like to do in interpreted scripts, it's a convenience layer for compiled languages for the JVM, particularly those that support lambdas.  Adding two double images/ iterables/ functions fa, and fb looks like:
```
sum = Converters.convert(fa, fb, (a, b, c) -> c.set(a.get() + b.get()), new DoubleType());
```