### PR TITLE
Fix RealInterval.maxAsRealPoint

### DIFF
--- a/src/main/java/net/imglib2/RealInterval.java
+++ b/src/main/java/net/imglib2/RealInterval.java
@@ -185,7 +185,7 @@ public interface RealInterval extends EuclideanSpace
 	default RealPoint maxAsRealPoint()
 	{
 		final RealPoint max = new RealPoint( numDimensions() );
-		realMin( max );
+		realMax( max );
 		return max;
 	}
 }


### PR DESCRIPTION
The return value `RealPoint max` gets populated via `realMin( max )` in `RealInterval.maxAsRealPoint` when it should be `realMax( max )`.