### PR TITLE
Add IntegerTypes utility class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,11 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<properties><id>bogovicj</id></properties>
 		</contributor>
 		<contributor>
+			<name>Jan Eglinger</name>
+			<url>https://imagej.net/User:Eglinger</url>
+			<properties><id>imagejan</id></properties>
+		</contributor>
+		<contributor>
 			<name>Jan Funke</name>
 			<url>https://imagej.net/User:Funke</url>
 			<properties><id>funkey</id></properties>
@@ -230,13 +235,11 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
-			<version>1.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-generator-annprocess</artifactId>
-			<version>1.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/net/imglib2/type/numeric/integer/IntegerTypes.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/IntegerTypes.java
@@ -1,0 +1,42 @@
+package net.imglib2.type.numeric.integer;
+
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.IntegerType;
+
+public class IntegerTypes
+{
+	private IntegerTypes()
+	{
+		// NB: prevent instantiation of static utility class
+	}
+
+	public static IntegerType< ? > smallestType( boolean signed, long max )
+	{
+		return smallestType( signed ? -1 : 0, max );
+	}
+
+	public static IntegerType< ? > smallestType( long min, long max )
+	{
+		if ( min > max )
+			throw new IllegalArgumentException( "Wrong usage: min (" + min + ") > max (" + max + ")" );
+		if ( min >= 0 )
+		{
+			if ( max <= 1L )
+				return new BitType();
+			if ( max <= 0xffL )
+				return new UnsignedByteType();
+			if ( max <= 0xffffL )
+				return new UnsignedShortType();
+			if ( max <= 0xffffffffL )
+				return new UnsignedIntType();
+			return new UnsignedLongType();
+		}
+		if ( min >= Byte.MIN_VALUE && max <= Byte.MAX_VALUE )
+			return new ByteType();
+		if ( min >= Short.MIN_VALUE && max <= Short.MAX_VALUE )
+			return new ShortType();
+		if ( min >= Integer.MIN_VALUE && max <= Integer.MAX_VALUE )
+			return new IntType();
+		return new LongType();
+	}
+}

--- a/src/main/java/net/imglib2/type/numeric/integer/IntegerTypes.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/IntegerTypes.java
@@ -1,42 +1,59 @@
 package net.imglib2.type.numeric.integer;
 
+import java.util.Arrays;
+import java.util.List;
+
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.IntegerType;
 
 public class IntegerTypes
 {
+	private static List< ? extends IntegerType< ? > > signedTypes = Arrays.asList( new ByteType(), new ShortType(), new IntType(), new LongType() );
+
+	private static List< ? extends IntegerType< ? > > unsignedTypes = Arrays.asList( new BitType(), new UnsignedByteType(), new UnsignedShortType(), new UnsignedIntType(), new UnsignedLongType() );
+
 	private IntegerTypes()
 	{
 		// NB: prevent instantiation of static utility class
 	}
 
+	/**
+	 * Get an {@link IntegerType} that can hold the given {@code max} value.
+	 * 
+	 * The smallest byte-size type matching the constraints will be selected.
+	 * 
+	 * @param signed
+	 *            - {@code true} if a signed {@link IntegerType} is required
+	 * @param max
+	 *            - the expected maximum value
+	 * @return an {@link IntegerType} matching the given constraints
+	 */
 	public static IntegerType< ? > smallestType( boolean signed, long max )
 	{
 		return smallestType( signed ? -1 : 0, max );
 	}
 
+	/**
+	 * Get an {@link IntegerType} that can hold the given {@code min} and
+	 * {@code max} values.
+	 * 
+	 * The smallest byte-size type matching the constraints will be selected,
+	 * with a preference for unsigned types.
+	 * 
+	 * @param min
+	 *            - the expected minimum value
+	 * @param max
+	 *            - the expected maximum value
+	 * @return an {@link IntegerType} matching the given constraints
+	 */
 	public static IntegerType< ? > smallestType( long min, long max )
 	{
 		if ( min > max )
 			throw new IllegalArgumentException( "Wrong usage: min (" + min + ") > max (" + max + ")" );
-		if ( min >= 0 )
+		if ( min >= 0 ) // unsigned
 		{
-			if ( max <= 1L )
-				return new BitType();
-			if ( max <= 0xffL )
-				return new UnsignedByteType();
-			if ( max <= 0xffffL )
-				return new UnsignedShortType();
-			if ( max <= 0xffffffffL )
-				return new UnsignedIntType();
-			return new UnsignedLongType();
+			return unsignedTypes.stream().filter( i -> min >= i.getMinValue() && max <= i.getMaxValue() ).findFirst().get().createVariable();
 		}
-		if ( min >= Byte.MIN_VALUE && max <= Byte.MAX_VALUE )
-			return new ByteType();
-		if ( min >= Short.MIN_VALUE && max <= Short.MAX_VALUE )
-			return new ShortType();
-		if ( min >= Integer.MIN_VALUE && max <= Integer.MAX_VALUE )
-			return new IntType();
-		return new LongType();
+		return signedTypes.stream().filter( i -> min >= i.getMinValue() && max <= i.getMaxValue() ).findFirst().get().createVariable();
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/IntegerTypesTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/IntegerTypesTest.java
@@ -1,0 +1,47 @@
+package net.imglib2.type.numeric.integer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+import net.imglib2.type.logic.BitType;
+
+public class IntegerTypesTest
+{
+
+	@Test
+	public void testIntegerTypes()
+	{
+		/* smallestType(min, max) */
+		assertEquals( BitType.class, IntegerTypes.smallestType( 0, 1 ).getClass() );
+		assertEquals( UnsignedByteType.class, IntegerTypes.smallestType( 0, 128 ).getClass() );
+		assertEquals( UnsignedByteType.class, IntegerTypes.smallestType( 0, 255 ).getClass() );
+		assertEquals( UnsignedShortType.class, IntegerTypes.smallestType( 0, 256 ).getClass() );
+		assertEquals( UnsignedShortType.class, IntegerTypes.smallestType( 0, 65535 ).getClass() );
+		assertEquals( UnsignedIntType.class, IntegerTypes.smallestType( 0, 65536 ).getClass() );
+		assertEquals( UnsignedIntType.class, IntegerTypes.smallestType( 0, ( long ) Integer.MAX_VALUE - Integer.MIN_VALUE ).getClass() );
+		assertEquals( UnsignedLongType.class, IntegerTypes.smallestType( 0, ( long ) Integer.MAX_VALUE - Integer.MIN_VALUE + 1 ).getClass() );
+
+		assertEquals( ByteType.class, IntegerTypes.smallestType( -128, 0 ).getClass() );
+		assertEquals( ShortType.class, IntegerTypes.smallestType( -129, 0 ).getClass() );
+		assertEquals( ShortType.class, IntegerTypes.smallestType( -32768, 0 ).getClass() );
+		assertEquals( IntType.class, IntegerTypes.smallestType( -32769, 0 ).getClass() );
+		assertEquals( IntType.class, IntegerTypes.smallestType( Integer.MIN_VALUE, 0 ).getClass() );
+		assertEquals( LongType.class, IntegerTypes.smallestType( ( long ) Integer.MIN_VALUE - 1, 0 ).getClass() );
+
+		/* smallestType(signed, max) */
+		assertEquals( UnsignedByteType.class, IntegerTypes.smallestType( false, 128 ).getClass() );
+		assertEquals( ShortType.class, IntegerTypes.smallestType( true, 128 ).getClass() );
+
+		assertEquals( UnsignedShortType.class, IntegerTypes.smallestType( false, 32768 ).getClass() );
+		assertEquals( IntType.class, IntegerTypes.smallestType( true, 32768 ).getClass() );
+
+		assertEquals( UnsignedIntType.class, IntegerTypes.smallestType( false, ( long ) Integer.MAX_VALUE + 1 ).getClass() );
+		assertEquals( LongType.class, IntegerTypes.smallestType( true, ( long ) Integer.MAX_VALUE + 1 ).getClass() );
+
+		/* wrong usage */
+		assertThrows( IllegalArgumentException.class, () -> IntegerTypes.smallestType( 0, -1 ) );
+	}
+
+}


### PR DESCRIPTION
This commits adds a simple utility class to retrieve an `IntegerType` based on given `min` and `max` values, or on a `max` value and a flag for signed/unsigned.

It includes a test for all possible return types.

Also removed hard-coded version pinning in the test dependencies, and added myself as contributor.

See also [this discussion](https://gitter.im/imglib/imglib2?at=5f97c99ebbffc02b5841671d) on Gitter.