### PR TITLE
add methods and constructors taking Localizable and RealLocalizable

### DIFF
--- a/src/main/java/net/imglib2/AbstractInterval.java
+++ b/src/main/java/net/imglib2/AbstractInterval.java
@@ -111,6 +111,26 @@ public abstract class AbstractInterval extends AbstractEuclideanSpace implements
 	}
 
 	/**
+	 * Creates an Interval with the boundaries [min, max] (both including)
+	 * 
+	 * @param min
+	 *            - the position of the first elements in each dimension
+	 * @param max
+	 *            - the position of the last elements in each dimension
+	 */
+	public AbstractInterval( final Localizable min, final Localizable max )
+	{
+		this( min.numDimensions() );
+		assert min.numDimensions() == max.numDimensions();
+
+		for ( int d = 0; d < n; ++d )
+		{
+			this.min[ d ] = min.getLongPosition( d );
+			this.max[ d ] = max.getLongPosition( d );
+		}
+	}
+
+	/**
 	 * Creates an Interval with the boundaries [0, dimensions-1]
 	 * 
 	 * @param dimensions

--- a/src/main/java/net/imglib2/AbstractRealInterval.java
+++ b/src/main/java/net/imglib2/AbstractRealInterval.java
@@ -88,6 +88,24 @@ public class AbstractRealInterval extends AbstractEuclideanSpace implements Real
 		this.max = max.clone();
 	}
 
+	/**
+	 * Creates a new {@link AbstractRealInterval} from min and max coordinates
+	 * 
+	 * @param min
+	 * @param max
+	 */
+	public AbstractRealInterval( final RealLocalizable min, final RealLocalizable max )
+	{
+		this( min.numDimensions() );
+		assert min.numDimensions() == max.numDimensions();
+
+		for ( int d = 0; d < n; ++d )
+		{
+			this.min[ d ] = min.getDoublePosition( d );
+			this.max[ d ] = max.getDoublePosition( d );
+		}
+	}
+
 	@Override
 	public double realMin( final int d )
 	{

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -35,11 +35,12 @@
 package net.imglib2;
 
 import java.util.Arrays;
+
 import net.imglib2.exception.InvalidDimensionsException;
 
 /**
  * Defines an extent in <em>n</em>-dimensional discrete space.
- * 
+ *
  * @author Tobias Pietzsch
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
@@ -49,7 +50,7 @@ public interface Dimensions extends EuclideanSpace
 {
 	/**
 	 * Write the number of pixels in each dimension into long[].
-	 * 
+	 *
 	 * @param dimensions
 	 */
 	default void dimensions( final long[] dimensions )
@@ -61,26 +62,36 @@ public interface Dimensions extends EuclideanSpace
 
 	/**
 	 * Get the number of pixels in a given dimension <em>d</em>.
-	 * 
+	 *
 	 * @param d
 	 */
 	public long dimension( int d );
 
 	/**
 	 * Allocates a new long array with the dimensions of this object.
-	 * 
+	 *
+	 * Please note that his method allocates a new array each time which
+	 * introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #dimensions(long[])}.
+	 *
 	 * @return the dimensions
 	 */
 	default long[] dimensionsAsLongArray()
 	{
-		long[] dims = new long[ numDimensions() ];
+		final long[] dims = new long[ numDimensions() ];
 		dimensions( dims );
 		return dims;
 	}
 
 	/**
 	 * Allocates a new {@link Point} with the dimensions of this object.
-	 * 
+	 *
+	 * Please note that his method allocates a new {@link Point} each time
+	 * which introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #dimensions(long[])}.
+	 *
 	 * @return the dimensions
 	 */
 	default Point dimensionsAsPoint()

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -66,6 +66,28 @@ public interface Dimensions extends EuclideanSpace
 	 */
 	public long dimension( int d );
 
+	/**
+	 * Allocates a new long array with the dimensions of this object.
+	 * 
+	 * @return the dimensions
+	 */
+	default long[] dimensionsAsLongArray()
+	{
+		long[] dims = new long[ numDimensions() ];
+		dimensions( dims );
+		return dims;
+	}
+
+	/**
+	 * Allocates a new {@link Point} with the dimensions of this object.
+	 * 
+	 * @return the dimensions
+	 */
+	default Point dimensionsAsPoint()
+	{
+		return new Point( dimensionsAsLongArray() );
+	}
+
 	/*
 	 * -----------------------------------------------------------------------
 	 *

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -61,6 +61,18 @@ public interface Dimensions extends EuclideanSpace
 	}
 
 	/**
+	 * Write the number of pixels in each dimension into {@link Positionable}.
+	 *
+	 * @param dimensions
+	 */
+	default void dimensions( final Positionable dimensions )
+	{
+		final int n = numDimensions();
+		for ( int d = 0; d < n; d++ )
+			dimensions.setPosition( dimension( d ), d );
+	}
+
+	/**
 	 * Get the number of pixels in a given dimension <em>d</em>.
 	 *
 	 * @param d
@@ -89,8 +101,8 @@ public interface Dimensions extends EuclideanSpace
 	 *
 	 * Please note that his method allocates a new {@link Point} each time
 	 * which introduces notable overhead in both compute and memory.
-	 * If you query it frequently, you should allocate a dedicated array
-	 * first and reuse it with {@link #dimensions(long[])}.
+	 * If you query it frequently, you should allocate a dedicated
+	 * {@link Point} first and reuse it with {@link #dimensions(Positionable)}.
 	 *
 	 * @return the dimensions
 	 */

--- a/src/main/java/net/imglib2/FinalInterval.java
+++ b/src/main/java/net/imglib2/FinalInterval.java
@@ -84,6 +84,19 @@ public final class FinalInterval extends AbstractInterval
 	}
 
 	/**
+	 * Creates an Interval with the boundaries [min, max] (both including)
+	 * 
+	 * @param min
+	 *            the position of the first elements in each dimension
+	 * @param max
+	 *            the position of the last elements in each dimension
+	 */
+	public FinalInterval( final Localizable min, final Localizable max )
+	{
+		super( min, max );
+	}
+
+	/**
 	 * Creates an Interval with the boundaries [0, dimensions-1]
 	 * 
 	 * @param dimensions

--- a/src/main/java/net/imglib2/FinalRealInterval.java
+++ b/src/main/java/net/imglib2/FinalRealInterval.java
@@ -70,6 +70,17 @@ public final class FinalRealInterval extends AbstractRealInterval
 	}
 
 	/**
+	 * Creates a new {@link AbstractRealInterval} from min and max coordinates
+	 * 
+	 * @param min
+	 * @param max
+	 */
+	public FinalRealInterval( final RealLocalizable min, final RealLocalizable max )
+	{
+		super( min, max );
+	}
+
+	/**
 	 * THIS METHOD WILL BE REMOVED IN A FUTURE RELEASE. It was mistakenly
 	 * introduced, analogous to {@link FinalInterval#createMinSize(long...)} for
 	 * integer intervals. Dimension is not defined for {@link RealInterval} and

--- a/src/main/java/net/imglib2/Interval.java
+++ b/src/main/java/net/imglib2/Interval.java
@@ -191,26 +191,4 @@ public interface Interval extends RealInterval, Dimensions
 		return max;
 	}
 
-	/**
-	 * Allocates a new long array with the dimensions of this Interval.
-	 * 
-	 * @return the dimensions
-	 */
-	default long[] dimensionsAsLongArray()
-	{
-		long[] dims = new long[ numDimensions() ];
-		dimensions( dims );
-		return dims;
-	}
-
-	/**
-	 * Allocates a new {@link Point} with the dimensions of this Interval.
-	 * 
-	 * @return the dimensions
-	 */
-	default Point dimensionsAsPoint()
-	{
-		return new Point( dimensionsAsLongArray() );
-	}
-
 }

--- a/src/main/java/net/imglib2/Interval.java
+++ b/src/main/java/net/imglib2/Interval.java
@@ -165,8 +165,8 @@ public interface Interval extends RealInterval, Dimensions
 	 *
 	 * Please note that his method allocates a new {@link Point} each time
 	 * which introduces notable overhead in both compute and memory.
-	 * If you query it frequently, you should allocate a dedicated array
-	 * first and reuse it with {@link #min(long[])}.
+	 * If you query it frequently, you should allocate a dedicated
+	 * {@link Point} first and reuse it with {@link #min(Positionable)}.
 	 *
 	 * @return the min
 	 */
@@ -199,8 +199,8 @@ public interface Interval extends RealInterval, Dimensions
 	 *
 	 * Please note that his method allocates a new {@link Point} each time
 	 * which introduces notable overhead in both compute and memory.
-	 * If you query it frequently, you should allocate a dedicated array
-	 * first and reuse it with {@link #max(long[])}.
+	 * If you query it frequently, you should allocate a dedicated
+	 * {@link Point} first and reuse it with {@link #max(Positionable)}.
 	 *
 	 * @return the max
 	 */

--- a/src/main/java/net/imglib2/Interval.java
+++ b/src/main/java/net/imglib2/Interval.java
@@ -142,4 +142,75 @@ public interface Interval extends RealInterval, Dimensions
 	{
 		return max( d ) - min( d ) + 1;
 	}
+
+	/**
+	 * Allocates a new long array with the minimum of this Interval.
+	 * 
+	 * @return the min
+	 */
+	default long[] minAsLongArray()
+	{
+		long[] min = new long[ numDimensions() ];
+		min( min );
+		return min;
+	}
+
+	/**
+	 * Allocates a new {@link Point} with the maximum of this Interval.
+	 * 
+	 * @return the min
+	 */
+	default Point minAsPoint()
+	{
+		Point min = new Point( numDimensions() );
+		min( min );
+		return min;
+	}
+
+	/**
+	 * Allocates a new long array with the maximum of this Interval.
+	 * 
+	 * @return the max
+	 */
+	default long[] maxAsLongArray()
+	{
+		long[] max = new long[ numDimensions() ];
+		max( max );
+		return max;
+	}
+
+	/**
+	 * Allocates a new {@link Point} with the maximum of this Interval.
+	 * 
+	 * @return the max
+	 */
+	default Point maxAsPoint()
+	{
+		Point max = new Point( numDimensions() );
+		max( max );
+		return max;
+	}
+
+	/**
+	 * Allocates a new long array with the dimensions of this Interval.
+	 * 
+	 * @return the dimensions
+	 */
+	default long[] dimensionsAsLongArray()
+	{
+		long[] dims = new long[ numDimensions() ];
+		dimensions( dims );
+		return dims;
+	}
+
+	/**
+	 * Allocates a new {@link Point} with the dimensions of this Interval.
+	 * 
+	 * @return the dimensions
+	 */
+	default Point dimensionsAsPoint()
+	{
+		return new Point( dimensionsAsLongArray() );
+	}
+
 }

--- a/src/main/java/net/imglib2/Interval.java
+++ b/src/main/java/net/imglib2/Interval.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,7 +40,7 @@ package net.imglib2;
  * <em>x<sub>d</sub></em>&le;<em>max<sub>d</sub></em>;<em>d</em>&isin;{0&hellip;
  * <em>n</em>-1}}
  * </p>
- * 
+ *
  * <p>
  * An {@link Interval} over the discrete source domain. <em>Note</em> that this
  * does <em>not</em> imply that for <em>all</em> coordinates in the
@@ -50,7 +50,7 @@ package net.imglib2;
  * coordinate for each. By that, minimum and maximum are defined but the
  * {@link Interval} does not define a value for all coordinates in between.
  * </p>
- * 
+ *
  * @author Stephan Saalfeld
  * @author Stephan Preibisch
  */
@@ -145,48 +145,68 @@ public interface Interval extends RealInterval, Dimensions
 
 	/**
 	 * Allocates a new long array with the minimum of this Interval.
-	 * 
+	 *
+	 * Please note that his method allocates a new array each time which
+	 * introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #min(long[])}.
+	 *
 	 * @return the min
 	 */
 	default long[] minAsLongArray()
 	{
-		long[] min = new long[ numDimensions() ];
+		final long[] min = new long[ numDimensions() ];
 		min( min );
 		return min;
 	}
 
 	/**
 	 * Allocates a new {@link Point} with the maximum of this Interval.
-	 * 
+	 *
+	 * Please note that his method allocates a new {@link Point} each time
+	 * which introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #min(long[])}.
+	 *
 	 * @return the min
 	 */
 	default Point minAsPoint()
 	{
-		Point min = new Point( numDimensions() );
+		final Point min = new Point( numDimensions() );
 		min( min );
 		return min;
 	}
 
 	/**
 	 * Allocates a new long array with the maximum of this Interval.
-	 * 
+	 *
+	 * Please note that his method allocates a new array each time which
+	 * introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #max(long[])}.
+	 *
 	 * @return the max
 	 */
 	default long[] maxAsLongArray()
 	{
-		long[] max = new long[ numDimensions() ];
+		final long[] max = new long[ numDimensions() ];
 		max( max );
 		return max;
 	}
 
 	/**
 	 * Allocates a new {@link Point} with the maximum of this Interval.
-	 * 
+	 *
+	 * Please note that his method allocates a new {@link Point} each time
+	 * which introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #max(long[])}.
+	 *
 	 * @return the max
 	 */
 	default Point maxAsPoint()
 	{
-		Point max = new Point( numDimensions() );
+		final Point max = new Point( numDimensions() );
 		max( max );
 		return max;
 	}

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -104,4 +104,17 @@ public interface Localizable extends RealLocalizable
 	{
 		return getLongPosition( d );
 	}
+
+	/**
+	 * Allocate and return a long array containing the localizable's position.
+	 * 
+	 * @param localizable the localizable
+	 * @return the array
+	 */
+	public static long[] asLongArray( final Localizable localizable )
+	{
+		final long[] out = new long[ localizable.numDimensions() ];
+		localizable.localize( out );
+		return out;
+	}
 }

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -127,18 +127,4 @@ public interface Localizable extends RealLocalizable
 	{
 		return getLongPosition( d );
 	}
-
-	/**
-	 * Allocate and return a long array containing the localizable's position.
-	 * 
-	 * @param localizable
-	 *            the localizable
-	 * @return the array
-	 */
-	public static long[] asLongArray( final Localizable localizable )
-	{
-		final long[] out = new long[ localizable.numDimensions() ];
-		localizable.localize( out );
-		return out;
-	}
 }

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -85,6 +85,29 @@ public interface Localizable extends RealLocalizable
 	}
 
 	/**
+	 * Allocate and return a long array containing the localizable's position.
+	 * 
+	 * @return the position
+	 */
+	default long[] locationToLongArray()
+	{
+		final long[] out = new long[ numDimensions() ];
+		localize( out );
+		return out;
+	}
+
+	/**
+	 * Allocate and return a {@link Point} containing the localizable's
+	 * position.
+	 * 
+	 * @return the position
+	 */
+	default Point locationToPoint()
+	{
+		return new Point( this );
+	}
+
+	/**
 	 * Return the current position in a given dimension.
 	 * 
 	 * @param d
@@ -108,7 +131,8 @@ public interface Localizable extends RealLocalizable
 	/**
 	 * Allocate and return a long array containing the localizable's position.
 	 * 
-	 * @param localizable the localizable
+	 * @param localizable
+	 *            the localizable
 	 * @return the array
 	 */
 	public static long[] asLongArray( final Localizable localizable )

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -89,7 +89,7 @@ public interface Localizable extends RealLocalizable
 	 * 
 	 * @return the position
 	 */
-	default long[] locationToLongArray()
+	default long[] positionAsLongArray()
 	{
 		final long[] out = new long[ numDimensions() ];
 		localize( out );
@@ -102,7 +102,7 @@ public interface Localizable extends RealLocalizable
 	 * 
 	 * @return the position
 	 */
-	default Point locationToPoint()
+	default Point positionAsPoint()
 	{
 		return new Point( this );
 	}

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -39,8 +39,8 @@ package net.imglib2;
  * discrete space. Not only {@link Cursor}s can use this interface, it might be
  * used by much more classes as {@link RandomAccess}s can take any
  * {@link Localizable} as input for where they should move to.
- * 
- * 
+ *
+ *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
@@ -61,7 +61,7 @@ public interface Localizable extends RealLocalizable
 
 	/**
 	 * Write the current position into the passed array.
-	 * 
+	 *
 	 * @param position
 	 *            receives current position
 	 */
@@ -86,7 +86,12 @@ public interface Localizable extends RealLocalizable
 
 	/**
 	 * Allocate and return a long array containing the localizable's position.
-	 * 
+	 *
+	 * Please note that his method allocates a new array each time which
+	 * introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #localize(long[])}.
+	 *
 	 * @return the position
 	 */
 	default long[] positionAsLongArray()
@@ -99,7 +104,12 @@ public interface Localizable extends RealLocalizable
 	/**
 	 * Allocate and return a {@link Point} containing the localizable's
 	 * position.
-	 * 
+	 *
+	 * Please note that his method allocates a new {@link Point} each time
+	 * which introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #localize(long[])}.
+	 *
 	 * @return the position
 	 */
 	default Point positionAsPoint()
@@ -109,7 +119,7 @@ public interface Localizable extends RealLocalizable
 
 	/**
 	 * Return the current position in a given dimension.
-	 * 
+	 *
 	 * @param d
 	 *            dimension
 	 * @return dimension of current position

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -73,6 +73,21 @@ public interface Localizable extends RealLocalizable
 	}
 
 	/**
+	 * Write the current position into the passed {@link Positionable}.
+	 *
+	 * Note for developers: This default implementation forwards to
+	 * {@link Positionable#setPosition(Localizable)}, so don't do the
+	 * same there.
+	 *
+	 * @param position
+	 *            receives current position
+	 */
+	default void localize( final Positionable position )
+	{
+		position.setPosition( this );
+	}
+
+	/**
 	 * Return the current position in a given dimension.
 	 *
 	 * @param d
@@ -107,8 +122,8 @@ public interface Localizable extends RealLocalizable
 	 *
 	 * Please note that his method allocates a new {@link Point} each time
 	 * which introduces notable overhead in both compute and memory.
-	 * If you query it frequently, you should allocate a dedicated array
-	 * first and reuse it with {@link #localize(long[])}.
+	 * If you query it frequently, you should allocate a dedicated
+	 * {@link Point} first and reuse it with {@link #localize(Positionable)}.
 	 *
 	 * @return the position
 	 */

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -69,7 +69,7 @@ public interface Localizable extends RealLocalizable
 	{
 		final int n = numDimensions();
 		for ( int d = 0; d < n; d++ )
-			position[ d ] = getIntPosition( d );
+			position[ d ] = getLongPosition( d );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/RealInterval.java
+++ b/src/main/java/net/imglib2/RealInterval.java
@@ -118,4 +118,53 @@ public interface RealInterval extends EuclideanSpace
 		for ( int d = 0; d < n; d++ )
 			max.setPosition( realMax( d ), d );
 	}
+
+	/**
+	 * Allocates a new double array with the minimum of this RealInterval.
+	 * 
+	 * @return the min
+	 */
+	default double[] minAsDoubleArray()
+	{
+		double[] min = new double[ numDimensions() ];
+		realMin( min );
+		return min;
+	}
+
+	/**
+	 * Allocates a new {@link RealPoint} with the maximum of this RealInterval.
+	 * 
+	 * @return the min
+	 */
+	default RealPoint minAsRealPoint()
+	{
+		RealPoint min = new RealPoint( numDimensions() );
+		realMin( min );
+		return min;
+	}
+
+	/**
+	 * Allocates a new double array with the maximum of this RealInterval.
+	 * 
+	 * @return the max
+	 */
+	default double[] maxAsDoubleArray()
+	{
+		double[] max = new double[ numDimensions() ];
+		realMax( max );
+		return max;
+	}
+
+	/**
+	 * Allocates a new {@link RealPoint} with the maximum of this RealInterval.
+	 * 
+	 * @return the max
+	 */
+	default RealPoint maxAsRealPoint()
+	{
+		RealPoint max = new RealPoint( numDimensions() );
+		realMin( max );
+		return max;
+	}
+
 }

--- a/src/main/java/net/imglib2/RealInterval.java
+++ b/src/main/java/net/imglib2/RealInterval.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,7 +40,7 @@ package net.imglib2;
  * <em>x<sub>d</sub></em>&le;<em>max<sub>d</sub></em>;<em>d</em>&isin;{0&hellip;
  * <em>n</em>-1}}
  * </p>
- * 
+ *
  * An {@link RealInterval} over the real source domain. <em>Note</em> that this
  * does <em>not</em> imply that for <em>all</em> coordinates in the
  * {@link RealInterval} function values exist or can be generated. It only
@@ -48,14 +48,14 @@ package net.imglib2;
  * {@link IterableRealInterval} has a limited number of values and a source
  * coordinate for each. By that, minimum and maximum are defined but the
  * {@link RealInterval} does not define a value for all coordinates in between.
- * 
+ *
  * @author Stephan Saalfeld
  */
 public interface RealInterval extends EuclideanSpace
 {
 	/**
 	 * Get the minimum in dimension d.
-	 * 
+	 *
 	 * @param d
 	 *            dimension
 	 * @return minimum in dimension d.
@@ -64,7 +64,7 @@ public interface RealInterval extends EuclideanSpace
 
 	/**
 	 * Write the minimum of each dimension into double[].
-	 * 
+	 *
 	 * @param min
 	 */
 	default void realMin( final double[] min )
@@ -76,7 +76,7 @@ public interface RealInterval extends EuclideanSpace
 
 	/**
 	 * Sets a {@link RealPositionable} to the minimum of this {@link Interval}
-	 * 
+	 *
 	 * @param min
 	 */
 	default void realMin( final RealPositionable min )
@@ -88,7 +88,7 @@ public interface RealInterval extends EuclideanSpace
 
 	/**
 	 * Get the maximum in dimension d.
-	 * 
+	 *
 	 * @param d
 	 *            dimension
 	 * @return maximum in dimension d.
@@ -97,7 +97,7 @@ public interface RealInterval extends EuclideanSpace
 
 	/**
 	 * Write the maximum of each dimension into double[].
-	 * 
+	 *
 	 * @param max
 	 */
 	default void realMax( final double[] max )
@@ -109,7 +109,7 @@ public interface RealInterval extends EuclideanSpace
 
 	/**
 	 * Sets a {@link RealPositionable} to the maximum of this {@link Interval}
-	 * 
+	 *
 	 * @param max
 	 */
 	default void realMax( final RealPositionable max )
@@ -121,50 +121,69 @@ public interface RealInterval extends EuclideanSpace
 
 	/**
 	 * Allocates a new double array with the minimum of this RealInterval.
-	 * 
+	 *
+	 * Please note that his method allocates a new array each time which
+	 * introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #realMin(double[])}.
+	 *
 	 * @return the min
 	 */
 	default double[] minAsDoubleArray()
 	{
-		double[] min = new double[ numDimensions() ];
+		final double[] min = new double[ numDimensions() ];
 		realMin( min );
 		return min;
 	}
 
 	/**
-	 * Allocates a new {@link RealPoint} with the maximum of this RealInterval.
-	 * 
+	 * Allocates a new {@link RealPoint} with the minimum of this RealInterval.
+	 *
+	 * Please note that his method allocates a new {@link RealPoint} each time
+	 * which introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #realMin(double[])}.
+	 *
 	 * @return the min
 	 */
 	default RealPoint minAsRealPoint()
 	{
-		RealPoint min = new RealPoint( numDimensions() );
+		final RealPoint min = new RealPoint( numDimensions() );
 		realMin( min );
 		return min;
 	}
 
 	/**
 	 * Allocates a new double array with the maximum of this RealInterval.
-	 * 
+	 *
+	 * Please note that his method allocates a new array each time which
+	 * introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #realMax(double[])}.
+	 *
 	 * @return the max
 	 */
 	default double[] maxAsDoubleArray()
 	{
-		double[] max = new double[ numDimensions() ];
+		final double[] max = new double[ numDimensions() ];
 		realMax( max );
 		return max;
 	}
 
 	/**
 	 * Allocates a new {@link RealPoint} with the maximum of this RealInterval.
-	 * 
+	 *
+	 * Please note that his method allocates a new {@link RealPoint} each time
+	 * which introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #realMax(double[])}.
+	 *
 	 * @return the max
 	 */
 	default RealPoint maxAsRealPoint()
 	{
-		RealPoint max = new RealPoint( numDimensions() );
+		final RealPoint max = new RealPoint( numDimensions() );
 		realMin( max );
 		return max;
 	}
-
 }

--- a/src/main/java/net/imglib2/RealInterval.java
+++ b/src/main/java/net/imglib2/RealInterval.java
@@ -141,8 +141,9 @@ public interface RealInterval extends EuclideanSpace
 	 *
 	 * Please note that his method allocates a new {@link RealPoint} each time
 	 * which introduces notable overhead in both compute and memory.
-	 * If you query it frequently, you should allocate a dedicated array
-	 * first and reuse it with {@link #realMin(double[])}.
+	 * If you query it frequently, you should allocate a dedicated
+	 * {@link RealPoint} first and reuse it with
+	 * {@link #realMin(RealPositionable)}.
 	 *
 	 * @return the min
 	 */
@@ -175,8 +176,9 @@ public interface RealInterval extends EuclideanSpace
 	 *
 	 * Please note that his method allocates a new {@link RealPoint} each time
 	 * which introduces notable overhead in both compute and memory.
-	 * If you query it frequently, you should allocate a dedicated array
-	 * first and reuse it with {@link #realMax(double[])}.
+	 * If you query it frequently, you should allocate a dedicated
+	 * {@link RealPoint} first and reuse it with
+	 * {@link #realMax(RealPositionable)}.
 	 *
 	 * @return the max
 	 */

--- a/src/main/java/net/imglib2/RealLocalizable.java
+++ b/src/main/java/net/imglib2/RealLocalizable.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -37,8 +37,8 @@ package net.imglib2;
 /**
  * The {@link RealLocalizable} interface can localize itself in an n-dimensional
  * real space.
- * 
- * 
+ *
+ *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
@@ -46,7 +46,7 @@ public interface RealLocalizable extends EuclideanSpace
 {
 	/**
 	 * Write the current position into the passed array.
-	 * 
+	 *
 	 * @param position
 	 *            receives current position
 	 */
@@ -72,19 +72,29 @@ public interface RealLocalizable extends EuclideanSpace
 
 	/**
 	 * Allocate and return a double array with the position.
-	 * 
+	 *
+	 * Please note that his method allocates a new array each time which
+	 * introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #localize(double[])}.
+	 *
 	 * @return the position
 	 */
 	default double[] positionAsDoubleArray()
 	{
 		final double[] out = new double[ numDimensions() ];
 		localize( out );
-		return out;	
+		return out;
 	}
 
 	/**
 	 * Allocate and return a {@link RealPoint} with the current position.
-	 * 
+	 *
+	 * Please note that his method allocates a new {@link RealPoint} each time
+	 * which introduces notable overhead in both compute and memory.
+	 * If you query it frequently, you should allocate a dedicated array
+	 * first and reuse it with {@link #localize(double[])}.
+	 *
 	 * @return the position
 	 */
 	default RealPoint positionAsRealPoint()
@@ -94,7 +104,7 @@ public interface RealLocalizable extends EuclideanSpace
 
 	/**
 	 * Return the current position in a given dimension.
-	 * 
+	 *
 	 * @param d
 	 *            dimension
 	 * @return dimension of current position
@@ -106,11 +116,10 @@ public interface RealLocalizable extends EuclideanSpace
 
 	/**
 	 * Return the current position in a given dimension.
-	 * 
+	 *
 	 * @param d
 	 *            dimension
 	 * @return dimension of current position
 	 */
 	public double getDoublePosition( int d );
-
 }

--- a/src/main/java/net/imglib2/RealLocalizable.java
+++ b/src/main/java/net/imglib2/RealLocalizable.java
@@ -71,6 +71,28 @@ public interface RealLocalizable extends EuclideanSpace
 	}
 
 	/**
+	 * Allocate and return a double array with the position.
+	 * 
+	 * @return the position
+	 */
+	default double[] locationToDoubleArray()
+	{
+		final double[] out = new double[ numDimensions() ];
+		localize( out );
+		return out;	
+	}
+
+	/**
+	 * Allocate and return a {@link RealPoint} with the current position.
+	 * 
+	 * @return the position
+	 */
+	default RealPoint locationToRealPoint()
+	{
+		return new RealPoint( this );
+	}
+
+	/**
 	 * Return the current position in a given dimension.
 	 * 
 	 * @param d
@@ -91,17 +113,4 @@ public interface RealLocalizable extends EuclideanSpace
 	 */
 	public double getDoublePosition( int d );
 
-	/**
-	 * Allocate and return a double array containing the localizable's position.
-	 * 
-	 * @param realLocalizable
-	 *            the real localizable
-	 * @return the array
-	 */
-	public static double[] asDoubleArray( final RealLocalizable realLocalizable )
-	{
-		final double[] out = new double[ realLocalizable.numDimensions() ];
-		realLocalizable.localize( out );
-		return out;
-	}
 }

--- a/src/main/java/net/imglib2/RealLocalizable.java
+++ b/src/main/java/net/imglib2/RealLocalizable.java
@@ -71,6 +71,21 @@ public interface RealLocalizable extends EuclideanSpace
 	}
 
 	/**
+	 * Write the current position into the passed {@link RealPositionable}.
+	 *
+	 * Note for developers: This default implementation forwards to
+	 * {@link RealPositionable#setPosition(RealLocalizable)}, so don't do the
+	 * same there.
+	 *
+	 * @param position
+	 *            receives current position
+	 */
+	default void localize( final RealPositionable position )
+	{
+		position.setPosition( this );
+	}
+
+	/**
 	 * Allocate and return a double array with the position.
 	 *
 	 * Please note that his method allocates a new array each time which
@@ -92,8 +107,9 @@ public interface RealLocalizable extends EuclideanSpace
 	 *
 	 * Please note that his method allocates a new {@link RealPoint} each time
 	 * which introduces notable overhead in both compute and memory.
-	 * If you query it frequently, you should allocate a dedicated array
-	 * first and reuse it with {@link #localize(double[])}.
+	 * If you query it frequently, you should allocate a dedicated
+	 * {@link RealPoint} first and reuse it with
+	 * {@link #localize(RealPositionable)}.
 	 *
 	 * @return the position
 	 */

--- a/src/main/java/net/imglib2/RealLocalizable.java
+++ b/src/main/java/net/imglib2/RealLocalizable.java
@@ -90,4 +90,18 @@ public interface RealLocalizable extends EuclideanSpace
 	 * @return dimension of current position
 	 */
 	public double getDoublePosition( int d );
+
+	/**
+	 * Allocate and return a double array containing the localizable's position.
+	 * 
+	 * @param realLocalizable
+	 *            the real localizable
+	 * @return the array
+	 */
+	public static double[] asDoubleArray( final RealLocalizable realLocalizable )
+	{
+		final double[] out = new double[ realLocalizable.numDimensions() ];
+		realLocalizable.localize( out );
+		return out;
+	}
 }

--- a/src/main/java/net/imglib2/RealLocalizable.java
+++ b/src/main/java/net/imglib2/RealLocalizable.java
@@ -75,7 +75,7 @@ public interface RealLocalizable extends EuclideanSpace
 	 * 
 	 * @return the position
 	 */
-	default double[] locationToDoubleArray()
+	default double[] positionAsDoubleArray()
 	{
 		final double[] out = new double[ numDimensions() ];
 		localize( out );
@@ -87,7 +87,7 @@ public interface RealLocalizable extends EuclideanSpace
 	 * 
 	 * @return the position
 	 */
-	default RealPoint locationToRealPoint()
+	default RealPoint positionAsRealPoint()
 	{
 		return new RealPoint( this );
 	}

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -40,9 +40,11 @@ import net.imglib2.FinalInterval;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.Localizable;
+import net.imglib2.Point;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
 import net.imglib2.transform.integer.Mixed;
 import net.imglib2.view.ViewTransforms;
 
@@ -955,6 +957,26 @@ public class Intervals
 	}
 
 	/**
+	 * Create a {@link Point} with the minimum of an {@link Interval}.
+	 * 
+	 * <p>
+	 * Keep in mind that creating arrays wildly is not good practice and
+	 * consider using the interval directly.
+	 * </p>
+	 * 
+	 * @param interval
+	 *            something with interval boundaries
+	 * 
+	 * @return minimum as a new Point
+	 */
+	public static Point minAsPoint( final Interval interval )
+	{
+		final Point min = new Point( interval.numDimensions() );
+		interval.min( min );
+		return min;
+	}
+
+	/**
 	 * Create a <code>long[]</code> with the maximum of an {@link Interval}.
 	 * 
 	 * <p>
@@ -997,6 +1019,26 @@ public class Intervals
 	}
 
 	/**
+	 * Create a {@link Point} with the maximum of an {@link Interval}.
+	 * 
+	 * <p>
+	 * Keep in mind that creating arrays wildly is not good practice and
+	 * consider using the interval directly.
+	 * </p>
+	 * 
+	 * @param interval
+	 *            something with interval boundaries
+	 * 
+	 * @return maximum as a new Point
+	 */
+	public static Point maxAsPoint( final Interval interval )
+	{
+		final Point max = new Point( interval.numDimensions() );
+		interval.max( max );
+		return max;
+	}
+
+	/**
 	 * Create a <code>double[]</code> with the maximum of a {@link RealInterval}
 	 * .
 	 * 
@@ -1019,6 +1061,28 @@ public class Intervals
 	}
 
 	/**
+	 * Create a {@link RealPoint} with the maxiumum of a {@link RealInterval}
+	 * .
+	 * 
+	 * <p>
+	 * Keep in mind that creating arrays wildly is not good practice and
+	 * consider using the interval directly. See
+	 * {@link RealInterval#realMin(double[])}.
+	 * </p>
+	 * 
+	 * @param interval
+	 *            something with interval boundaries
+	 * 
+	 * @return maximum as a new RealPoint 
+	 */
+	public static RealPoint maxAsRealPoint( final RealInterval interval )
+	{
+		final RealPoint max = new RealPoint( interval.numDimensions() );
+		interval.realMax( max );
+		return max;
+	}
+
+	/**
 	 * Create a <code>double[]</code> with the minimum of a {@link RealInterval}
 	 * .
 	 * 
@@ -1036,6 +1100,28 @@ public class Intervals
 	public static double[] minAsDoubleArray( final RealInterval interval )
 	{
 		final double[] min = new double[ interval.numDimensions() ];
+		interval.realMin( min );
+		return min;
+	}
+
+	/**
+	 * Create a {@link RealPoint} with the minimum of a {@link RealInterval}
+	 * .
+	 * 
+	 * <p>
+	 * Keep in mind that creating arrays wildly is not good practice and
+	 * consider using the interval directly. See
+	 * {@link RealInterval#realMin(double[])}.
+	 * </p>
+	 * 
+	 * @param interval
+	 *            something with interval boundaries
+	 * 
+	 * @return minimum as a new RealPoint 
+	 */
+	public static RealPoint minAsRealPoint( final RealInterval interval )
+	{
+		final RealPoint min = new RealPoint( interval.numDimensions() );
 		interval.realMin( min );
 		return min;
 	}

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,25 +34,23 @@
 
 package net.imglib2.util;
 
+import java.util.StringJoiner;
+
 import net.imglib2.Dimensions;
 import net.imglib2.FinalDimensions;
 import net.imglib2.FinalInterval;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.Localizable;
-import net.imglib2.Point;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealInterval;
 import net.imglib2.RealLocalizable;
-import net.imglib2.RealPoint;
 import net.imglib2.transform.integer.Mixed;
 import net.imglib2.view.ViewTransforms;
 
-import java.util.StringJoiner;
-
 /**
  * Convenience methods for manipulating {@link Interval Intervals}.
- * 
+ *
  * @author Tobias Pietzsch
  */
 public class Intervals
@@ -61,7 +59,7 @@ public class Intervals
 	 * Create a {@link FinalInterval} from a parameter list comprising minimum
 	 * coordinates and size. For example, to create a 2D interval from (10, 10)
 	 * to (20, 40) use createMinSize( 10, 10, 11, 31 ).
-	 * 
+	 *
 	 * @param minsize
 	 *            a list of <em>2*n</em> parameters to create a <em>n</em>
 	 *            -dimensional interval. The first <em>n</em> parameters specify
@@ -78,7 +76,7 @@ public class Intervals
 	 * Create a {@link FinalInterval} from a parameter list comprising minimum
 	 * and maximum coordinates. For example, to create a 2D interval from (10,
 	 * 10) to (20, 40) use createMinMax( 10, 10, 20, 40 ).
-	 * 
+	 *
 	 * @param minmax
 	 *            a list of <em>2*n</em> parameters to create a <em>n</em>
 	 *            -dimensional interval. The first <em>n</em> parameters specify
@@ -101,7 +99,7 @@ public class Intervals
 	 * Create a {@link FinalRealInterval} from a parameter list comprising
 	 * minimum coordinates and size. For example, to create a 2D interval from
 	 * (10, 10) to (20, 40) use createMinSize( 10, 10, 11, 31 ).
-	 * 
+	 *
 	 * @param minsize
 	 *            a list of <em>2*n</em> parameters to create a <em>n</em>
 	 *            -dimensional interval. The first <em>n</em> parameters specify
@@ -119,7 +117,7 @@ public class Intervals
 	 * Create a {@link FinalRealInterval} from a parameter list comprising
 	 * minimum and maximum coordinates. For example, to create a 2D interval
 	 * from (10, 10) to (20, 40) use createMinMax( 10, 10, 20, 40 ).
-	 * 
+	 *
 	 * @param minmax
 	 *            a list of <em>2*n</em> parameters to create a <em>n</em>
 	 *            -dimensional interval. The first <em>n</em> parameters specify
@@ -158,13 +156,13 @@ public class Intervals
 		}
 		return new FinalInterval( min, max );
 	}
-	
+
 	/**
 	 * Grow/shrink an interval in all dimensions.
-	 * 
+	 *
 	 * Create a {@link FinalInterval}, which is the input interval plus border
 	 * pixels on every side, in every dimension.
-	 * 
+	 *
 	 * @param interval
 	 *            the input interval
 	 * @param border
@@ -178,10 +176,10 @@ public class Intervals
 
 	/**
 	 * Grow/shrink an interval in all dimensions.
-	 * 
+	 *
 	 * Create a {@link FinalInterval}, which is the input interval plus border
 	 * pixels on every side, in every dimension.
-	 * 
+	 *
 	 * @param interval
 	 *            the input interval
 	 * @param border
@@ -490,10 +488,10 @@ public class Intervals
 
 	/**
 	 * Compute the intersection of two intervals.
-	 * 
+	 *
 	 * Create a {@link FinalInterval} , which is the intersection of the input
 	 * intervals (i.e., the area contained in both input intervals).
-	 * 
+	 *
 	 * @param intervalA
 	 *            input interval
 	 * @param intervalB
@@ -544,9 +542,9 @@ public class Intervals
 
 	/**
 	 * Compute the smallest interval that contains both input intervals.
-	 * 
+	 *
 	 * Create a {@link FinalInterval} that represents that interval.
-	 * 
+	 *
 	 * @param intervalA
 	 *            input interval
 	 * @param intervalB
@@ -597,7 +595,7 @@ public class Intervals
 	/**
 	 * Compute the smallest {@link Interval} containing the specified
 	 * {@link RealInterval}.
-	 * 
+	 *
 	 * @param ri
 	 *            input interval.
 	 * @return the smallest integer interval that completely contains the input
@@ -619,7 +617,7 @@ public class Intervals
 	/**
 	 * Compute the largest {@link Interval} that is contained in the specified
 	 * {@link RealInterval}.
-	 * 
+	 *
 	 * @param ri
 	 *            input interval.
 	 * @return the largest integer interval that is completely contained in the
@@ -641,7 +639,7 @@ public class Intervals
 	/**
 	 * Check whether the given interval is empty, that is, the maximum is
 	 * smaller than the minimum in some dimension.
-	 * 
+	 *
 	 * @param interval
 	 *            interval to check
 	 * @return true when the interval is empty, that is, the maximum is smaller
@@ -678,7 +676,7 @@ public class Intervals
 	 * Test whether the {@code containing} interval contains the
 	 * {@code contained} point. The interval is closed, that is, boundary points
 	 * are contained.
-	 * 
+	 *
 	 * @return true, iff {@code contained} is in {@code containing}.
 	 */
 	public static boolean contains( final Interval containing, final Localizable contained )
@@ -699,7 +697,7 @@ public class Intervals
 	 * Test whether the {@code containing} interval contains the
 	 * {@code contained} point. The interval is closed, that is, boundary points
 	 * are contained.
-	 * 
+	 *
 	 * @return true, iff {@code contained} is in {@code containing}.
 	 */
 	public static boolean contains( final RealInterval containing, final RealLocalizable contained )
@@ -753,7 +751,7 @@ public class Intervals
 	/**
 	 * Compute the number of elements contained in an (integer) {@link Interval}
 	 * .
-	 * 
+	 *
 	 * @return number of elements in {@code interval}.
 	 */
 	public static long numElements( final Dimensions interval )
@@ -767,7 +765,7 @@ public class Intervals
 
 	/**
 	 * Compute the number of elements contained in an (integer) interval.
-	 * 
+	 *
 	 * @param dimensions
 	 *            dimensions of the interval.
 	 * @return number of elements in the interval.
@@ -782,7 +780,7 @@ public class Intervals
 
 	/**
 	 * Compute the number of elements contained in an (integer) interval.
-	 * 
+	 *
 	 * @param dimensions
 	 *            dimensions of the interval.
 	 * @return number of elements in the interval.
@@ -873,20 +871,20 @@ public class Intervals
 
 	/**
 	 * Create a <code>long[]</code> with the dimensions of a {@link Dimensions}.
-	 * 
+	 *
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See
 	 * {@link Dimensions#dimensions(long[])}.
 	 * </p>
 	 * <p>
-	 * Consider using the more convenient {@link Dimensions#dimensionsAsLongArray}. 
-	 * This method may be deprecated in a future release. 
+	 * Consider using the more convenient {@link Dimensions#dimensionsAsLongArray}.
+	 * This method may be deprecated in a future release.
 	 * </p>
-	 * 
+	 *
 	 * @param dimensions
 	 *            something which has dimensions
-	 * 
+	 *
 	 * @return dimensions as a new <code>long[]</code>
 	 */
 	public static long[] dimensionsAsLongArray( final Dimensions dimensions )
@@ -898,15 +896,15 @@ public class Intervals
 
 	/**
 	 * Create a <code>int[]</code> with the dimensions of an {@link Interval}.
-	 * 
+	 *
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly.
 	 * </p>
-	 * 
+	 *
 	 * @param dimensions
 	 *            something which has dimensions
-	 * 
+	 *
 	 * @return dimensions as a new <code>int[]</code>
 	 */
 	public static int[] dimensionsAsIntArray( final Dimensions dimensions )
@@ -920,19 +918,19 @@ public class Intervals
 
 	/**
 	 * Create a <code>long[]</code> with the minimum of an {@link Interval}.
-	 * 
+	 *
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See {@link Interval#min(long[])}.
 	 * </p>
 	 * <p>
-	 * Consider using the more convenient {@link Interval#minAsLongArray}. 
-	 * This method may be deprecated in a future release. 
+	 * Consider using the more convenient {@link Interval#minAsLongArray}.
+	 * This method may be deprecated in a future release.
 	 * </p>
-	 * 
+	 *
 	 * @param interval
 	 *            something with interval boundaries
-	 * 
+	 *
 	 * @return minimum as a new <code>long[]</code>
 	 */
 	public static long[] minAsLongArray( final Interval interval )
@@ -944,15 +942,15 @@ public class Intervals
 
 	/**
 	 * Create a <code>int[]</code> with the minimum of an {@link Interval}.
-	 * 
+	 *
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly.
 	 * </p>
-	 * 
+	 *
 	 * @param interval
 	 *            something with interval boundaries
-	 * 
+	 *
 	 * @return minimum as a new <code>int[]</code>
 	 */
 	public static int[] minAsIntArray( final Interval interval )
@@ -965,45 +963,21 @@ public class Intervals
 	}
 
 	/**
-	 * Create a {@link Point} with the minimum of an {@link Interval}.
-	 * 
-	 * <p>
-	 * Keep in mind that creating arrays wildly is not good practice and
-	 * consider using the interval directly.
-	 * </p>
-	 * <p>
-	 * Consider using the more convenient {@link Interval#minAsPoint}. 
-	 * This method may be deprecated in a future release. 
-	 * </p>
-	 * 
-	 * @param interval
-	 *            something with interval boundaries
-	 * 
-	 * @return minimum as a new Point
-	 */
-	public static Point minAsPoint( final Interval interval )
-	{
-		final Point min = new Point( interval.numDimensions() );
-		interval.min( min );
-		return min;
-	}
-
-	/**
 	 * Create a <code>long[]</code> with the maximum of an {@link Interval}.
-	 * 
+	 *
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See {@link Interval#max(long[])}.
 	 * </p>
-	 * 
+	 *
 	 * <p>
-	 * Consider using the more convenient {@link Interval#maxAsLongArray}. 
-	 * This method may be deprecated in a future release. 
+	 * Consider using the more convenient {@link Interval#maxAsLongArray}.
+	 * This method may be deprecated in a future release.
 	 * </p>
-	 * 
+	 *
 	 * @param interval
 	 *            something with interval boundaries
-	 * 
+	 *
 	 * @return maximum as a new <code>long[]</code>
 	 */
 	public static long[] maxAsLongArray( final Interval interval )
@@ -1015,15 +989,15 @@ public class Intervals
 
 	/**
 	 * Create a <code>int[]</code> with the maximum of an {@link Interval}.
-	 * 
+	 *
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly.
 	 * </p>
-	 * 
+	 *
 	 * @param interval
 	 *            something with interval boundaries
-	 * 
+	 *
 	 * @return maximum as a new <code>int[]</code>
 	 */
 	public static int[] maxAsIntArray( final Interval interval )
@@ -1036,47 +1010,22 @@ public class Intervals
 	}
 
 	/**
-	 * Create a {@link Point} with the maximum of an {@link Interval}.
-	 * 
-	 * <p>
-	 * Keep in mind that creating arrays wildly is not good practice and
-	 * consider using the interval directly.
-	 * </p>
-	 * 
-	 * <p>
-	 * Consider using the more convenient {@link Interval#maxAsPoint}. 
-	 * This method may be deprecated in a future release. 
-	 * </p>
-	 * 
-	 * @param interval
-	 *            something with interval boundaries
-	 * 
-	 * @return maximum as a new Point
-	 */
-	public static Point maxAsPoint( final Interval interval )
-	{
-		final Point max = new Point( interval.numDimensions() );
-		interval.max( max );
-		return max;
-	}
-
-	/**
 	 * Create a <code>double[]</code> with the maximum of a {@link RealInterval}
 	 * .
-	 * 
+	 *
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See
 	 * {@link RealInterval#realMax(double[])}.
 	 * </p>
 	 * <p>
-	 * Consider using the more convenient {@link RealInterval#maxAsDoubleArray}. 
-	 * This method may be deprecated in a future release. 
+	 * Consider using the more convenient {@link RealInterval#maxAsDoubleArray}.
+	 * This method may be deprecated in a future release.
 	 * </p>
-	 * 
+	 *
 	 * @param interval
 	 *            something with interval boundaries
-	 * 
+	 *
 	 * @return maximum as a new double[]
 	 */
 	public static double[] maxAsDoubleArray( final RealInterval interval )
@@ -1087,79 +1036,27 @@ public class Intervals
 	}
 
 	/**
-	 * Create a {@link RealPoint} with the maxiumum of a {@link RealInterval}
-	 * .
-	 * 
-	 * <p>
-	 * Keep in mind that creating arrays wildly is not good practice and
-	 * consider using the interval directly. See
-	 * {@link RealInterval#realMin(double[])}.
-	 * </p>
-	 * <p>
-	 * Consider using the more convenient {@link RealInterval#maxAsRealPoint} 
-	 * This method may be deprecated in a future release. 
-	 * </p>
-	 * 
-	 * @param interval
-	 *            something with interval boundaries
-	 * 
-	 * @return maximum as a new RealPoint 
-	 */
-	public static RealPoint maxAsRealPoint( final RealInterval interval )
-	{
-		final RealPoint max = new RealPoint( interval.numDimensions() );
-		interval.realMax( max );
-		return max;
-	}
-
-	/**
 	 * Create a <code>double[]</code> with the minimum of a {@link RealInterval}
 	 * .
-	 * 
+	 *
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See
 	 * {@link RealInterval#realMin(double[])}.
 	 * </p>
 	 * <p>
-	 * Consider using the more convenient {@link RealInterval#minAsDoubleArray} 
-	 * This method may be deprecated in a future release. 
+	 * Consider using the more convenient {@link RealInterval#minAsDoubleArray}
+	 * This method may be deprecated in a future release.
 	 * </p>
-	 * 
+	 *
 	 * @param interval
 	 *            something with interval boundaries
-	 * 
+	 *
 	 * @return minimum as a new double[]
 	 */
 	public static double[] minAsDoubleArray( final RealInterval interval )
 	{
 		final double[] min = new double[ interval.numDimensions() ];
-		interval.realMin( min );
-		return min;
-	}
-
-	/**
-	 * Create a {@link RealPoint} with the minimum of a {@link RealInterval}
-	 * .
-	 * 
-	 * <p>
-	 * Keep in mind that creating arrays wildly is not good practice and
-	 * consider using the interval directly. See
-	 * {@link RealInterval#realMin(double[])}.
-	 * </p>
-	 * <p>
-	 * Consider using the more convenient {@link RealInterval#minAsRealPoint} 
-	 * This method may be deprecated in a future release. 
-	 * </p>
-	 * 
-	 * @param interval
-	 *            something with interval boundaries
-	 * 
-	 * @return minimum as a new RealPoint 
-	 */
-	public static RealPoint minAsRealPoint( final RealInterval interval )
-	{
-		final RealPoint min = new RealPoint( interval.numDimensions() );
 		interval.realMin( min );
 		return min;
 	}

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -879,6 +879,10 @@ public class Intervals
 	 * consider using the interval directly. See
 	 * {@link Dimensions#dimensions(long[])}.
 	 * </p>
+	 * <p>
+	 * Consider using the more convenient {@link Dimensions#dimensionsAsLongArray}. 
+	 * This method may be deprecated in a future release. 
+	 * </p>
 	 * 
 	 * @param dimensions
 	 *            something which has dimensions
@@ -920,6 +924,10 @@ public class Intervals
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See {@link Interval#min(long[])}.
+	 * </p>
+	 * <p>
+	 * Consider using the more convenient {@link Interval#minAsLongArray}. 
+	 * This method may be deprecated in a future release. 
 	 * </p>
 	 * 
 	 * @param interval
@@ -963,6 +971,10 @@ public class Intervals
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly.
 	 * </p>
+	 * <p>
+	 * Consider using the more convenient {@link Interval#minAsPoint}. 
+	 * This method may be deprecated in a future release. 
+	 * </p>
 	 * 
 	 * @param interval
 	 *            something with interval boundaries
@@ -982,6 +994,11 @@ public class Intervals
 	 * <p>
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See {@link Interval#max(long[])}.
+	 * </p>
+	 * 
+	 * <p>
+	 * Consider using the more convenient {@link Interval#maxAsLongArray}. 
+	 * This method may be deprecated in a future release. 
 	 * </p>
 	 * 
 	 * @param interval
@@ -1026,6 +1043,11 @@ public class Intervals
 	 * consider using the interval directly.
 	 * </p>
 	 * 
+	 * <p>
+	 * Consider using the more convenient {@link Interval#maxAsPoint}. 
+	 * This method may be deprecated in a future release. 
+	 * </p>
+	 * 
 	 * @param interval
 	 *            something with interval boundaries
 	 * 
@@ -1046,6 +1068,10 @@ public class Intervals
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See
 	 * {@link RealInterval#realMax(double[])}.
+	 * </p>
+	 * <p>
+	 * Consider using the more convenient {@link RealInterval#maxAsDoubleArray}. 
+	 * This method may be deprecated in a future release. 
 	 * </p>
 	 * 
 	 * @param interval
@@ -1069,6 +1095,10 @@ public class Intervals
 	 * consider using the interval directly. See
 	 * {@link RealInterval#realMin(double[])}.
 	 * </p>
+	 * <p>
+	 * Consider using the more convenient {@link RealInterval#maxAsRealPoint} 
+	 * This method may be deprecated in a future release. 
+	 * </p>
 	 * 
 	 * @param interval
 	 *            something with interval boundaries
@@ -1091,6 +1121,10 @@ public class Intervals
 	 * consider using the interval directly. See
 	 * {@link RealInterval#realMin(double[])}.
 	 * </p>
+	 * <p>
+	 * Consider using the more convenient {@link RealInterval#minAsDoubleArray} 
+	 * This method may be deprecated in a future release. 
+	 * </p>
 	 * 
 	 * @param interval
 	 *            something with interval boundaries
@@ -1112,6 +1146,10 @@ public class Intervals
 	 * Keep in mind that creating arrays wildly is not good practice and
 	 * consider using the interval directly. See
 	 * {@link RealInterval#realMin(double[])}.
+	 * </p>
+	 * <p>
+	 * Consider using the more convenient {@link RealInterval#minAsRealPoint} 
+	 * This method may be deprecated in a future release. 
 	 * </p>
 	 * 
 	 * @param interval

--- a/src/main/java/net/imglib2/util/Localizables.java
+++ b/src/main/java/net/imglib2/util/Localizables.java
@@ -47,14 +47,16 @@ import net.imglib2.view.Views;
 
 public class Localizables
 {
+	/**
+	 * @deprecated
+	 * Use {@link Localizable#positionAsLongArray}. 
+	 */
+	@Deprecated
 	public static long[] asLongArray( final Localizable localizable )
 	{
-		return localizable.locationToLongArray();
-	}
-
-	public static double[] asDoubleArray( final RealLocalizable realLocalizable )
-	{
-		return realLocalizable.locationToDoubleArray();
+		final long[] result = new long[ localizable.numDimensions() ];
+		localizable.localize( result );
+		return result;
 	}
 
 	public static RandomAccessible< Localizable > randomAccessible( final int n )

--- a/src/main/java/net/imglib2/util/Localizables.java
+++ b/src/main/java/net/imglib2/util/Localizables.java
@@ -47,12 +47,14 @@ import net.imglib2.view.Views;
 
 public class Localizables
 {
-
 	public static long[] asLongArray( final Localizable localizable )
 	{
-		final long[] result = new long[ localizable.numDimensions() ];
-		localizable.localize( result );
-		return result;
+		return Localizable.asLongArray( localizable );
+	}
+
+	public static double[] asDoubleArray( final RealLocalizable realLocalizable )
+	{
+		return RealLocalizable.asDoubleArray( realLocalizable );
 	}
 
 	public static RandomAccessible< Localizable > randomAccessible( final int n )

--- a/src/main/java/net/imglib2/util/Localizables.java
+++ b/src/main/java/net/imglib2/util/Localizables.java
@@ -49,12 +49,12 @@ public class Localizables
 {
 	public static long[] asLongArray( final Localizable localizable )
 	{
-		return Localizable.asLongArray( localizable );
+		return localizable.locationToLongArray();
 	}
 
 	public static double[] asDoubleArray( final RealLocalizable realLocalizable )
 	{
-		return RealLocalizable.asDoubleArray( realLocalizable );
+		return realLocalizable.locationToDoubleArray();
 	}
 
 	public static RandomAccessible< Localizable > randomAccessible( final int n )

--- a/src/test/java/net/imglib2/loops/LoopPerformanceBenchmark.java
+++ b/src/test/java/net/imglib2/loops/LoopPerformanceBenchmark.java
@@ -96,8 +96,8 @@ public class LoopPerformanceBenchmark
 		final RandomAccess< DoubleType > back = Views.extendBorder( in ).randomAccess();
 		final RandomAccess< DoubleType > front = Views.extendBorder( in ).randomAccess();
 
-		back.setPosition( Intervals.minAsLongArray( out ) );
-		front.setPosition( Intervals.minAsLongArray( out ) );
+		back.setPosition( out.minAsLongArray() );
+		front.setPosition( out.minAsLongArray() );
 		back.bck( 0 );
 		front.fwd( 0 );
 

--- a/src/test/java/net/imglib2/util/ConstantUtilsTest.java
+++ b/src/test/java/net/imglib2/util/ConstantUtilsTest.java
@@ -80,7 +80,7 @@ public class ConstantUtilsTest
 		final RandomAccessibleInterval< IntType > randomAccessibleInterval = ConstantUtils.constantRandomAccessibleInterval( constVal, new FinalInterval( dims ) );
 
 		Assert.assertArrayEquals( dims, Intervals.dimensionsAsLongArray( randomAccessibleInterval ) );
-		Assert.assertArrayEquals( new long[ nDim ], Intervals.minAsLongArray( randomAccessibleInterval ) );
+		Assert.assertArrayEquals( new long[ nDim ], randomAccessibleInterval.minAsLongArray() );
 
 		Views.iterable( randomAccessibleInterval ).forEach( p -> Assert.assertTrue( constVal.valueEquals( constVal ) ) );
 	}

--- a/src/test/java/net/imglib2/util/IntervalIndexerTest.java
+++ b/src/test/java/net/imglib2/util/IntervalIndexerTest.java
@@ -90,7 +90,7 @@ public class IntervalIndexerTest
 	{
 		final long numElements = Intervals.numElements( interval );
 		final long[] pos = new long[ dim.length ];
-		final long[] min = Intervals.minAsLongArray( interval );
+		final long[] min = interval.minAsLongArray();
 		final long[] store = new long[ dim.length ];
 		final Point positionable = Point.wrap( store );
 		for ( long index = 0; index < numElements; ++index )
@@ -104,7 +104,7 @@ public class IntervalIndexerTest
 	public void testPositionToIndex( final RandomAccessibleInterval< ? > interval )
 	{
 		final long[] pos = new long[ dim.length ];
-		final long[] min = Intervals.minAsLongArray( interval );
+		final long[] min = interval.minAsLongArray();
 		for ( final Cursor< ? > cursor = Views.flatIterable( interval ).localizingCursor(); cursor.hasNext(); )
 		{
 			cursor.fwd();

--- a/src/test/java/net/imglib2/util/LocalizablesTest.java
+++ b/src/test/java/net/imglib2/util/LocalizablesTest.java
@@ -48,7 +48,7 @@ public class LocalizablesTest
 	@Test
 	public void testAsLongArray() {
 		Localizable input = new Point( 5,7 );
-		long[] result = Localizables.asLongArray( input );
+		long[] result = input.positionAsLongArray();
 		assertArrayEquals( new long[] { 5, 7 }, result );
 	}
 
@@ -61,6 +61,6 @@ public class LocalizablesTest
 		assertEquals( n, randomAccessible.numDimensions() );
 		assertEquals( n, randomAccess.numDimensions() );
 		randomAccess.setPosition( position );
-		assertArrayEquals( position, Localizables.asLongArray( randomAccess.get() ) );
+		assertArrayEquals( position, randomAccess.get().positionAsLongArray() );
 	}
 }

--- a/src/test/java/net/imglib2/view/ConcatenateViewTest.java
+++ b/src/test/java/net/imglib2/view/ConcatenateViewTest.java
@@ -111,8 +111,8 @@ public class ConcatenateViewTest
 			int axis,
 			long divider )
 	{
-		final long[] min = Intervals.minAsLongArray( img );
-		final long[] max = Intervals.maxAsLongArray( img );
+		final long[] min = img.minAsLongArray();
+		final long[] max = img.maxAsLongArray();
 		final long[] min1 = min.clone();
 		final long[] min2 = min.clone();
 		final long[] max1 = max.clone();

--- a/src/test/java/net/imglib2/view/ViewsTest.java
+++ b/src/test/java/net/imglib2/view/ViewsTest.java
@@ -61,7 +61,7 @@ public class ViewsTest
 		RandomAccessible< Localizable > view = Views.moveAxis( input, 1, 3 );
 		RandomAccess< Localizable > ra = view.randomAccess();
 		ra.setPosition( new long[] {1, 3, 4, 2} );
-		assertArrayEquals( new long[] {1, 2, 3, 4}, Localizables.asLongArray( ra.get() ) );
+		assertArrayEquals( new long[] {1, 2, 3, 4}, ra.get().positionAsLongArray() );
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class ViewsTest
 		RandomAccessible< Localizable > view = Views.moveAxis( input, 3, 1 );
 		RandomAccess< Localizable > ra = view.randomAccess();
 		ra.setPosition( new long[] {1, 4, 2, 3} );
-		assertArrayEquals( new long[] {1, 2, 3, 4}, Localizables.asLongArray( ra.get() ) );
+		assertArrayEquals( new long[] {1, 2, 3, 4}, ra.get().positionAsLongArray() );
 	}
 
 	@Test


### PR DESCRIPTION
Changes are in line with the discussion in issue #285.  Two remaining points / questions:

I added `Localizable.asLongArray` and `RealLocalizable.asDoubleArray`which duplicate `Localizables.asLongArray` and `Localizables.asDoubleArray`.  I modified the `Localizables` methods to call the other methods as appropriate. Is this situation okay? Should we deprecate the `Localizables` methods?  Or better to leave the methods in `Localizables` and remove from `RealLocalizable` and `Localizable`?

I also added a few static methods in Intervals: 
* `Point Intervals.minAsPoint( Interval )`
* `Point Intervals.maxAsPoint( Interval )`
* `RealPoint Intervals.minAsRealPoint( RealInterval )`
* `RealPoint Intervals.maxAsRealPoint( RealInterval )`

not sure how useful those will be, but seem reasonable, and is in-line with the idea of this PR.