### PR TITLE
Buffer-backed access (full implementation)

### DIFF
--- a/src/main/java/net/imglib2/display/screenimage/awt/ArrayImgAWTScreenImage.java
+++ b/src/main/java/net/imglib2/display/screenimage/awt/ArrayImgAWTScreenImage.java
@@ -47,6 +47,7 @@ import java.awt.image.WritableRaster;
 
 import net.imglib2.Dimensions;
 import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.DataAccess;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 
@@ -55,7 +56,7 @@ import net.imglib2.type.numeric.RealType;
  * 
  * @author Curtis Rueden
  */
-public abstract class ArrayImgAWTScreenImage< T extends NativeType< T >, A > extends ArrayImg< T, A > implements AWTScreenImage
+public abstract class ArrayImgAWTScreenImage< T extends NativeType< T >, A extends DataAccess > extends ArrayImg< T, A > implements AWTScreenImage
 {
 
 	private final BufferedImage bufferedImage;

--- a/src/main/java/net/imglib2/display/screenimage/awt/ArrayImgAWTScreenImage.java
+++ b/src/main/java/net/imglib2/display/screenimage/awt/ArrayImgAWTScreenImage.java
@@ -108,4 +108,19 @@ public abstract class ArrayImgAWTScreenImage< T extends NativeType< T >, A exten
 		img.dimensions( dimensions );
 		return dimensions;
 	}
+
+	/**
+	 * Deprecated constructor for when A was not bounded by DataAccess
+	 * 
+	 * @param type
+	 * @param data
+	 *            - will be cast to DataAccess type A
+	 * @param dim
+	 */
+	@SuppressWarnings( "unchecked" )
+	@Deprecated
+	public ArrayImgAWTScreenImage( final T type, final Object data, final long[] dim )
+	{
+		this( type, ( A ) data, dim );
+	}
 }

--- a/src/main/java/net/imglib2/img/array/ArrayImg.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImg.java
@@ -84,7 +84,7 @@ public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends
 	@Override
 	public A update( final Object o )
 	{
-		return (A) data.createView(o);
+		return ( A ) data.createView( o );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/array/ArrayImg.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImg.java
@@ -39,6 +39,7 @@ import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.img.AbstractNativeImg;
 import net.imglib2.img.Img;
+import net.imglib2.img.basictypeaccess.DataAccess;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Fraction;
 import net.imglib2.util.IntervalIndexer;
@@ -58,7 +59,7 @@ import net.imglib2.view.iteration.SubIntervalIterable;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public class ArrayImg< T extends NativeType< T >, A > extends AbstractNativeImg< T, A > implements SubIntervalIterable< T >
+public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends AbstractNativeImg< T, A > implements SubIntervalIterable< T >
 {
 	final int[] steps, dim;
 
@@ -79,10 +80,11 @@ public class ArrayImg< T extends NativeType< T >, A > extends AbstractNativeImg<
 		this.data = data;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public A update( final Object o )
 	{
-		return data;
+		return (A) data.createView(o);
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/array/ArrayImg.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImg.java
@@ -80,7 +80,7 @@ public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends
 		this.data = data;
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings( "unchecked" )
 	@Override
 	public A update( final Object o )
 	{
@@ -232,5 +232,21 @@ public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends
 	public Object subIntervalIterationOrder( final Interval interval )
 	{
 		return new FlatIterationOrder( interval );
+	}
+
+	/**
+	 * Deprecated constructor for binary compatibility when A was not bounded by
+	 * DataAccess
+	 * 
+	 * @param data
+	 *            - will be cast to DataAccess type A
+	 * @param dim
+	 * @param entitiesPerPixel
+	 */
+	@SuppressWarnings( "unchecked" )
+	@Deprecated
+	public ArrayImg( final Object data, final long[] dim, final Fraction entitiesPerPixel )
+	{
+		this( ( A ) data, dim, entitiesPerPixel );
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/BooleanAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/BooleanAccess.java
@@ -39,7 +39,7 @@ package net.imglib2.img.basictypeaccess;
  * 
  * @author Curtis Rueden
  */
-public interface BooleanAccess
+public interface BooleanAccess extends DataAccess
 {
 	public boolean getValue( final int index );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/CharAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/CharAccess.java
@@ -40,7 +40,7 @@ package net.imglib2.img.basictypeaccess;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface CharAccess
+public interface CharAccess extends DataAccess
 {
 	public char getValue( final int index );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/DataAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/DataAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,31 +40,35 @@ import net.imglib2.type.NativeType;
 
 /**
  * Top-level interface for access containers
- * 
- * Generally, sub-interfaces define specific getValue and setValue
- * methods for a given index.
- * 
+ *
+ * Generally, sub-interfaces define specific getValue and setValue methods for a
+ * given index.
+ *
  * @author Mark Kittisopikul
  *
  */
-public interface DataAccess {
-	
+public interface DataAccess
+{
+
 	/**
 	 * Create a copy of the current access without copying the underlying data.
-	 * 
+	 *
 	 * Useful for access containers whose instances are not thread safe such as
 	 * {@link java.nio.Buffer} derivatives that have a state.
-	 * 
+	 *
 	 * By default, <code>createView</code> returns <code>this</code> object
 	 * instance.
-	 * 
-	 * @param o Usually an accessor like {@link Cursor}. See {@link NativeImg#update(Object)}
+	 *
+	 * @param o
+	 *            Usually an accessor like {@link Cursor}. See
+	 *            {@link NativeImg#update(Object)}
 	 * @return A view of the original access and of the same concrete type.
 	 * @see NativeImg#update(Object)
 	 * @see NativeType#updateContainer(Object)
 	 */
-	public default DataAccess createView(final Object o) {
+	public default DataAccess createView( final Object o )
+	{
 		return this;
 	}
-	
+
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/DataAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/DataAccess.java
@@ -34,15 +34,37 @@
 
 package net.imglib2.img.basictypeaccess;
 
-/**
- * TODO
- * 
- * @author Stephan Preibisch
- * @author Stephan Saalfeld
- */
-public interface ByteAccess extends DataAccess
-{
-	public byte getValue( final int index );
+import net.imglib2.Cursor;
+import net.imglib2.img.NativeImg;
+import net.imglib2.type.NativeType;
 
-	public void setValue( final int index, final byte value );
+/**
+ * Top-level interface for access containers
+ * 
+ * Generally, sub-interfaces define specific getValue and setValue
+ * methods for a given index.
+ * 
+ * @author Mark Kittisopikul
+ *
+ */
+public interface DataAccess {
+	
+	/**
+	 * Create a copy of the current access without copying the underlying data.
+	 * 
+	 * Useful for access containers whose instances are not thread safe such as
+	 * {@link java.nio.Buffer} derivatives that have a state.
+	 * 
+	 * By default, <code>createView</code> returns <code>this</code> object
+	 * instance.
+	 * 
+	 * @param o Usually an accessor like {@link Cursor}. See {@link NativeImg#update(Object)}
+	 * @return A view of the original access and of the same concrete type.
+	 * @see NativeImg#update(Object)
+	 * @see NativeType#updateContainer(Object)
+	 */
+	public default DataAccess createView(final Object o) {
+		return this;
+	}
+	
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/DoubleAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/DoubleAccess.java
@@ -40,7 +40,7 @@ package net.imglib2.img.basictypeaccess;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface DoubleAccess
+public interface DoubleAccess extends DataAccess
 {
 	public double getValue( final int index );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/FloatAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/FloatAccess.java
@@ -40,7 +40,7 @@ package net.imglib2.img.basictypeaccess;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface FloatAccess
+public interface FloatAccess extends DataAccess
 {
 	public float getValue( final int index );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/IntAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/IntAccess.java
@@ -40,7 +40,7 @@ package net.imglib2.img.basictypeaccess;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface IntAccess
+public interface IntAccess extends DataAccess
 {
 	public int getValue( final int index );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/LongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/LongAccess.java
@@ -40,7 +40,7 @@ package net.imglib2.img.basictypeaccess;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface LongAccess
+public interface LongAccess extends DataAccess
 {
 	public long getValue( final int index );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/PlanarAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/PlanarAccess.java
@@ -41,7 +41,7 @@ package net.imglib2.img.basictypeaccess;
  *            primitive array type
  * @author Curtis Rueden
  */
-public interface PlanarAccess< A >
+public interface PlanarAccess< A > extends DataAccess
 {
 	A getPlane( int no );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/ShortAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/ShortAccess.java
@@ -40,7 +40,7 @@ package net.imglib2.img.basictypeaccess;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface ShortAccess
+public interface ShortAccess extends DataAccess
 {
 	public short getValue( final int index );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/ArrayDataAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/ArrayDataAccess.java
@@ -36,6 +36,8 @@ package net.imglib2.img.basictypeaccess.array;
 
 import java.io.Serializable;
 
+import net.imglib2.img.basictypeaccess.DataAccess;
+
 /**
  * Trivial interface for primitive array based data access implementations
  * that can replicate themselves and return the underlying array.
@@ -43,7 +45,7 @@ import java.io.Serializable;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface ArrayDataAccess< A > extends Serializable
+public interface ArrayDataAccess< A > extends DataAccess, Serializable
 {
 	A createArray( int numEntities );
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
@@ -61,14 +61,14 @@ public abstract class AbstractBufferAccess< A extends AbstractBufferAccess< A, B
 	/**
 	 * Default valid setting if not specified
 	 */
-	protected final static boolean DEFAULT_IS_VALID = true;
+	static final boolean DEFAULT_IS_VALID = true;
 
 	/**
 	 * If valid or not as per {@link VolatileAccess}.
 	 */
-	protected final boolean isValid;
+	private final boolean isValid;
 
-	protected final B buffer;
+	final B buffer;
 
 	/*
 	 * Constructors
@@ -169,7 +169,7 @@ public abstract class AbstractBufferAccess< A extends AbstractBufferAccess< A, B
 	 * @param isDirect
 	 * @return
 	 */
-	protected ByteBuffer allocateByteBuffer( final int numEntities, final boolean isDirect )
+	ByteBuffer allocateByteBuffer( final int numEntities, final boolean isDirect )
 	{
 		if ( isDirect )
 			return ByteBuffer.allocateDirect( numEntities * getNumBytesPerEntity() );
@@ -185,7 +185,7 @@ public abstract class AbstractBufferAccess< A extends AbstractBufferAccess< A, B
 	 * @param isValid
 	 * @return
 	 */
-	protected A allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	A allocate( final int numEntities, final boolean isDirect, final boolean isValid )
 	{
 		return newInstance( allocateByteBuffer( numEntities, isDirect ), isValid );
 	}
@@ -197,7 +197,7 @@ public abstract class AbstractBufferAccess< A extends AbstractBufferAccess< A, B
 	 * @param numEntities
 	 * @return
 	 */
-	protected A allocate( final int numEntities )
+	A allocate( final int numEntities )
 	{
 		return allocate( numEntities, isDirect(), isValid() );
 	}
@@ -231,6 +231,6 @@ public abstract class AbstractBufferAccess< A extends AbstractBufferAccess< A, B
 	 *
 	 * @return
 	 */
-	protected abstract B duplicateBuffer( B buffer );
+	abstract B duplicateBuffer( B buffer );
 
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
@@ -1,0 +1,223 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.function.Function;
+
+import net.imglib2.img.basictypeaccess.DataAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+
+/**
+ * Base abstract class for {@link DataAccess} implementations that wrap
+ * {@link Buffer}.
+ * 
+ * @author Mark Kittisopikul
+ * @author Philipp Hanslovsky (initial specification)
+ *
+ * @param <A> Subclass used as return type for 
+ * {@link #newInstance(Buffer, boolean)} and
+ * {@link #newInstance(ByteBuffer, boolean)}
+ * 
+ * @param <B> {@link Buffer} subclass
+ */
+public abstract class AbstractBufferAccess <A extends AbstractBufferAccess< A, B >, B extends Buffer> implements BufferAccess< A > {
+	
+	/**
+	 * Default valid setting if not specified
+	 */
+	protected static boolean DEFAULT_IS_VALID = true;
+	
+	/**
+	 * If valid or not as per {@link VolatileAccess}.
+	 */
+	protected final boolean isValid;
+
+	protected final B buffer;
+	
+	/*
+	 * Constructors
+	 */
+
+	public AbstractBufferAccess(final B buffer, final boolean isValid) {
+		this.buffer = buffer;
+		this.isValid = isValid;
+	}
+	
+	public AbstractBufferAccess(final B buffer) {
+		this(buffer, DEFAULT_IS_VALID);
+	}
+	
+	public AbstractBufferAccess(final Function<Integer,B> allocate, final int numEntities) {
+		this( allocate.apply(numEntities) );
+	}
+	
+	/*
+	 * Public methods
+	 */
+	
+	/**
+	 * Returns a new instance of BufferAccess with duplicated Buffer for
+	 * thread safety.
+	 */
+	@Override
+	public A createView(Object o) {
+		return newInstance( duplicateBuffer(buffer), isValid() );
+	}
+	
+	@Override
+	public boolean isValid()
+	{
+		return isValid;
+	}
+	
+	/**
+	 * Respects the directness of the buffer.
+	 * If this buffer is direct, then the new backing buffer is also direct.
+	 */
+	@Override
+	public A createArray( int numEntities )
+	{
+		return allocate( numEntities );
+	}
+
+	/**
+	 * Returns the raw buffer (not duplicated)
+	 */
+	@Override
+	public B getCurrentStorageArray()
+	{
+		return buffer;
+	}
+
+	/**
+	 * Returns the Buffer's limit or zero if buffer is null.
+	 * 
+	 * @see Buffer#limit()
+	 */
+	@Override
+	public int getArrayLength()
+	{
+		if( buffer == null )
+			return 0;
+		else
+			return buffer.limit();
+	}
+	
+	/**
+	 * Return the Buffer's directness or false is the buffer is null.
+	 */
+	@Override
+	public boolean isDirect() {
+		return buffer != null && buffer.isDirect();
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return buffer.isReadOnly();
+	}
+	
+	/*
+	 * Protected methods
+	 */
+	
+	/**
+	 * Allocate a new ByteBuffer with initial capacity and directness.
+	 * 
+	 * @param numEntities
+	 * @param isDirect
+	 * @return
+	 */
+	protected ByteBuffer allocateByteBuffer( int numEntities, boolean isDirect ) {
+		if(isDirect)
+			return ByteBuffer.allocateDirect( numEntities * getNumBytes() );
+		else
+			return ByteBuffer.allocate( numEntities * getNumBytes() );
+	}
+	
+	/**
+	 * Allocate a new BufferAccess specifying the directness and validity.
+	 * 
+	 * @param numEntities
+	 * @param isDirect
+	 * @param isValid
+	 * @return
+	 */
+	protected A allocate( int numEntities, boolean isDirect, boolean isValid) {
+		return newInstance( allocateByteBuffer(numEntities, isDirect), isValid );
+	}
+	
+	/**
+	 * Allocate a new BufferAccess using the current buffer's directness
+	 * and validity.
+	 * 
+	 * @param numEntities
+	 * @return
+	 */
+	protected A allocate( int numEntities ) {
+		return allocate( numEntities, isDirect(), isValid() );
+	}
+	
+	/*
+	 * Abstract methods
+	 */
+	
+	/**
+	 * Get number of bytes for a specific primitive type.
+	 * 
+	 * This usually retrieves a static field.
+	 */
+	public abstract int getNumBytes();
+	
+	/**
+	 * Create a new instance of this class given a Buffer of the same type.
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public abstract A newInstance(B buffer, boolean isValid );
+		
+	/**
+	 * Call Buffer.duplicate()
+	 * 
+	 * Buffer.duplicate() only exists in the interface since Java 9
+	 * https://docs.oracle.com/javase/9/docs/api/java/nio/Buffer.html#duplicate--
+	 * 
+	 * @return
+	 */
+	protected abstract B duplicateBuffer(B buffer);
+	
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -43,72 +43,79 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 /**
  * Base abstract class for {@link DataAccess} implementations that wrap
  * {@link Buffer}.
- * 
+ *
  * @author Mark Kittisopikul
  * @author Philipp Hanslovsky (initial specification)
  *
- * @param <A> Subclass used as return type for 
- * {@link #newInstance(Buffer, boolean)} and
- * {@link #newInstance(ByteBuffer, boolean)}
- * 
- * @param <B> {@link Buffer} subclass
+ * @param <A>
+ *            Subclass used as return type for
+ *            {@link #newInstance(Buffer, boolean)} and
+ *            {@link #newInstance(ByteBuffer, boolean)}
+ *
+ * @param <B>
+ *            {@link Buffer} subclass
  */
-public abstract class AbstractBufferAccess <A extends AbstractBufferAccess< A, B >, B extends Buffer> implements BufferAccess< A > {
-	
+public abstract class AbstractBufferAccess< A extends AbstractBufferAccess< A, B >, B extends Buffer > implements BufferAccess< A >
+{
+
 	/**
 	 * Default valid setting if not specified
 	 */
 	protected final static boolean DEFAULT_IS_VALID = true;
-	
+
 	/**
 	 * If valid or not as per {@link VolatileAccess}.
 	 */
 	protected final boolean isValid;
 
 	protected final B buffer;
-	
+
 	/*
 	 * Constructors
 	 */
 
-	public AbstractBufferAccess(final B buffer, final boolean isValid) {
+	public AbstractBufferAccess( final B buffer, final boolean isValid )
+	{
 		this.buffer = buffer;
 		this.isValid = isValid;
 	}
-	
-	public AbstractBufferAccess(final B buffer) {
-		this(buffer, DEFAULT_IS_VALID);
+
+	public AbstractBufferAccess( final B buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
 	}
-	
-	public AbstractBufferAccess(final Function<Integer,B> allocate, final int numEntities) {
-		this( allocate.apply(numEntities) );
+
+	public AbstractBufferAccess( final Function< Integer, B > allocate, final int numEntities )
+	{
+		this( allocate.apply( numEntities ) );
 	}
-	
+
 	/*
 	 * Public methods
 	 */
-	
+
 	/**
-	 * Returns a new instance of BufferAccess with duplicated Buffer for
-	 * thread safety.
+	 * Returns a new instance of BufferAccess with duplicated Buffer for thread
+	 * safety.
 	 */
 	@Override
-	public A createView(Object o) {
-		return newInstance( duplicateBuffer(buffer), isValid() );
+	public A createView( final Object o )
+	{
+		return newInstance( duplicateBuffer( buffer ), isValid() );
 	}
-	
+
 	@Override
 	public boolean isValid()
 	{
 		return isValid;
 	}
-	
+
 	/**
-	 * Respects the directness of the buffer.
-	 * If this buffer is direct, then the new backing buffer is also direct.
+	 * Respects the directness of the buffer. If this buffer is direct, then the
+	 * new backing buffer is also direct.
 	 */
 	@Override
-	public A createArray( int numEntities )
+	public A createArray( final int numEntities )
 	{
 		return allocate( numEntities );
 	}
@@ -124,100 +131,106 @@ public abstract class AbstractBufferAccess <A extends AbstractBufferAccess< A, B
 
 	/**
 	 * Returns the Buffer's limit or zero if buffer is null.
-	 * 
+	 *
 	 * @see Buffer#limit()
 	 */
 	@Override
 	public int getArrayLength()
 	{
-		if( buffer == null )
+		if ( buffer == null )
 			return 0;
 		else
 			return buffer.limit();
 	}
-	
+
 	/**
 	 * Return the Buffer's directness or false is the buffer is null.
 	 */
 	@Override
-	public boolean isDirect() {
+	public boolean isDirect()
+	{
 		return buffer != null && buffer.isDirect();
 	}
-	
+
 	@Override
-	public boolean isReadOnly() {
+	public boolean isReadOnly()
+	{
 		return buffer.isReadOnly();
 	}
-	
+
 	/*
 	 * Protected methods
 	 */
-	
+
 	/**
 	 * Allocate a new ByteBuffer with initial capacity and directness.
-	 * 
+	 *
 	 * @param numEntities
 	 * @param isDirect
 	 * @return
 	 */
-	protected ByteBuffer allocateByteBuffer( int numEntities, boolean isDirect ) {
-		if(isDirect)
+	protected ByteBuffer allocateByteBuffer( final int numEntities, final boolean isDirect )
+	{
+		if ( isDirect )
 			return ByteBuffer.allocateDirect( numEntities * getNumBytesPerEntity() );
 		else
 			return ByteBuffer.allocate( numEntities * getNumBytesPerEntity() );
 	}
-	
+
 	/**
 	 * Allocate a new BufferAccess specifying the directness and validity.
-	 * 
+	 *
 	 * @param numEntities
 	 * @param isDirect
 	 * @param isValid
 	 * @return
 	 */
-	protected A allocate( int numEntities, boolean isDirect, boolean isValid) {
-		return newInstance( allocateByteBuffer(numEntities, isDirect), isValid );
+	protected A allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	{
+		return newInstance( allocateByteBuffer( numEntities, isDirect ), isValid );
 	}
-	
+
 	/**
-	 * Allocate a new BufferAccess using the current buffer's directness
-	 * and validity.
-	 * 
+	 * Allocate a new BufferAccess using the current buffer's directness and
+	 * validity.
+	 *
 	 * @param numEntities
 	 * @return
 	 */
-	protected A allocate( int numEntities ) {
+	protected A allocate( final int numEntities )
+	{
 		return allocate( numEntities, isDirect(), isValid() );
 	}
-	
+
 	/*
 	 * Abstract methods
 	 */
-	
+
 	/**
 	 * Get number of bytes for a specific primitive type.
-	 * 
+	 *
 	 * This usually retrieves a static field.
 	 */
+	@Override
 	public abstract int getNumBytesPerEntity();
-	
+
 	/**
 	 * Create a new instance of this class given a Buffer of the same type.
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
-	public abstract A newInstance(B buffer, boolean isValid );
-		
+	public abstract A newInstance( B buffer, boolean isValid );
+
 	/**
 	 * Call Buffer.duplicate()
-	 * 
+	 *
 	 * Buffer.duplicate() only exists in the interface since Java 9
 	 * https://docs.oracle.com/javase/9/docs/api/java/nio/Buffer.html#duplicate--
-	 * 
+	 *
 	 * @return
 	 */
-	protected abstract B duplicateBuffer(B buffer);
-	
+	protected abstract B duplicateBuffer( B buffer );
+
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
@@ -58,7 +58,7 @@ public abstract class AbstractBufferAccess <A extends AbstractBufferAccess< A, B
 	/**
 	 * Default valid setting if not specified
 	 */
-	protected static boolean DEFAULT_IS_VALID = true;
+	protected final static boolean DEFAULT_IS_VALID = true;
 	
 	/**
 	 * If valid or not as per {@link VolatileAccess}.
@@ -162,9 +162,9 @@ public abstract class AbstractBufferAccess <A extends AbstractBufferAccess< A, B
 	 */
 	protected ByteBuffer allocateByteBuffer( int numEntities, boolean isDirect ) {
 		if(isDirect)
-			return ByteBuffer.allocateDirect( numEntities * getNumBytes() );
+			return ByteBuffer.allocateDirect( numEntities * getNumBytesPerEntity() );
 		else
-			return ByteBuffer.allocate( numEntities * getNumBytes() );
+			return ByteBuffer.allocate( numEntities * getNumBytesPerEntity() );
 	}
 	
 	/**
@@ -199,7 +199,7 @@ public abstract class AbstractBufferAccess <A extends AbstractBufferAccess< A, B
 	 * 
 	 * This usually retrieves a static field.
 	 */
-	public abstract int getNumBytes();
+	public abstract int getNumBytesPerEntity();
 	
 	/**
 	 * Create a new instance of this class given a Buffer of the same type.

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+
+/**
+ * BufferAccess wraps java.nio.Buffer subclasses
+ * and implements {@link ArrayDataAccess} and {@link VolatileAccess}.
+ * 
+ * Subclasses should be able to be constructed from either a specific
+ * buffer (e.g. LongBuffer) or {@link ByteBuffer}.
+ * 
+ * @author Mark Kittisopikul
+ * @author Philipp Hanslovsky (initial specification)
+ */
+public interface BufferAccess < A > extends VolatileAccess, ArrayDataAccess< A > {
+	
+	/**
+	 * Determine if the underlying Buffer is allocated
+	 * direct (outside of the JVM).
+	 * 
+	 * @return true if the Buffer is direct.
+	 * @see Buffer#isDirect()
+	 */
+	public boolean isDirect();
+	
+	/**
+	 * Determine if data can be read only and not written
+	 * 
+	 * @return
+	 * @see Buffer#isReadOnly()
+	 */
+	public boolean isReadOnly();
+	
+	/**
+	 * Number of bytes for this type
+	 * 
+	 * @return
+	 */
+	public int getNumBytes();
+		
+	/**
+	 * Create a new instance from a ByteBuffer
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public A newInstance( ByteBuffer buffer, boolean isValid );
+		
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,48 +40,49 @@ import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 
 /**
- * BufferAccess wraps java.nio.Buffer subclasses
- * and implements {@link ArrayDataAccess} and {@link VolatileAccess}.
- * 
- * Subclasses should be able to be constructed from either a specific
- * buffer (e.g. LongBuffer) or {@link ByteBuffer}.
- * 
+ * BufferAccess wraps java.nio.Buffer subclasses and implements
+ * {@link ArrayDataAccess} and {@link VolatileAccess}.
+ *
+ * Subclasses should be able to be constructed from either a specific buffer
+ * (e.g. LongBuffer) or {@link ByteBuffer}.
+ *
  * @author Mark Kittisopikul
  * @author Philipp Hanslovsky (initial specification)
  */
-public interface BufferAccess < A > extends VolatileAccess, ArrayDataAccess< A > {
-	
+public interface BufferAccess< A > extends VolatileAccess, ArrayDataAccess< A >
+{
+
 	/**
-	 * Determine if the underlying Buffer is allocated
-	 * direct (outside of the JVM).
-	 * 
+	 * Determine if the underlying Buffer is allocated direct (outside of the
+	 * JVM).
+	 *
 	 * @return true if the Buffer is direct.
 	 * @see Buffer#isDirect()
 	 */
 	public boolean isDirect();
-	
+
 	/**
 	 * Determine if data can be read only and not written
-	 * 
+	 *
 	 * @return
 	 * @see Buffer#isReadOnly()
 	 */
 	public boolean isReadOnly();
-	
+
 	/**
 	 * Number of bytes for this type
-	 * 
+	 *
 	 * @return
 	 */
 	public int getNumBytesPerEntity();
-		
+
 	/**
 	 * Create a new instance from a ByteBuffer
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
 	public A newInstance( ByteBuffer buffer, boolean isValid );
-		
+
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
@@ -73,7 +73,7 @@ public interface BufferAccess < A > extends VolatileAccess, ArrayDataAccess< A >
 	 * 
 	 * @return
 	 */
-	public int getNumBytes();
+	public int getNumBytesPerEntity();
 		
 	/**
 	 * Create a new instance from a ByteBuffer

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,14 +40,14 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileByteAccess;
 
 /**
  * Access for {@link ByteBuffer}
- * 
+ *
  * @author Mark Kittisopikul
  */
 public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, ByteBuffer > implements VolatileByteAccess
 {
 
 	/**
-	 * Automatically generated 
+	 * Automatically generated
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
@@ -55,130 +55,148 @@ public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, By
 
 	public ByteBufferAccess( final ByteBuffer buffer, final boolean isValid )
 	{
-		super(buffer, isValid);
+		super( buffer, isValid );
 	}
-	
-	public ByteBufferAccess( final int numEntities, final boolean isValid ) {
-		super( ByteBuffer.allocate(numEntities), isValid );
+
+	public ByteBufferAccess( final int numEntities, final boolean isValid )
+	{
+		super( ByteBuffer.allocate( numEntities ), isValid );
 	}
-	
+
 	// Convenience constructors
-	
-	public ByteBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
-	public ByteBufferAccess() { this( (ByteBuffer) null, false); }
+
+	public ByteBufferAccess( final int numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public ByteBufferAccess()
+	{
+		this( ( ByteBuffer ) null, false );
+	}
 
 	/*
 	 * ByteAccess methods
 	 */
-	
+
 	@Override
-	public byte getValue( int index ) {
+	public byte getValue( final int index )
+	{
 		return buffer.get( index );
 	}
 
 	@Override
-	public void setValue( int index, byte value ) {
+	public void setValue( final int index, final byte value )
+	{
 		buffer.put( index, value );
 	}
-	
+
 	/*
 	 * AbstractBufferAccess methods
 	 */
 
 	@Override
-	public int getNumBytesPerEntity() {
+	public int getNumBytesPerEntity()
+	{
 		return NUM_BYTES_PER_ENTITY;
 	}
-	
+
 	@Override
-	public ByteBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
-		return fromByteBuffer(buffer, isValid);
+	public ByteBufferAccess newInstance( final ByteBuffer buffer, final boolean isValid )
+	{
+		return fromByteBuffer( buffer, isValid );
 	}
-	
+
 	@Override
-	protected ByteBuffer duplicateBuffer(ByteBuffer buffer) {
+	protected ByteBuffer duplicateBuffer( final ByteBuffer buffer )
+	{
 		return buffer.duplicate();
 	}
-	
+
 	/*
 	 * Static methods
 	 */
 
 	/**
 	 * Create a new ByteBufferAccess from a ByteBuffer
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
-	public static ByteBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
-		return new ByteBufferAccess(buffer, isValid);
+	public static ByteBufferAccess fromByteBuffer( final ByteBuffer buffer, final boolean isValid )
+	{
+		return new ByteBufferAccess( buffer, isValid );
 	}
 
-	
 	/*
 	 * Bulk convenience methods
-	 * 
-	 * These are not trivial because the buffer should be duplicated
-	 * to prevent changing the current buffer state. The duplicated
-	 * buffer is returned for chained operations.
+	 *
+	 * These are not trivial because the buffer should be duplicated to prevent
+	 * changing the current buffer state. The duplicated buffer is returned for
+	 * chained operations.
 	 */
-	
+
 	/**
 	 * Copy values into a {@link AbstractByteArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see ByteBuffer#get(byte[])
 	 */
-	public ByteBuffer getValues(final AbstractByteArray< ? > array) {
+	public ByteBuffer getValues( final AbstractByteArray< ? > array )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values into a {@link AbstractByteArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see ByteBuffer#get(byte[], int, int)
 	 */
-	public ByteBuffer getValues(final AbstractByteArray< ? > array, int offset, int length) {
+	public ByteBuffer getValues( final AbstractByteArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractByteArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see ByteBuffer#put(byte[])
 	 */
-	public ByteBuffer setValues(final AbstractByteArray< ? > array) {
+	public ByteBuffer setValues( final AbstractByteArray< ? > array )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractByteArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see ByteBuffer#put(byte[], int, int)
 	 */
-	public ByteBuffer setValues(final AbstractByteArray< ? > array, int offset, int length) {
+	public ByteBuffer setValues( final AbstractByteArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from another ByteBufferAccess.
-	 * 
+	 *
 	 * @param access
 	 * @return
 	 */
-	public ByteBuffer setValues(final ByteBufferAccess access) {
+	public ByteBuffer setValues( final ByteBufferAccess access )
+	{
 		return buffer.duplicate().put( access.getCurrentStorageArray() );
 	}
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
@@ -35,7 +35,7 @@ package net.imglib2.img.basictypeaccess.nio;
 
 import java.nio.ByteBuffer;
 
-import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.AbstractByteArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileByteAccess;
 
 /**
@@ -125,18 +125,18 @@ public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, By
 	 */
 	
 	/**
-	 * Copy values into a {@link ByteArray}.
+	 * Copy values into a {@link AbstractByteArray}.
 	 * 
 	 * @param array
 	 * @return
 	 * @see ByteBuffer#get(byte[])
 	 */
-	public ByteBuffer getValues(final ByteArray array) {
+	public ByteBuffer getValues(final AbstractByteArray< ? > array) {
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values into a {@link ByteArray}.
+	 * Copy values into a {@link AbstractByteArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -144,23 +144,23 @@ public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, By
 	 * @return
 	 * @see ByteBuffer#get(byte[], int, int)
 	 */
-	public ByteBuffer getValues(final ByteArray array, int offset, int length) {
+	public ByteBuffer getValues(final AbstractByteArray< ? > array, int offset, int length) {
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
 	
 	/**
-	 * Copy values from a {@link ByteArray}.
+	 * Copy values from a {@link AbstractByteArray}.
 	 * 
 	 * @param array
 	 * @return
-	 * @see ByteBuffer#put(ByteArray, int, int)
+	 * @see ByteBuffer#put(byte[])
 	 */
-	public ByteBuffer setValues(final ByteArray array) {
+	public ByteBuffer setValues(final AbstractByteArray< ? > array) {
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values from a {@link ByteArray}.
+	 * Copy values from a {@link AbstractByteArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -168,7 +168,7 @@ public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, By
 	 * @return
 	 * @see ByteBuffer#put(byte[], int, int)
 	 */
-	public ByteBuffer setValues(final ByteArray array, int offset, int length) {
+	public ByteBuffer setValues(final AbstractByteArray< ? > array, int offset, int length) {
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
 	

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
@@ -108,7 +108,7 @@ public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, By
 	}
 
 	@Override
-	protected ByteBuffer duplicateBuffer( final ByteBuffer buffer )
+	ByteBuffer duplicateBuffer( final ByteBuffer buffer )
 	{
 		return buffer.duplicate();
 	}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
@@ -51,7 +51,7 @@ public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, By
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
-	private static final int NUM_BYTES = Byte.BYTES;
+	private static final int NUM_BYTES_PER_ENTITY = Byte.BYTES;
 
 	public ByteBufferAccess( final ByteBuffer buffer, final boolean isValid )
 	{
@@ -86,10 +86,10 @@ public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, By
 	 */
 
 	@Override
-	public int getNumBytes() {
-		return NUM_BYTES;
+	public int getNumBytesPerEntity() {
+		return NUM_BYTES_PER_ENTITY;
 	}
-
+	
 	@Override
 	public ByteBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
 		return fromByteBuffer(buffer, isValid);

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ByteBufferAccess.java
@@ -1,0 +1,185 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Byteair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.ByteBuffer;
+
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileByteAccess;
+
+/**
+ * Access for {@link ByteBuffer}
+ * 
+ * @author Mark Kittisopikul
+ */
+public class ByteBufferAccess extends AbstractBufferAccess< ByteBufferAccess, ByteBuffer > implements VolatileByteAccess
+{
+
+	/**
+	 * Automatically generated 
+	 */
+	private static final long serialVersionUID = -7265085228179236189L;
+
+	private static final int NUM_BYTES = Byte.BYTES;
+
+	public ByteBufferAccess( final ByteBuffer buffer, final boolean isValid )
+	{
+		super(buffer, isValid);
+	}
+	
+	public ByteBufferAccess( final int numEntities, final boolean isValid ) {
+		super( ByteBuffer.allocate(numEntities), isValid );
+	}
+	
+	// Convenience constructors
+	
+	public ByteBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
+	public ByteBufferAccess() { this( (ByteBuffer) null, false); }
+
+	/*
+	 * ByteAccess methods
+	 */
+	
+	@Override
+	public byte getValue( int index ) {
+		return buffer.get( index );
+	}
+
+	@Override
+	public void setValue( int index, byte value ) {
+		buffer.put( index, value );
+	}
+	
+	/*
+	 * AbstractBufferAccess methods
+	 */
+
+	@Override
+	public int getNumBytes() {
+		return NUM_BYTES;
+	}
+
+	@Override
+	public ByteBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
+		return fromByteBuffer(buffer, isValid);
+	}
+	
+	@Override
+	protected ByteBuffer duplicateBuffer(ByteBuffer buffer) {
+		return buffer.duplicate();
+	}
+	
+	/*
+	 * Static methods
+	 */
+
+	/**
+	 * Create a new ByteBufferAccess from a ByteBuffer
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public static ByteBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
+		return new ByteBufferAccess(buffer, isValid);
+	}
+
+	
+	/*
+	 * Bulk convenience methods
+	 * 
+	 * These are not trivial because the buffer should be duplicated
+	 * to prevent changing the current buffer state. The duplicated
+	 * buffer is returned for chained operations.
+	 */
+	
+	/**
+	 * Copy values into a {@link ByteArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see ByteBuffer#get(byte[])
+	 */
+	public ByteBuffer getValues(final ByteArray array) {
+		return buffer.duplicate().get( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values into a {@link ByteArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see ByteBuffer#get(byte[], int, int)
+	 */
+	public ByteBuffer getValues(final ByteArray array, int offset, int length) {
+		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from a {@link ByteArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see ByteBuffer#put(ByteArray, int, int)
+	 */
+	public ByteBuffer setValues(final ByteArray array) {
+		return buffer.duplicate().put( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values from a {@link ByteArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see ByteBuffer#put(byte[], int, int)
+	 */
+	public ByteBuffer setValues(final ByteArray array, int offset, int length) {
+		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from another ByteBufferAccess.
+	 * 
+	 * @param access
+	 * @return
+	 */
+	public ByteBuffer setValues(final ByteBufferAccess access) {
+		return buffer.duplicate().put( access.getCurrentStorageArray() );
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
@@ -130,7 +130,7 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 	}
 
 	@Override
-	protected CharBuffer duplicateBuffer( final CharBuffer buffer )
+	CharBuffer duplicateBuffer( final CharBuffer buffer )
 	{
 		return buffer.duplicate();
 	}
@@ -140,7 +140,7 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected CharBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	CharBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
 	{
 		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
@@ -36,7 +36,7 @@ package net.imglib2.img.basictypeaccess.nio;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 
-import net.imglib2.img.basictypeaccess.array.CharArray;
+import net.imglib2.img.basictypeaccess.array.AbstractCharArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileCharAccess;
 
 /**
@@ -137,18 +137,18 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 	 */
 	
 	/**
-	 * Copy values into a {@link CharArray}.
+	 * Copy values into a {@link AbstractCharArray}.
 	 * 
 	 * @param array
 	 * @return
 	 * @see CharBuffer#get(char[])
 	 */
-	public CharBuffer getValues(final CharArray array) {
+	public CharBuffer getValues(final AbstractCharArray< ? > array) {
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values into a {@link CharArray}.
+	 * Copy values into a {@link AbstractCharArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -156,23 +156,23 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 	 * @return
 	 * @see CharBuffer#get(char[], int, int)
 	 */
-	public CharBuffer getValues(final CharArray array, int offset, int length) {
+	public CharBuffer getValues(final AbstractCharArray< ? > array, int offset, int length) {
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
 	
 	/**
-	 * Copy values from a {@link CharArray}.
+	 * Copy values from a {@link AbstractCharArray}.
 	 * 
 	 * @param array
 	 * @return
-	 * @see CharBuffer#put(CharArray, int, int)
+	 * @see CharBuffer#put(char[])
 	 */
-	public CharBuffer setValues(final CharArray array) {
+	public CharBuffer setValues(final AbstractCharArray< ? > array) {
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values from a {@link CharArray}.
+	 * Copy values from a {@link AbstractCharArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -180,7 +180,7 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 	 * @return
 	 * @see CharBuffer#put(char[], int, int)
 	 */
-	public CharBuffer setValues(final CharArray array, int offset, int length) {
+	public CharBuffer setValues(final AbstractCharArray< ? > array, int offset, int length) {
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
 	

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
@@ -1,0 +1,197 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Charair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+
+import net.imglib2.img.basictypeaccess.array.CharArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileCharAccess;
+
+/**
+ * Access for {@link CharBuffer}
+ * 
+ * @author Mark Kittisopikul
+ */
+public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, CharBuffer > implements VolatileCharAccess
+{
+
+	/**
+	 * Automatically generated 
+	 */
+	private static final long serialVersionUID = -7265085228179236189L;
+
+	private static final int NUM_BYTES = Character.BYTES;
+
+	public CharBufferAccess( final CharBuffer buffer, final boolean isValid )
+	{
+		super(buffer, isValid);
+	}
+	
+	public CharBufferAccess( final int numEntities, final boolean isValid ) {
+		super( CharBuffer.allocate(numEntities), isValid );
+	}
+	
+	public CharBufferAccess( final ByteBuffer buffer, boolean isValid) {
+		super(buffer.asCharBuffer(), isValid);
+	}
+	
+	// Convenience constructors
+	
+	public CharBufferAccess( final CharBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
+	public CharBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
+	public CharBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
+	public CharBufferAccess() { this( (CharBuffer) null, false); }
+
+	/*
+	 * CharAccess methods
+	 */
+	
+	@Override
+	public char getValue( int index ) {
+		return buffer.get( index );
+	}
+
+	@Override
+	public void setValue( int index, char value ) {
+		buffer.put( index, value );
+	}
+	
+	/*
+	 * AbstractBufferAccess methods
+	 */
+
+	@Override
+	public int getNumBytes() {
+		return NUM_BYTES;
+	}
+
+	@Override
+	public CharBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
+		return fromByteBuffer(buffer, isValid);
+	}
+	
+	@Override
+	public CharBufferAccess newInstance(CharBuffer buffer, boolean isValid) {
+		return new CharBufferAccess(buffer, isValid);
+	}
+	
+	@Override
+	protected CharBuffer duplicateBuffer(CharBuffer buffer) {
+		return buffer.duplicate();
+	}
+	
+	/*
+	 * Static methods
+	 */
+
+	/**
+	 * Create a new CharBufferAccess from a ByteBuffer
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public static CharBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
+		return new CharBufferAccess(buffer, isValid);
+	}
+
+	
+	/*
+	 * Bulk convenience methods
+	 * 
+	 * These are not trivial because the buffer should be duplicated
+	 * to prevent changing the current buffer state. The duplicated
+	 * buffer is returned for chained operations.
+	 */
+	
+	/**
+	 * Copy values into a {@link CharArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see CharBuffer#get(char[])
+	 */
+	public CharBuffer getValues(final CharArray array) {
+		return buffer.duplicate().get( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values into a {@link CharArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see CharBuffer#get(char[], int, int)
+	 */
+	public CharBuffer getValues(final CharArray array, int offset, int length) {
+		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from a {@link CharArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see CharBuffer#put(CharArray, int, int)
+	 */
+	public CharBuffer setValues(final CharArray array) {
+		return buffer.duplicate().put( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values from a {@link CharArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see CharBuffer#put(char[], int, int)
+	 */
+	public CharBuffer setValues(final CharArray array, int offset, int length) {
+		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from another CharBufferAccess.
+	 * 
+	 * @param access
+	 * @return
+	 */
+	public CharBuffer setValues(final CharBufferAccess access) {
+		return buffer.duplicate().put( access.getCurrentStorageArray() );
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -41,14 +41,14 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileCharAccess;
 
 /**
  * Access for {@link CharBuffer}
- * 
+ *
  * @author Mark Kittisopikul
  */
 public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, CharBuffer > implements VolatileCharAccess
 {
 
 	/**
-	 * Automatically generated 
+	 * Automatically generated
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
@@ -56,153 +56,182 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 
 	public CharBufferAccess( final CharBuffer buffer, final boolean isValid )
 	{
-		super(buffer, isValid);
+		super( buffer, isValid );
 	}
-	
-	public CharBufferAccess( final int numEntities, final boolean isValid ) {
-		super( CharBuffer.allocate(numEntities), isValid );
+
+	public CharBufferAccess( final int numEntities, final boolean isValid )
+	{
+		super( CharBuffer.allocate( numEntities ), isValid );
 	}
-	
-	public CharBufferAccess( final ByteBuffer buffer, boolean isValid) {
-		super(buffer.asCharBuffer(), isValid);
+
+	public CharBufferAccess( final ByteBuffer buffer, final boolean isValid )
+	{
+		super( buffer.asCharBuffer(), isValid );
 	}
-	
+
 	// Convenience constructors
-	
-	public CharBufferAccess( final CharBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
-	public CharBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
-	public CharBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
-	public CharBufferAccess() { this( (CharBuffer) null, false); }
+
+	public CharBufferAccess( final CharBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public CharBufferAccess( final int numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public CharBufferAccess( final ByteBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public CharBufferAccess()
+	{
+		this( ( CharBuffer ) null, false );
+	}
 
 	/*
 	 * CharAccess methods
 	 */
-	
+
 	@Override
-	public char getValue( int index ) {
+	public char getValue( final int index )
+	{
 		return buffer.get( index );
 	}
 
 	@Override
-	public void setValue( int index, char value ) {
+	public void setValue( final int index, final char value )
+	{
 		buffer.put( index, value );
 	}
-	
+
 	/*
 	 * AbstractBufferAccess methods
 	 */
 
 	@Override
-	public int getNumBytesPerEntity() {
+	public int getNumBytesPerEntity()
+	{
 		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
-	public CharBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
-		return fromByteBuffer(buffer, isValid);
+	public CharBufferAccess newInstance( final ByteBuffer buffer, final boolean isValid )
+	{
+		return fromByteBuffer( buffer, isValid );
 	}
-	
+
 	@Override
-	public CharBufferAccess newInstance(CharBuffer buffer, boolean isValid) {
-		return new CharBufferAccess(buffer, isValid);
+	public CharBufferAccess newInstance( final CharBuffer buffer, final boolean isValid )
+	{
+		return new CharBufferAccess( buffer, isValid );
 	}
-	
+
 	@Override
-	protected CharBuffer duplicateBuffer(CharBuffer buffer) {
+	protected CharBuffer duplicateBuffer( final CharBuffer buffer )
+	{
 		return buffer.duplicate();
 	}
-	
+
 	/**
-	 * Override abstract implementation to allow for longer non-direct Buffers since
-	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 * Override abstract implementation to allow for longer non-direct Buffers
+	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected CharBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
-		if(isDirect)
+	protected CharBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	{
+		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );
 		else
 			return new CharBufferAccess( numEntities, isValid );
 	}
-	
+
 	/*
 	 * Static methods
 	 */
 
 	/**
 	 * Create a new CharBufferAccess from a ByteBuffer
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
-	public static CharBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
-		return new CharBufferAccess(buffer, isValid);
+	public static CharBufferAccess fromByteBuffer( final ByteBuffer buffer, final boolean isValid )
+	{
+		return new CharBufferAccess( buffer, isValid );
 	}
 
-	
 	/*
 	 * Bulk convenience methods
-	 * 
-	 * These are not trivial because the buffer should be duplicated
-	 * to prevent changing the current buffer state. The duplicated
-	 * buffer is returned for chained operations.
+	 *
+	 * These are not trivial because the buffer should be duplicated to prevent
+	 * changing the current buffer state. The duplicated buffer is returned for
+	 * chained operations.
 	 */
-	
+
 	/**
 	 * Copy values into a {@link AbstractCharArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see CharBuffer#get(char[])
 	 */
-	public CharBuffer getValues(final AbstractCharArray< ? > array) {
+	public CharBuffer getValues( final AbstractCharArray< ? > array )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values into a {@link AbstractCharArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see CharBuffer#get(char[], int, int)
 	 */
-	public CharBuffer getValues(final AbstractCharArray< ? > array, int offset, int length) {
+	public CharBuffer getValues( final AbstractCharArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractCharArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see CharBuffer#put(char[])
 	 */
-	public CharBuffer setValues(final AbstractCharArray< ? > array) {
+	public CharBuffer setValues( final AbstractCharArray< ? > array )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractCharArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see CharBuffer#put(char[], int, int)
 	 */
-	public CharBuffer setValues(final AbstractCharArray< ? > array, int offset, int length) {
+	public CharBuffer setValues( final AbstractCharArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from another CharBufferAccess.
-	 * 
+	 *
 	 * @param access
 	 * @return
 	 */
-	public CharBuffer setValues(final CharBufferAccess access) {
+	public CharBuffer setValues( final CharBufferAccess access )
+	{
 		return buffer.duplicate().put( access.getCurrentStorageArray() );
 	}
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/CharBufferAccess.java
@@ -52,7 +52,7 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
-	private static final int NUM_BYTES = Character.BYTES;
+	private static final int NUM_BYTES_PER_ENTITY = Character.BYTES;
 
 	public CharBufferAccess( final CharBuffer buffer, final boolean isValid )
 	{
@@ -93,8 +93,8 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 	 */
 
 	@Override
-	public int getNumBytes() {
-		return NUM_BYTES;
+	public int getNumBytesPerEntity() {
+		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
@@ -110,6 +110,18 @@ public class CharBufferAccess extends AbstractBufferAccess< CharBufferAccess, Ch
 	@Override
 	protected CharBuffer duplicateBuffer(CharBuffer buffer) {
 		return buffer.duplicate();
+	}
+	
+	/**
+	 * Override abstract implementation to allow for longer non-direct Buffers since
+	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 */
+	@Override
+	protected CharBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
+		if(isDirect)
+			return super.allocate( numEntities, isDirect, isValid );
+		else
+			return new CharBufferAccess( numEntities, isValid );
 	}
 	
 	/*

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -41,14 +41,14 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileDoubleAccess;
 
 /**
  * Access for {@link DoubleBuffer}
- * 
+ *
  * @author Mark Kittisopikul
  */
 public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess, DoubleBuffer > implements VolatileDoubleAccess
 {
 
 	/**
-	 * Automatically generated 
+	 * Automatically generated
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
@@ -56,153 +56,182 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 
 	public DoubleBufferAccess( final DoubleBuffer buffer, final boolean isValid )
 	{
-		super(buffer, isValid);
+		super( buffer, isValid );
 	}
-	
-	public DoubleBufferAccess( final int numEntities, final boolean isValid ) {
-		super( DoubleBuffer.allocate(numEntities), isValid );
+
+	public DoubleBufferAccess( final int numEntities, final boolean isValid )
+	{
+		super( DoubleBuffer.allocate( numEntities ), isValid );
 	}
-	
-	public DoubleBufferAccess( final ByteBuffer buffer, boolean isValid) {
-		super(buffer.asDoubleBuffer(), isValid);
+
+	public DoubleBufferAccess( final ByteBuffer buffer, final boolean isValid )
+	{
+		super( buffer.asDoubleBuffer(), isValid );
 	}
-	
+
 	// Convenience constructors
-	
-	public DoubleBufferAccess( final DoubleBuffer buffer ) { this(buffer,    DEFAULT_IS_VALID); }
-	public DoubleBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
-	public DoubleBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
-	public DoubleBufferAccess() { this( (DoubleBuffer) null, false); }
+
+	public DoubleBufferAccess( final DoubleBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public DoubleBufferAccess( final int numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public DoubleBufferAccess( final ByteBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public DoubleBufferAccess()
+	{
+		this( ( DoubleBuffer ) null, false );
+	}
 
 	/*
 	 * DoubleAccess methods
 	 */
-	
+
 	@Override
-	public double getValue( int index ) {
+	public double getValue( final int index )
+	{
 		return buffer.get( index );
 	}
 
 	@Override
-	public void setValue( int index, double value ) {
+	public void setValue( final int index, final double value )
+	{
 		buffer.put( index, value );
 	}
-	
+
 	/*
 	 * AbstractBufferAccess methods
 	 */
 
 	@Override
-	public int getNumBytesPerEntity() {
+	public int getNumBytesPerEntity()
+	{
 		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
-	public DoubleBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
-		return fromByteBuffer(buffer, isValid);
+	public DoubleBufferAccess newInstance( final ByteBuffer buffer, final boolean isValid )
+	{
+		return fromByteBuffer( buffer, isValid );
 	}
-	
+
 	@Override
-	public DoubleBufferAccess newInstance(DoubleBuffer buffer, boolean isValid) {
-		return new DoubleBufferAccess(buffer, isValid);
+	public DoubleBufferAccess newInstance( final DoubleBuffer buffer, final boolean isValid )
+	{
+		return new DoubleBufferAccess( buffer, isValid );
 	}
-	
+
 	@Override
-	protected DoubleBuffer duplicateBuffer(DoubleBuffer buffer) {
+	protected DoubleBuffer duplicateBuffer( final DoubleBuffer buffer )
+	{
 		return buffer.duplicate();
 	}
-	
+
 	/**
-	 * Override abstract implementation to allow for longer non-direct Buffers since
-	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 * Override abstract implementation to allow for longer non-direct Buffers
+	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected DoubleBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
-		if(isDirect)
+	protected DoubleBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	{
+		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );
 		else
 			return new DoubleBufferAccess( numEntities, isValid );
 	}
-	
+
 	/*
 	 * Static methods
 	 */
 
 	/**
 	 * Create a new DoubleBufferAccess from a ByteBuffer
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
-	public static DoubleBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
-		return new DoubleBufferAccess(buffer, isValid);
+	public static DoubleBufferAccess fromByteBuffer( final ByteBuffer buffer, final boolean isValid )
+	{
+		return new DoubleBufferAccess( buffer, isValid );
 	}
 
-	
 	/*
 	 * Bulk convenience methods
-	 * 
-	 * These are not trivial because the buffer should be duplicated
-	 * to prevent changing the current buffer state. The duplicated
-	 * buffer is returned for chained operations.
+	 *
+	 * These are not trivial because the buffer should be duplicated to prevent
+	 * changing the current buffer state. The duplicated buffer is returned for
+	 * chained operations.
 	 */
-	
+
 	/**
 	 * Copy values into a {@link AbstractDoubleArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see DoubleBuffer#get(double[])
 	 */
-	public DoubleBuffer getValues(final AbstractDoubleArray< ? > array) {
+	public DoubleBuffer getValues( final AbstractDoubleArray< ? > array )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values into a {@link AbstractDoubleArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see DoubleBuffer#get(double[], int, int)
 	 */
-	public DoubleBuffer getValues(final AbstractDoubleArray< ? > array, int offset, int length) {
+	public DoubleBuffer getValues( final AbstractDoubleArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractDoubleArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see DoubleBuffer#put(double[])
 	 */
-	public DoubleBuffer setValues(final AbstractDoubleArray< ? > array) {
+	public DoubleBuffer setValues( final AbstractDoubleArray< ? > array )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractDoubleArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see DoubleBuffer#put(double[], int, int)
 	 */
-	public DoubleBuffer setValues(final AbstractDoubleArray< ? > array, int offset, int length) {
+	public DoubleBuffer setValues( final AbstractDoubleArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from another DoubleBufferAccess.
-	 * 
+	 *
 	 * @param access
 	 * @return
 	 */
-	public DoubleBuffer setValues(final DoubleBufferAccess access) {
+	public DoubleBuffer setValues( final DoubleBufferAccess access )
+	{
 		return buffer.duplicate().put( access.getCurrentStorageArray() );
 	}
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
@@ -130,7 +130,7 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 	}
 
 	@Override
-	protected DoubleBuffer duplicateBuffer( final DoubleBuffer buffer )
+	DoubleBuffer duplicateBuffer( final DoubleBuffer buffer )
 	{
 		return buffer.duplicate();
 	}
@@ -140,7 +140,7 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected DoubleBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	DoubleBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
 	{
 		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
@@ -1,0 +1,197 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Doubleair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileDoubleAccess;
+
+/**
+ * Access for {@link DoubleBuffer}
+ * 
+ * @author Mark Kittisopikul
+ */
+public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess, DoubleBuffer > implements VolatileDoubleAccess
+{
+
+	/**
+	 * Automatically generated 
+	 */
+	private static final long serialVersionUID = -7265085228179236189L;
+
+	private static final int NUM_BYTES = Double.BYTES;
+
+	public DoubleBufferAccess( final DoubleBuffer buffer, final boolean isValid )
+	{
+		super(buffer, isValid);
+	}
+	
+	public DoubleBufferAccess( final int numEntities, final boolean isValid ) {
+		super( DoubleBuffer.allocate(numEntities), isValid );
+	}
+	
+	public DoubleBufferAccess( final ByteBuffer buffer, boolean isValid) {
+		super(buffer.asDoubleBuffer(), isValid);
+	}
+	
+	// Convenience constructors
+	
+	public DoubleBufferAccess( final DoubleBuffer buffer ) { this(buffer,    DEFAULT_IS_VALID); }
+	public DoubleBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
+	public DoubleBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
+	public DoubleBufferAccess() { this( (DoubleBuffer) null, false); }
+
+	/*
+	 * DoubleAccess methods
+	 */
+	
+	@Override
+	public double getValue( int index ) {
+		return buffer.get( index );
+	}
+
+	@Override
+	public void setValue( int index, double value ) {
+		buffer.put( index, value );
+	}
+	
+	/*
+	 * AbstractBufferAccess methods
+	 */
+
+	@Override
+	public int getNumBytes() {
+		return NUM_BYTES;
+	}
+
+	@Override
+	public DoubleBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
+		return fromByteBuffer(buffer, isValid);
+	}
+	
+	@Override
+	public DoubleBufferAccess newInstance(DoubleBuffer buffer, boolean isValid) {
+		return new DoubleBufferAccess(buffer, isValid);
+	}
+	
+	@Override
+	protected DoubleBuffer duplicateBuffer(DoubleBuffer buffer) {
+		return buffer.duplicate();
+	}
+	
+	/*
+	 * Static methods
+	 */
+
+	/**
+	 * Create a new DoubleBufferAccess from a ByteBuffer
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public static DoubleBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
+		return new DoubleBufferAccess(buffer, isValid);
+	}
+
+	
+	/*
+	 * Bulk convenience methods
+	 * 
+	 * These are not trivial because the buffer should be duplicated
+	 * to prevent changing the current buffer state. The duplicated
+	 * buffer is returned for chained operations.
+	 */
+	
+	/**
+	 * Copy values into a {@link DoubleArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see DoubleBuffer#get(double[])
+	 */
+	public DoubleBuffer getValues(final DoubleArray array) {
+		return buffer.duplicate().get( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values into a {@link DoubleArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see DoubleBuffer#get(double[], int, int)
+	 */
+	public DoubleBuffer getValues(final DoubleArray array, int offset, int length) {
+		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from a {@link DoubleArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see DoubleBuffer#put(DoubleArray, int, int)
+	 */
+	public DoubleBuffer setValues(final DoubleArray array) {
+		return buffer.duplicate().put( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values from a {@link DoubleArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see DoubleBuffer#put(double[], int, int)
+	 */
+	public DoubleBuffer setValues(final DoubleArray array, int offset, int length) {
+		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from another DoubleBufferAccess.
+	 * 
+	 * @param access
+	 * @return
+	 */
+	public DoubleBuffer setValues(final DoubleBufferAccess access) {
+		return buffer.duplicate().put( access.getCurrentStorageArray() );
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
@@ -52,7 +52,7 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
-	private static final int NUM_BYTES = Double.BYTES;
+	private static final int NUM_BYTES_PER_ENTITY = Double.BYTES;
 
 	public DoubleBufferAccess( final DoubleBuffer buffer, final boolean isValid )
 	{
@@ -93,8 +93,8 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 	 */
 
 	@Override
-	public int getNumBytes() {
-		return NUM_BYTES;
+	public int getNumBytesPerEntity() {
+		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
@@ -110,6 +110,18 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 	@Override
 	protected DoubleBuffer duplicateBuffer(DoubleBuffer buffer) {
 		return buffer.duplicate();
+	}
+	
+	/**
+	 * Override abstract implementation to allow for longer non-direct Buffers since
+	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 */
+	@Override
+	protected DoubleBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
+		if(isDirect)
+			return super.allocate( numEntities, isDirect, isValid );
+		else
+			return new DoubleBufferAccess( numEntities, isValid );
 	}
 	
 	/*

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/DoubleBufferAccess.java
@@ -36,7 +36,7 @@ package net.imglib2.img.basictypeaccess.nio;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 
-import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.AbstractDoubleArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileDoubleAccess;
 
 /**
@@ -137,18 +137,18 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 	 */
 	
 	/**
-	 * Copy values into a {@link DoubleArray}.
+	 * Copy values into a {@link AbstractDoubleArray}.
 	 * 
 	 * @param array
 	 * @return
 	 * @see DoubleBuffer#get(double[])
 	 */
-	public DoubleBuffer getValues(final DoubleArray array) {
+	public DoubleBuffer getValues(final AbstractDoubleArray< ? > array) {
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values into a {@link DoubleArray}.
+	 * Copy values into a {@link AbstractDoubleArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -156,23 +156,23 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 	 * @return
 	 * @see DoubleBuffer#get(double[], int, int)
 	 */
-	public DoubleBuffer getValues(final DoubleArray array, int offset, int length) {
+	public DoubleBuffer getValues(final AbstractDoubleArray< ? > array, int offset, int length) {
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
 	
 	/**
-	 * Copy values from a {@link DoubleArray}.
+	 * Copy values from a {@link AbstractDoubleArray}.
 	 * 
 	 * @param array
 	 * @return
-	 * @see DoubleBuffer#put(DoubleArray, int, int)
+	 * @see DoubleBuffer#put(double[])
 	 */
-	public DoubleBuffer setValues(final DoubleArray array) {
+	public DoubleBuffer setValues(final AbstractDoubleArray< ? > array) {
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values from a {@link DoubleArray}.
+	 * Copy values from a {@link AbstractDoubleArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -180,7 +180,7 @@ public class DoubleBufferAccess extends AbstractBufferAccess< DoubleBufferAccess
 	 * @return
 	 * @see DoubleBuffer#put(double[], int, int)
 	 */
-	public DoubleBuffer setValues(final DoubleArray array, int offset, int length) {
+	public DoubleBuffer setValues(final AbstractDoubleArray< ? > array, int offset, int length) {
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
 	

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
@@ -52,7 +52,7 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
-	private static final int NUM_BYTES = Float.BYTES;
+	private static final int NUM_BYTES_PER_ENTITY = Float.BYTES;
 
 	public FloatBufferAccess( final FloatBuffer buffer, final boolean isValid )
 	{
@@ -93,8 +93,8 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 	 */
 
 	@Override
-	public int getNumBytes() {
-		return NUM_BYTES;
+	public int getNumBytesPerEntity() {
+		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
@@ -110,6 +110,18 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 	@Override
 	protected FloatBuffer duplicateBuffer(FloatBuffer buffer) {
 		return buffer.duplicate();
+	}
+	
+	/**
+	 * Override abstract implementation to allow for longer non-direct Buffers since
+	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 */
+	@Override
+	protected FloatBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
+		if(isDirect)
+			return super.allocate( numEntities, isDirect, isValid );
+		else
+			return new FloatBufferAccess( numEntities, isValid );
 	}
 	
 	/*

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
@@ -36,7 +36,7 @@ package net.imglib2.img.basictypeaccess.nio;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
-import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.AbstractFloatArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileFloatAccess;
 
 /**
@@ -137,18 +137,18 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 	 */
 	
 	/**
-	 * Copy values into a {@link FloatArray}.
+	 * Copy values into a {@link AbstractFloatArray}.
 	 * 
 	 * @param array
 	 * @return
 	 * @see FloatBuffer#get(float[])
 	 */
-	public FloatBuffer getValues(final FloatArray array) {
+	public FloatBuffer getValues(final AbstractFloatArray< ? > array) {
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values into a {@link FloatArray}.
+	 * Copy values into a {@link AbstractFloatArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -156,23 +156,23 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 	 * @return
 	 * @see FloatBuffer#get(float[], int, int)
 	 */
-	public FloatBuffer getValues(final FloatArray array, int offset, int length) {
+	public FloatBuffer getValues(final AbstractFloatArray< ? > array, int offset, int length) {
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
 	
 	/**
-	 * Copy values from a {@link FloatArray}.
+	 * Copy values from a {@link AbstractFloatArray}.
 	 * 
 	 * @param array
 	 * @return
-	 * @see FloatBuffer#put(FloatArray, int, int)
+	 * @see FloatBuffer#put(float[])
 	 */
-	public FloatBuffer setValues(final FloatArray array) {
+	public FloatBuffer setValues(final AbstractFloatArray< ? > array) {
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values from a {@link FloatArray}.
+	 * Copy values from a {@link AbstractFloatArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -180,7 +180,7 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 	 * @return
 	 * @see FloatBuffer#put(float[], int, int)
 	 */
-	public FloatBuffer setValues(final FloatArray array, int offset, int length) {
+	public FloatBuffer setValues(final AbstractFloatArray< ? > array, int offset, int length) {
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
 	

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
@@ -130,7 +130,7 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 	}
 
 	@Override
-	protected FloatBuffer duplicateBuffer( final FloatBuffer buffer )
+	FloatBuffer duplicateBuffer( final FloatBuffer buffer )
 	{
 		return buffer.duplicate();
 	}
@@ -140,7 +140,7 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected FloatBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	FloatBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
 	{
 		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
@@ -1,0 +1,197 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Floatair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileFloatAccess;
+
+/**
+ * Access for {@link FloatBuffer}
+ * 
+ * @author Mark Kittisopikul
+ */
+public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, FloatBuffer > implements VolatileFloatAccess
+{
+
+	/**
+	 * Automatically generated 
+	 */
+	private static final long serialVersionUID = -7265085228179236189L;
+
+	private static final int NUM_BYTES = Float.BYTES;
+
+	public FloatBufferAccess( final FloatBuffer buffer, final boolean isValid )
+	{
+		super(buffer, isValid);
+	}
+	
+	public FloatBufferAccess( final int numEntities, final boolean isValid ) {
+		super( FloatBuffer.allocate(numEntities), isValid );
+	}
+	
+	public FloatBufferAccess( final ByteBuffer buffer, boolean isValid) {
+		super(buffer.asFloatBuffer(), isValid);
+	}
+	
+	// Convenience constructors
+	
+	public FloatBufferAccess( final FloatBuffer buffer ) { this(buffer,     DEFAULT_IS_VALID); }
+	public FloatBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
+	public FloatBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
+	public FloatBufferAccess() { this( (FloatBuffer) null, false); }
+
+	/*
+	 * FloatAccess methods
+	 */
+	
+	@Override
+	public float getValue( int index ) {
+		return buffer.get( index );
+	}
+
+	@Override
+	public void setValue( int index, float value ) {
+		buffer.put( index, value );
+	}
+	
+	/*
+	 * AbstractBufferAccess methods
+	 */
+
+	@Override
+	public int getNumBytes() {
+		return NUM_BYTES;
+	}
+
+	@Override
+	public FloatBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
+		return fromByteBuffer(buffer, isValid);
+	}
+	
+	@Override
+	public FloatBufferAccess newInstance(FloatBuffer buffer, boolean isValid) {
+		return new FloatBufferAccess(buffer, isValid);
+	}
+	
+	@Override
+	protected FloatBuffer duplicateBuffer(FloatBuffer buffer) {
+		return buffer.duplicate();
+	}
+	
+	/*
+	 * Static methods
+	 */
+
+	/**
+	 * Create a new FloatBufferAccess from a ByteBuffer
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public static FloatBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
+		return new FloatBufferAccess(buffer, isValid);
+	}
+
+	
+	/*
+	 * Bulk convenience methods
+	 * 
+	 * These are not trivial because the buffer should be duplicated
+	 * to prevent changing the current buffer state. The duplicated
+	 * buffer is returned for chained operations.
+	 */
+	
+	/**
+	 * Copy values into a {@link FloatArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see FloatBuffer#get(float[])
+	 */
+	public FloatBuffer getValues(final FloatArray array) {
+		return buffer.duplicate().get( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values into a {@link FloatArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see FloatBuffer#get(float[], int, int)
+	 */
+	public FloatBuffer getValues(final FloatArray array, int offset, int length) {
+		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from a {@link FloatArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see FloatBuffer#put(FloatArray, int, int)
+	 */
+	public FloatBuffer setValues(final FloatArray array) {
+		return buffer.duplicate().put( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values from a {@link FloatArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see FloatBuffer#put(float[], int, int)
+	 */
+	public FloatBuffer setValues(final FloatArray array, int offset, int length) {
+		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from another FloatBufferAccess.
+	 * 
+	 * @param access
+	 * @return
+	 */
+	public FloatBuffer setValues(final FloatBufferAccess access) {
+		return buffer.duplicate().put( access.getCurrentStorageArray() );
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/FloatBufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -41,14 +41,14 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileFloatAccess;
 
 /**
  * Access for {@link FloatBuffer}
- * 
+ *
  * @author Mark Kittisopikul
  */
 public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, FloatBuffer > implements VolatileFloatAccess
 {
 
 	/**
-	 * Automatically generated 
+	 * Automatically generated
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
@@ -56,153 +56,182 @@ public class FloatBufferAccess extends AbstractBufferAccess< FloatBufferAccess, 
 
 	public FloatBufferAccess( final FloatBuffer buffer, final boolean isValid )
 	{
-		super(buffer, isValid);
+		super( buffer, isValid );
 	}
-	
-	public FloatBufferAccess( final int numEntities, final boolean isValid ) {
-		super( FloatBuffer.allocate(numEntities), isValid );
+
+	public FloatBufferAccess( final int numEntities, final boolean isValid )
+	{
+		super( FloatBuffer.allocate( numEntities ), isValid );
 	}
-	
-	public FloatBufferAccess( final ByteBuffer buffer, boolean isValid) {
-		super(buffer.asFloatBuffer(), isValid);
+
+	public FloatBufferAccess( final ByteBuffer buffer, final boolean isValid )
+	{
+		super( buffer.asFloatBuffer(), isValid );
 	}
-	
+
 	// Convenience constructors
-	
-	public FloatBufferAccess( final FloatBuffer buffer ) { this(buffer,     DEFAULT_IS_VALID); }
-	public FloatBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
-	public FloatBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
-	public FloatBufferAccess() { this( (FloatBuffer) null, false); }
+
+	public FloatBufferAccess( final FloatBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public FloatBufferAccess( final int numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public FloatBufferAccess( final ByteBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public FloatBufferAccess()
+	{
+		this( ( FloatBuffer ) null, false );
+	}
 
 	/*
 	 * FloatAccess methods
 	 */
-	
+
 	@Override
-	public float getValue( int index ) {
+	public float getValue( final int index )
+	{
 		return buffer.get( index );
 	}
 
 	@Override
-	public void setValue( int index, float value ) {
+	public void setValue( final int index, final float value )
+	{
 		buffer.put( index, value );
 	}
-	
+
 	/*
 	 * AbstractBufferAccess methods
 	 */
 
 	@Override
-	public int getNumBytesPerEntity() {
+	public int getNumBytesPerEntity()
+	{
 		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
-	public FloatBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
-		return fromByteBuffer(buffer, isValid);
+	public FloatBufferAccess newInstance( final ByteBuffer buffer, final boolean isValid )
+	{
+		return fromByteBuffer( buffer, isValid );
 	}
-	
+
 	@Override
-	public FloatBufferAccess newInstance(FloatBuffer buffer, boolean isValid) {
-		return new FloatBufferAccess(buffer, isValid);
+	public FloatBufferAccess newInstance( final FloatBuffer buffer, final boolean isValid )
+	{
+		return new FloatBufferAccess( buffer, isValid );
 	}
-	
+
 	@Override
-	protected FloatBuffer duplicateBuffer(FloatBuffer buffer) {
+	protected FloatBuffer duplicateBuffer( final FloatBuffer buffer )
+	{
 		return buffer.duplicate();
 	}
-	
+
 	/**
-	 * Override abstract implementation to allow for longer non-direct Buffers since
-	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 * Override abstract implementation to allow for longer non-direct Buffers
+	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected FloatBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
-		if(isDirect)
+	protected FloatBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	{
+		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );
 		else
 			return new FloatBufferAccess( numEntities, isValid );
 	}
-	
+
 	/*
 	 * Static methods
 	 */
 
 	/**
 	 * Create a new FloatBufferAccess from a ByteBuffer
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
-	public static FloatBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
-		return new FloatBufferAccess(buffer, isValid);
+	public static FloatBufferAccess fromByteBuffer( final ByteBuffer buffer, final boolean isValid )
+	{
+		return new FloatBufferAccess( buffer, isValid );
 	}
 
-	
 	/*
 	 * Bulk convenience methods
-	 * 
-	 * These are not trivial because the buffer should be duplicated
-	 * to prevent changing the current buffer state. The duplicated
-	 * buffer is returned for chained operations.
+	 *
+	 * These are not trivial because the buffer should be duplicated to prevent
+	 * changing the current buffer state. The duplicated buffer is returned for
+	 * chained operations.
 	 */
-	
+
 	/**
 	 * Copy values into a {@link AbstractFloatArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see FloatBuffer#get(float[])
 	 */
-	public FloatBuffer getValues(final AbstractFloatArray< ? > array) {
+	public FloatBuffer getValues( final AbstractFloatArray< ? > array )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values into a {@link AbstractFloatArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see FloatBuffer#get(float[], int, int)
 	 */
-	public FloatBuffer getValues(final AbstractFloatArray< ? > array, int offset, int length) {
+	public FloatBuffer getValues( final AbstractFloatArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractFloatArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see FloatBuffer#put(float[])
 	 */
-	public FloatBuffer setValues(final AbstractFloatArray< ? > array) {
+	public FloatBuffer setValues( final AbstractFloatArray< ? > array )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractFloatArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see FloatBuffer#put(float[], int, int)
 	 */
-	public FloatBuffer setValues(final AbstractFloatArray< ? > array, int offset, int length) {
+	public FloatBuffer setValues( final AbstractFloatArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from another FloatBufferAccess.
-	 * 
+	 *
 	 * @param access
 	 * @return
 	 */
-	public FloatBuffer setValues(final FloatBufferAccess access) {
+	public FloatBuffer setValues( final FloatBufferAccess access )
+	{
 		return buffer.duplicate().put( access.getCurrentStorageArray() );
 	}
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
@@ -52,7 +52,7 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
-	private static final int NUM_BYTES = Integer.BYTES;
+	private static final int NUM_BYTES_PER_ENTITY = Integer.BYTES;
 
 	public IntBufferAccess( final IntBuffer buffer, final boolean isValid )
 	{
@@ -93,8 +93,8 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 	 */
 
 	@Override
-	public int getNumBytes() {
-		return NUM_BYTES;
+	public int getNumBytesPerEntity() {
+		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
@@ -110,6 +110,18 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 	@Override
 	protected IntBuffer duplicateBuffer(IntBuffer buffer) {
 		return buffer.duplicate();
+	}
+	
+	/**
+	 * Override abstract implementation to allow for longer non-direct Buffers since
+	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 */
+	@Override
+	protected IntBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
+		if(isDirect)
+			return super.allocate( numEntities, isDirect, isValid );
+		else
+			return new IntBufferAccess( numEntities, isValid );
 	}
 	
 	/*

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
@@ -130,7 +130,7 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 	}
 
 	@Override
-	protected IntBuffer duplicateBuffer( final IntBuffer buffer )
+	IntBuffer duplicateBuffer( final IntBuffer buffer )
 	{
 		return buffer.duplicate();
 	}
@@ -140,7 +140,7 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected IntBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	IntBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
 	{
 		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -41,14 +41,14 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileIntAccess;
 
 /**
  * Access for {@link IntBuffer}
- * 
+ *
  * @author Mark Kittisopikul
  */
 public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntBuffer > implements VolatileIntAccess
 {
 
 	/**
-	 * Automatically generated 
+	 * Automatically generated
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
@@ -56,153 +56,182 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 
 	public IntBufferAccess( final IntBuffer buffer, final boolean isValid )
 	{
-		super(buffer, isValid);
+		super( buffer, isValid );
 	}
-	
-	public IntBufferAccess( final int numEntities, final boolean isValid ) {
-		super( IntBuffer.allocate(numEntities), isValid );
+
+	public IntBufferAccess( final int numEntities, final boolean isValid )
+	{
+		super( IntBuffer.allocate( numEntities ), isValid );
 	}
-	
-	public IntBufferAccess( final ByteBuffer buffer, boolean isValid) {
-		super(buffer.asIntBuffer(), isValid);
+
+	public IntBufferAccess( final ByteBuffer buffer, final boolean isValid )
+	{
+		super( buffer.asIntBuffer(), isValid );
 	}
-	
+
 	// Convenience constructors
-	
-	public IntBufferAccess( final IntBuffer buffer ) { this(buffer,       DEFAULT_IS_VALID); }
-	public IntBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
-	public IntBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
-	public IntBufferAccess() { this( (IntBuffer) null, false); }
+
+	public IntBufferAccess( final IntBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public IntBufferAccess( final int numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public IntBufferAccess( final ByteBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public IntBufferAccess()
+	{
+		this( ( IntBuffer ) null, false );
+	}
 
 	/*
 	 * IntAccess methods
 	 */
-	
+
 	@Override
-	public int getValue( int index ) {
+	public int getValue( final int index )
+	{
 		return buffer.get( index );
 	}
 
 	@Override
-	public void setValue( int index, int value ) {
+	public void setValue( final int index, final int value )
+	{
 		buffer.put( index, value );
 	}
-	
+
 	/*
 	 * AbstractBufferAccess methods
 	 */
 
 	@Override
-	public int getNumBytesPerEntity() {
+	public int getNumBytesPerEntity()
+	{
 		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
-	public IntBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
-		return fromByteBuffer(buffer, isValid);
+	public IntBufferAccess newInstance( final ByteBuffer buffer, final boolean isValid )
+	{
+		return fromByteBuffer( buffer, isValid );
 	}
-	
+
 	@Override
-	public IntBufferAccess newInstance(IntBuffer buffer, boolean isValid) {
-		return new IntBufferAccess(buffer, isValid);
+	public IntBufferAccess newInstance( final IntBuffer buffer, final boolean isValid )
+	{
+		return new IntBufferAccess( buffer, isValid );
 	}
-	
+
 	@Override
-	protected IntBuffer duplicateBuffer(IntBuffer buffer) {
+	protected IntBuffer duplicateBuffer( final IntBuffer buffer )
+	{
 		return buffer.duplicate();
 	}
-	
+
 	/**
-	 * Override abstract implementation to allow for longer non-direct Buffers since
-	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 * Override abstract implementation to allow for longer non-direct Buffers
+	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected IntBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
-		if(isDirect)
+	protected IntBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	{
+		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );
 		else
 			return new IntBufferAccess( numEntities, isValid );
 	}
-	
+
 	/*
 	 * Static methods
 	 */
 
 	/**
 	 * Create a new IntBufferAccess from a ByteBuffer
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
-	public static IntBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
-		return new IntBufferAccess(buffer, isValid);
+	public static IntBufferAccess fromByteBuffer( final ByteBuffer buffer, final boolean isValid )
+	{
+		return new IntBufferAccess( buffer, isValid );
 	}
 
-	
 	/*
 	 * Bulk convenience methods
-	 * 
-	 * These are not trivial because the buffer should be duplicated
-	 * to prevent changing the current buffer state. The duplicated
-	 * buffer is returned for chained operations.
+	 *
+	 * These are not trivial because the buffer should be duplicated to prevent
+	 * changing the current buffer state. The duplicated buffer is returned for
+	 * chained operations.
 	 */
-	
+
 	/**
 	 * Copy values into a {@link AbstractIntArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see IntBuffer#get(int[])
 	 */
-	public IntBuffer getValues(final AbstractIntArray< ? > array) {
+	public IntBuffer getValues( final AbstractIntArray< ? > array )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values into a {@link AbstractIntArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see IntBuffer#get(int[], int, int)
 	 */
-	public IntBuffer getValues(final AbstractIntArray< ? > array, int offset, int length) {
+	public IntBuffer getValues( final AbstractIntArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractIntArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see IntBuffer#put(int[])
 	 */
-	public IntBuffer setValues(final AbstractIntArray< ? > array) {
+	public IntBuffer setValues( final AbstractIntArray< ? > array )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractIntArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see IntBuffer#put(int[], int, int)
 	 */
-	public IntBuffer setValues(final AbstractIntArray< ? > array, int offset, int length) {
+	public IntBuffer setValues( final AbstractIntArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from another IntBufferAccess.
-	 * 
+	 *
 	 * @param access
 	 * @return
 	 */
-	public IntBuffer setValues(final IntBufferAccess access) {
+	public IntBuffer setValues( final IntBufferAccess access )
+	{
 		return buffer.duplicate().put( access.getCurrentStorageArray() );
 	}
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
@@ -1,0 +1,197 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Intair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileIntAccess;
+
+/**
+ * Access for {@link IntBuffer}
+ * 
+ * @author Mark Kittisopikul
+ */
+public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntBuffer > implements VolatileIntAccess
+{
+
+	/**
+	 * Automatically generated 
+	 */
+	private static final long serialVersionUID = -7265085228179236189L;
+
+	private static final int NUM_BYTES = Integer.BYTES;
+
+	public IntBufferAccess( final IntBuffer buffer, final boolean isValid )
+	{
+		super(buffer, isValid);
+	}
+	
+	public IntBufferAccess( final int numEntities, final boolean isValid ) {
+		super( IntBuffer.allocate(numEntities), isValid );
+	}
+	
+	public IntBufferAccess( final ByteBuffer buffer, boolean isValid) {
+		super(buffer.asIntBuffer(), isValid);
+	}
+	
+	// Convenience constructors
+	
+	public IntBufferAccess( final IntBuffer buffer ) { this(buffer,       DEFAULT_IS_VALID); }
+	public IntBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
+	public IntBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
+	public IntBufferAccess() { this( (IntBuffer) null, false); }
+
+	/*
+	 * IntAccess methods
+	 */
+	
+	@Override
+	public int getValue( int index ) {
+		return buffer.get( index );
+	}
+
+	@Override
+	public void setValue( int index, int value ) {
+		buffer.put( index, value );
+	}
+	
+	/*
+	 * AbstractBufferAccess methods
+	 */
+
+	@Override
+	public int getNumBytes() {
+		return NUM_BYTES;
+	}
+
+	@Override
+	public IntBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
+		return fromByteBuffer(buffer, isValid);
+	}
+	
+	@Override
+	public IntBufferAccess newInstance(IntBuffer buffer, boolean isValid) {
+		return new IntBufferAccess(buffer, isValid);
+	}
+	
+	@Override
+	protected IntBuffer duplicateBuffer(IntBuffer buffer) {
+		return buffer.duplicate();
+	}
+	
+	/*
+	 * Static methods
+	 */
+
+	/**
+	 * Create a new IntBufferAccess from a ByteBuffer
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public static IntBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
+		return new IntBufferAccess(buffer, isValid);
+	}
+
+	
+	/*
+	 * Bulk convenience methods
+	 * 
+	 * These are not trivial because the buffer should be duplicated
+	 * to prevent changing the current buffer state. The duplicated
+	 * buffer is returned for chained operations.
+	 */
+	
+	/**
+	 * Copy values into a {@link IntArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see IntBuffer#get(int[])
+	 */
+	public IntBuffer getValues(final IntArray array) {
+		return buffer.duplicate().get( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values into a {@link IntArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see IntBuffer#get(int[], int, int)
+	 */
+	public IntBuffer getValues(final IntArray array, int offset, int length) {
+		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from a {@link IntArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see IntBuffer#put(IntArray, int, int)
+	 */
+	public IntBuffer setValues(final IntArray array) {
+		return buffer.duplicate().put( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values from a {@link IntArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see IntBuffer#put(int[], int, int)
+	 */
+	public IntBuffer setValues(final IntArray array, int offset, int length) {
+		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from another IntBufferAccess.
+	 * 
+	 * @param access
+	 * @return
+	 */
+	public IntBuffer setValues(final IntBufferAccess access) {
+		return buffer.duplicate().put( access.getCurrentStorageArray() );
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/IntBufferAccess.java
@@ -36,7 +36,7 @@ package net.imglib2.img.basictypeaccess.nio;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
-import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.AbstractIntArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileIntAccess;
 
 /**
@@ -137,18 +137,18 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 	 */
 	
 	/**
-	 * Copy values into a {@link IntArray}.
+	 * Copy values into a {@link AbstractIntArray}.
 	 * 
 	 * @param array
 	 * @return
 	 * @see IntBuffer#get(int[])
 	 */
-	public IntBuffer getValues(final IntArray array) {
+	public IntBuffer getValues(final AbstractIntArray< ? > array) {
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values into a {@link IntArray}.
+	 * Copy values into a {@link AbstractIntArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -156,23 +156,23 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 	 * @return
 	 * @see IntBuffer#get(int[], int, int)
 	 */
-	public IntBuffer getValues(final IntArray array, int offset, int length) {
+	public IntBuffer getValues(final AbstractIntArray< ? > array, int offset, int length) {
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
 	
 	/**
-	 * Copy values from a {@link IntArray}.
+	 * Copy values from a {@link AbstractIntArray}.
 	 * 
 	 * @param array
 	 * @return
-	 * @see IntBuffer#put(IntArray, int, int)
+	 * @see IntBuffer#put(int[])
 	 */
-	public IntBuffer setValues(final IntArray array) {
+	public IntBuffer setValues(final AbstractIntArray< ? > array) {
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values from a {@link IntArray}.
+	 * Copy values from a {@link AbstractIntArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -180,7 +180,7 @@ public class IntBufferAccess extends AbstractBufferAccess< IntBufferAccess, IntB
 	 * @return
 	 * @see IntBuffer#put(int[], int, int)
 	 */
-	public IntBuffer setValues(final IntArray array, int offset, int length) {
+	public IntBuffer setValues(final AbstractIntArray< ? > array, int offset, int length) {
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
 	

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
@@ -52,7 +52,7 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
-	private static final int NUM_BYTES = Long.BYTES;
+	private static final int NUM_BYTES_PER_ENTITY = Long.BYTES;
 
 	public LongBufferAccess( final LongBuffer buffer, final boolean isValid )
 	{
@@ -93,8 +93,8 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 	 */
 
 	@Override
-	public int getNumBytes() {
-		return NUM_BYTES;
+	public int getNumBytesPerEntity() {
+		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
@@ -110,6 +110,18 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 	@Override
 	protected LongBuffer duplicateBuffer(LongBuffer buffer) {
 		return buffer.duplicate();
+	}
+	
+	/**
+	 * Override abstract implementation to allow for longer non-direct Buffers since
+	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 */
+	@Override
+	protected LongBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
+		if(isDirect)
+			return super.allocate( numEntities, isDirect, isValid );
+		else
+			return new LongBufferAccess( numEntities, isValid );
 	}
 	
 	/*

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
@@ -1,0 +1,198 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.ByteBuffer;
+import java.nio.LongBuffer;
+
+import net.imglib2.img.basictypeaccess.LongAccess;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileLongAccess;
+
+/**
+ * Access for {@link LongBuffer}
+ * 
+ * @author Mark Kittisopikul
+ */
+public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, LongBuffer > implements VolatileLongAccess
+{
+
+	/**
+	 * Automatically generated 
+	 */
+	private static final long serialVersionUID = -7265085228179236189L;
+
+	private static final int NUM_BYTES = Long.BYTES;
+
+	public LongBufferAccess( final LongBuffer buffer, final boolean isValid )
+	{
+		super(buffer, isValid);
+	}
+	
+	public LongBufferAccess( final int numEntities, final boolean isValid ) {
+		super( LongBuffer.allocate(numEntities), isValid );
+	}
+	
+	public LongBufferAccess( final ByteBuffer buffer, boolean isValid) {
+		super(buffer.asLongBuffer(), isValid);
+	}
+	
+	// Convenience constructors
+	
+	public LongBufferAccess( final LongBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
+	public LongBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
+	public LongBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
+	public LongBufferAccess() { this( (LongBuffer) null, false); }
+
+	/*
+	 * LongAccess methods
+	 */
+	
+	@Override
+	public long getValue( int index ) {
+		return buffer.get( index );
+	}
+
+	@Override
+	public void setValue( int index, long value ) {
+		buffer.put( index, value );
+	}
+	
+	/*
+	 * AbstractBufferAccess methods
+	 */
+
+	@Override
+	public int getNumBytes() {
+		return NUM_BYTES;
+	}
+
+	@Override
+	public LongBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
+		return fromByteBuffer(buffer, isValid);
+	}
+	
+	@Override
+	public LongBufferAccess newInstance(LongBuffer buffer, boolean isValid) {
+		return new LongBufferAccess(buffer, isValid);
+	}
+	
+	@Override
+	protected LongBuffer duplicateBuffer(LongBuffer buffer) {
+		return buffer.duplicate();
+	}
+	
+	/*
+	 * Static methods
+	 */
+
+	/**
+	 * Create a new LongBufferAccess from a ByteBuffer
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public static LongBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
+		return new LongBufferAccess(buffer, isValid);
+	}
+
+	
+	/*
+	 * Bulk convenience methods
+	 * 
+	 * These are not trivial because the buffer should be duplicated
+	 * to prevent changing the current buffer state. The duplicated
+	 * buffer is returned for chained operations.
+	 */
+	
+	/**
+	 * Copy values into a {@link LongArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see LongBuffer#get(long[])
+	 */
+	public LongBuffer getValues(final LongArray array) {
+		return buffer.duplicate().get( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values into a {@link LongArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see LongBuffer#get(long[], int, int)
+	 */
+	public LongBuffer getValues(final LongArray array, int offset, int length) {
+		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from a {@link LongArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see LongBuffer#put(LongArray, int, int)
+	 */
+	public LongBuffer setValues(final LongArray array) {
+		return buffer.duplicate().put( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values from a {@link LongArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see LongBuffer#put(long[], int, int)
+	 */
+	public LongBuffer setValues(final LongArray array, int offset, int length) {
+		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from another LongBufferAccess.
+	 * 
+	 * @param access
+	 * @return
+	 */
+	public LongBuffer setValues(final LongBufferAccess access) {
+		return buffer.duplicate().put( access.getCurrentStorageArray() );
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -41,14 +41,14 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileLongAccess;
 
 /**
  * Access for {@link LongBuffer}
- * 
+ *
  * @author Mark Kittisopikul
  */
 public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, LongBuffer > implements VolatileLongAccess
 {
 
 	/**
-	 * Automatically generated 
+	 * Automatically generated
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
@@ -56,153 +56,182 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 
 	public LongBufferAccess( final LongBuffer buffer, final boolean isValid )
 	{
-		super(buffer, isValid);
+		super( buffer, isValid );
 	}
-	
-	public LongBufferAccess( final int numEntities, final boolean isValid ) {
-		super( LongBuffer.allocate(numEntities), isValid );
+
+	public LongBufferAccess( final int numEntities, final boolean isValid )
+	{
+		super( LongBuffer.allocate( numEntities ), isValid );
 	}
-	
-	public LongBufferAccess( final ByteBuffer buffer, boolean isValid) {
-		super(buffer.asLongBuffer(), isValid);
+
+	public LongBufferAccess( final ByteBuffer buffer, final boolean isValid )
+	{
+		super( buffer.asLongBuffer(), isValid );
 	}
-	
+
 	// Convenience constructors
-	
-	public LongBufferAccess( final LongBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
-	public LongBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
-	public LongBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
-	public LongBufferAccess() { this( (LongBuffer) null, false); }
+
+	public LongBufferAccess( final LongBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public LongBufferAccess( final int numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public LongBufferAccess( final ByteBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public LongBufferAccess()
+	{
+		this( ( LongBuffer ) null, false );
+	}
 
 	/*
 	 * LongAccess methods
 	 */
-	
+
 	@Override
-	public long getValue( int index ) {
+	public long getValue( final int index )
+	{
 		return buffer.get( index );
 	}
 
 	@Override
-	public void setValue( int index, long value ) {
+	public void setValue( final int index, final long value )
+	{
 		buffer.put( index, value );
 	}
-	
+
 	/*
 	 * AbstractBufferAccess methods
 	 */
 
 	@Override
-	public int getNumBytesPerEntity() {
+	public int getNumBytesPerEntity()
+	{
 		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
-	public LongBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
-		return fromByteBuffer(buffer, isValid);
+	public LongBufferAccess newInstance( final ByteBuffer buffer, final boolean isValid )
+	{
+		return fromByteBuffer( buffer, isValid );
 	}
-	
+
 	@Override
-	public LongBufferAccess newInstance(LongBuffer buffer, boolean isValid) {
-		return new LongBufferAccess(buffer, isValid);
+	public LongBufferAccess newInstance( final LongBuffer buffer, final boolean isValid )
+	{
+		return new LongBufferAccess( buffer, isValid );
 	}
-	
+
 	@Override
-	protected LongBuffer duplicateBuffer(LongBuffer buffer) {
+	protected LongBuffer duplicateBuffer( final LongBuffer buffer )
+	{
 		return buffer.duplicate();
 	}
-	
+
 	/**
-	 * Override abstract implementation to allow for longer non-direct Buffers since
-	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 * Override abstract implementation to allow for longer non-direct Buffers
+	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected LongBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
-		if(isDirect)
+	protected LongBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	{
+		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );
 		else
 			return new LongBufferAccess( numEntities, isValid );
 	}
-	
+
 	/*
 	 * Static methods
 	 */
 
 	/**
 	 * Create a new LongBufferAccess from a ByteBuffer
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
-	public static LongBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
-		return new LongBufferAccess(buffer, isValid);
+	public static LongBufferAccess fromByteBuffer( final ByteBuffer buffer, final boolean isValid )
+	{
+		return new LongBufferAccess( buffer, isValid );
 	}
 
-	
 	/*
 	 * Bulk convenience methods
-	 * 
-	 * These are not trivial because the buffer should be duplicated
-	 * to prevent changing the current buffer state. The duplicated
-	 * buffer is returned for chained operations.
+	 *
+	 * These are not trivial because the buffer should be duplicated to prevent
+	 * changing the current buffer state. The duplicated buffer is returned for
+	 * chained operations.
 	 */
-	
+
 	/**
 	 * Copy values into a {@link AbstractLongArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see LongBuffer#get(long[])
 	 */
-	public LongBuffer getValues(final AbstractLongArray< ? > array) {
+	public LongBuffer getValues( final AbstractLongArray< ? > array )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values into a {@link AbstractLongArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see LongBuffer#get(long[], int, int)
 	 */
-	public LongBuffer getValues(final AbstractLongArray< ? > array, int offset, int length) {
+	public LongBuffer getValues( final AbstractLongArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractLongArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see LongBuffer#put(long[])
 	 */
-	public LongBuffer setValues(final AbstractLongArray< ? > array) {
+	public LongBuffer setValues( final AbstractLongArray< ? > array )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractLongArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see LongBuffer#put(long[], int, int)
 	 */
-	public LongBuffer setValues(final AbstractLongArray< ? > array, int offset, int length) {
+	public LongBuffer setValues( final AbstractLongArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from another LongBufferAccess.
-	 * 
+	 *
 	 * @param access
 	 * @return
 	 */
-	public LongBuffer setValues(final LongBufferAccess access) {
+	public LongBuffer setValues( final LongBufferAccess access )
+	{
 		return buffer.duplicate().put( access.getCurrentStorageArray() );
 	}
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
@@ -130,7 +130,7 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 	}
 
 	@Override
-	protected LongBuffer duplicateBuffer( final LongBuffer buffer )
+	LongBuffer duplicateBuffer( final LongBuffer buffer )
 	{
 		return buffer.duplicate();
 	}
@@ -140,7 +140,7 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected LongBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	LongBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
 	{
 		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/LongBufferAccess.java
@@ -36,8 +36,7 @@ package net.imglib2.img.basictypeaccess.nio;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 
-import net.imglib2.img.basictypeaccess.LongAccess;
-import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.basictypeaccess.array.AbstractLongArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileLongAccess;
 
 /**
@@ -138,18 +137,18 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 	 */
 	
 	/**
-	 * Copy values into a {@link LongArray}.
+	 * Copy values into a {@link AbstractLongArray}.
 	 * 
 	 * @param array
 	 * @return
 	 * @see LongBuffer#get(long[])
 	 */
-	public LongBuffer getValues(final LongArray array) {
+	public LongBuffer getValues(final AbstractLongArray< ? > array) {
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values into a {@link LongArray}.
+	 * Copy values into a {@link AbstractLongArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -157,23 +156,23 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 	 * @return
 	 * @see LongBuffer#get(long[], int, int)
 	 */
-	public LongBuffer getValues(final LongArray array, int offset, int length) {
+	public LongBuffer getValues(final AbstractLongArray< ? > array, int offset, int length) {
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
 	
 	/**
-	 * Copy values from a {@link LongArray}.
+	 * Copy values from a {@link AbstractLongArray}.
 	 * 
 	 * @param array
 	 * @return
-	 * @see LongBuffer#put(LongArray, int, int)
+	 * @see LongBuffer#put(long[])
 	 */
-	public LongBuffer setValues(final LongArray array) {
+	public LongBuffer setValues(final AbstractLongArray< ? > array) {
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values from a {@link LongArray}.
+	 * Copy values from a {@link AbstractLongArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -181,7 +180,7 @@ public class LongBufferAccess extends AbstractBufferAccess< LongBufferAccess, Lo
 	 * @return
 	 * @see LongBuffer#put(long[], int, int)
 	 */
-	public LongBuffer setValues(final LongArray array, int offset, int length) {
+	public LongBuffer setValues(final AbstractLongArray< ? > array, int offset, int length) {
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
 	

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -41,14 +41,14 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileShortAccess;
 
 /**
  * Access for {@link ShortBuffer}
- * 
+ *
  * @author Mark Kittisopikul
  */
 public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, ShortBuffer > implements VolatileShortAccess
 {
 
 	/**
-	 * Automatically generated 
+	 * Automatically generated
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
@@ -56,153 +56,182 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 
 	public ShortBufferAccess( final ShortBuffer buffer, final boolean isValid )
 	{
-		super(buffer, isValid);
+		super( buffer, isValid );
 	}
-	
-	public ShortBufferAccess( final int numEntities, final boolean isValid ) {
-		super( ShortBuffer.allocate(numEntities), isValid );
+
+	public ShortBufferAccess( final int numEntities, final boolean isValid )
+	{
+		super( ShortBuffer.allocate( numEntities ), isValid );
 	}
-	
-	public ShortBufferAccess( final ByteBuffer buffer, boolean isValid) {
-		super(buffer.asShortBuffer(), isValid);
+
+	public ShortBufferAccess( final ByteBuffer buffer, final boolean isValid )
+	{
+		super( buffer.asShortBuffer(), isValid );
 	}
-	
+
 	// Convenience constructors
-	
-	public ShortBufferAccess( final ShortBuffer buffer ) { this(buffer,     DEFAULT_IS_VALID); }
-	public ShortBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
-	public ShortBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
-	public ShortBufferAccess() { this( (ShortBuffer) null, false); }
+
+	public ShortBufferAccess( final ShortBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public ShortBufferAccess( final int numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public ShortBufferAccess( final ByteBuffer buffer )
+	{
+		this( buffer, DEFAULT_IS_VALID );
+	}
+
+	public ShortBufferAccess()
+	{
+		this( ( ShortBuffer ) null, false );
+	}
 
 	/*
 	 * ShortAccess methods
 	 */
-	
+
 	@Override
-	public short getValue( int index ) {
+	public short getValue( final int index )
+	{
 		return buffer.get( index );
 	}
 
 	@Override
-	public void setValue( int index, short value ) {
+	public void setValue( final int index, final short value )
+	{
 		buffer.put( index, value );
 	}
-	
+
 	/*
 	 * AbstractBufferAccess methods
 	 */
 
 	@Override
-	public int getNumBytesPerEntity() {
+	public int getNumBytesPerEntity()
+	{
 		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
-	public ShortBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
-		return fromByteBuffer(buffer, isValid);
+	public ShortBufferAccess newInstance( final ByteBuffer buffer, final boolean isValid )
+	{
+		return fromByteBuffer( buffer, isValid );
 	}
-	
+
 	@Override
-	public ShortBufferAccess newInstance(ShortBuffer buffer, boolean isValid) {
-		return new ShortBufferAccess(buffer, isValid);
+	public ShortBufferAccess newInstance( final ShortBuffer buffer, final boolean isValid )
+	{
+		return new ShortBufferAccess( buffer, isValid );
 	}
-	
+
 	@Override
-	protected ShortBuffer duplicateBuffer(ShortBuffer buffer) {
+	protected ShortBuffer duplicateBuffer( final ShortBuffer buffer )
+	{
 		return buffer.duplicate();
 	}
-	
+
 	/**
-	 * Override abstract implementation to allow for longer non-direct Buffers since
-	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 * Override abstract implementation to allow for longer non-direct Buffers
+	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected ShortBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
-		if(isDirect)
+	protected ShortBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	{
+		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );
 		else
 			return new ShortBufferAccess( numEntities, isValid );
 	}
-	
+
 	/*
 	 * Static methods
 	 */
 
 	/**
 	 * Create a new ShortBufferAccess from a ByteBuffer
-	 * 
+	 *
 	 * @param buffer
 	 * @param isValid
 	 * @return
 	 */
-	public static ShortBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
-		return new ShortBufferAccess(buffer, isValid);
+	public static ShortBufferAccess fromByteBuffer( final ByteBuffer buffer, final boolean isValid )
+	{
+		return new ShortBufferAccess( buffer, isValid );
 	}
 
-	
 	/*
 	 * Bulk convenience methods
-	 * 
-	 * These are not trivial because the buffer should be duplicated
-	 * to prevent changing the current buffer state. The duplicated
-	 * buffer is returned for chained operations.
+	 *
+	 * These are not trivial because the buffer should be duplicated to prevent
+	 * changing the current buffer state. The duplicated buffer is returned for
+	 * chained operations.
 	 */
-	
+
 	/**
 	 * Copy values into a {@link AbstractShortArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see ShortBuffer#get(short[])
 	 */
-	public ShortBuffer getValues(final AbstractShortArray< ? > array) {
+	public ShortBuffer getValues( final AbstractShortArray< ? > array )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values into a {@link AbstractShortArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see ShortBuffer#get(short[], int, int)
 	 */
-	public ShortBuffer getValues(final AbstractShortArray< ? > array, int offset, int length) {
+	public ShortBuffer getValues( final AbstractShortArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractShortArray}.
-	 * 
+	 *
 	 * @param array
 	 * @return
 	 * @see ShortBuffer#put(short[])
 	 */
-	public ShortBuffer setValues(final AbstractShortArray< ? > array) {
+	public ShortBuffer setValues( final AbstractShortArray< ? > array )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
-	
+
 	/**
 	 * Copy values from a {@link AbstractShortArray}.
-	 * 
+	 *
 	 * @param array
 	 * @param offset
 	 * @param length
 	 * @return
 	 * @see ShortBuffer#put(short[], int, int)
 	 */
-	public ShortBuffer setValues(final AbstractShortArray< ? > array, int offset, int length) {
+	public ShortBuffer setValues( final AbstractShortArray< ? > array, final int offset, final int length )
+	{
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
-	
+
 	/**
 	 * Copy values from another ShortBufferAccess.
-	 * 
+	 *
 	 * @param access
 	 * @return
 	 */
-	public ShortBuffer setValues(final ShortBufferAccess access) {
+	public ShortBuffer setValues( final ShortBufferAccess access )
+	{
 		return buffer.duplicate().put( access.getCurrentStorageArray() );
 	}
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
@@ -36,8 +36,7 @@ package net.imglib2.img.basictypeaccess.nio;
 import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
-import net.imglib2.img.basictypeaccess.ShortAccess;
-import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.img.basictypeaccess.array.AbstractShortArray;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileShortAccess;
 
 /**
@@ -138,18 +137,18 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 	 */
 	
 	/**
-	 * Copy values into a {@link ShortArray}.
+	 * Copy values into a {@link AbstractShortArray}.
 	 * 
 	 * @param array
 	 * @return
 	 * @see ShortBuffer#get(short[])
 	 */
-	public ShortBuffer getValues(final ShortArray array) {
+	public ShortBuffer getValues(final AbstractShortArray< ? > array) {
 		return buffer.duplicate().get( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values into a {@link ShortArray}.
+	 * Copy values into a {@link AbstractShortArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -157,23 +156,23 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 	 * @return
 	 * @see ShortBuffer#get(short[], int, int)
 	 */
-	public ShortBuffer getValues(final ShortArray array, int offset, int length) {
+	public ShortBuffer getValues(final AbstractShortArray< ? > array, int offset, int length) {
 		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
 	}
 	
 	/**
-	 * Copy values from a {@link ShortArray}.
+	 * Copy values from a {@link AbstractShortArray}.
 	 * 
 	 * @param array
 	 * @return
-	 * @see ShortBuffer#put(ShortArray, int, int)
+	 * @see ShortBuffer#put(short[])
 	 */
-	public ShortBuffer setValues(final ShortArray array) {
+	public ShortBuffer setValues(final AbstractShortArray< ? > array) {
 		return buffer.duplicate().put( array.getCurrentStorageArray() );
 	}
 	
 	/**
-	 * Copy values from a {@link ShortArray}.
+	 * Copy values from a {@link AbstractShortArray}.
 	 * 
 	 * @param array
 	 * @param offset
@@ -181,7 +180,7 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 	 * @return
 	 * @see ShortBuffer#put(short[], int, int)
 	 */
-	public ShortBuffer setValues(final ShortArray array, int offset, int length) {
+	public ShortBuffer setValues(final AbstractShortArray< ? > array, int offset, int length) {
 		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
 	}
 	

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
@@ -130,7 +130,7 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 	}
 
 	@Override
-	protected ShortBuffer duplicateBuffer( final ShortBuffer buffer )
+	ShortBuffer duplicateBuffer( final ShortBuffer buffer )
 	{
 		return buffer.duplicate();
 	}
@@ -140,7 +140,7 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 	 * since ByteBuffer is restricted to Integer.MAX_VALUE entities.
 	 */
 	@Override
-	protected ShortBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
+	ShortBufferAccess allocate( final int numEntities, final boolean isDirect, final boolean isValid )
 	{
 		if ( isDirect )
 			return super.allocate( numEntities, isDirect, isValid );

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
@@ -52,7 +52,7 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 	 */
 	private static final long serialVersionUID = -7265085228179236189L;
 
-	private static final int NUM_BYTES = Short.BYTES;
+	private static final int NUM_BYTES_PER_ENTITY = Short.BYTES;
 
 	public ShortBufferAccess( final ShortBuffer buffer, final boolean isValid )
 	{
@@ -93,8 +93,8 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 	 */
 
 	@Override
-	public int getNumBytes() {
-		return NUM_BYTES;
+	public int getNumBytesPerEntity() {
+		return NUM_BYTES_PER_ENTITY;
 	}
 
 	@Override
@@ -110,6 +110,18 @@ public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, 
 	@Override
 	protected ShortBuffer duplicateBuffer(ShortBuffer buffer) {
 		return buffer.duplicate();
+	}
+	
+	/**
+	 * Override abstract implementation to allow for longer non-direct Buffers since
+	 * ByteBuffer is restricted to Integer.MAX_VALUE entities.
+	 */
+	@Override
+	protected ShortBufferAccess allocate( int numEntities, boolean isDirect, boolean isValid) {
+		if(isDirect)
+			return super.allocate( numEntities, isDirect, isValid );
+		else
+			return new ShortBufferAccess( numEntities, isValid );
 	}
 	
 	/*

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/ShortBufferAccess.java
@@ -1,0 +1,198 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2020 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Shortair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.nio;
+
+import java.nio.ByteBuffer;
+import java.nio.ShortBuffer;
+
+import net.imglib2.img.basictypeaccess.ShortAccess;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileShortAccess;
+
+/**
+ * Access for {@link ShortBuffer}
+ * 
+ * @author Mark Kittisopikul
+ */
+public class ShortBufferAccess extends AbstractBufferAccess< ShortBufferAccess, ShortBuffer > implements VolatileShortAccess
+{
+
+	/**
+	 * Automatically generated 
+	 */
+	private static final long serialVersionUID = -7265085228179236189L;
+
+	private static final int NUM_BYTES = Short.BYTES;
+
+	public ShortBufferAccess( final ShortBuffer buffer, final boolean isValid )
+	{
+		super(buffer, isValid);
+	}
+	
+	public ShortBufferAccess( final int numEntities, final boolean isValid ) {
+		super( ShortBuffer.allocate(numEntities), isValid );
+	}
+	
+	public ShortBufferAccess( final ByteBuffer buffer, boolean isValid) {
+		super(buffer.asShortBuffer(), isValid);
+	}
+	
+	// Convenience constructors
+	
+	public ShortBufferAccess( final ShortBuffer buffer ) { this(buffer,     DEFAULT_IS_VALID); }
+	public ShortBufferAccess( final int numEntities   ) { this(numEntities, DEFAULT_IS_VALID); }
+	public ShortBufferAccess( final ByteBuffer buffer ) { this(buffer,      DEFAULT_IS_VALID); }
+	public ShortBufferAccess() { this( (ShortBuffer) null, false); }
+
+	/*
+	 * ShortAccess methods
+	 */
+	
+	@Override
+	public short getValue( int index ) {
+		return buffer.get( index );
+	}
+
+	@Override
+	public void setValue( int index, short value ) {
+		buffer.put( index, value );
+	}
+	
+	/*
+	 * AbstractBufferAccess methods
+	 */
+
+	@Override
+	public int getNumBytes() {
+		return NUM_BYTES;
+	}
+
+	@Override
+	public ShortBufferAccess newInstance(ByteBuffer buffer, boolean isValid) {
+		return fromByteBuffer(buffer, isValid);
+	}
+	
+	@Override
+	public ShortBufferAccess newInstance(ShortBuffer buffer, boolean isValid) {
+		return new ShortBufferAccess(buffer, isValid);
+	}
+	
+	@Override
+	protected ShortBuffer duplicateBuffer(ShortBuffer buffer) {
+		return buffer.duplicate();
+	}
+	
+	/*
+	 * Static methods
+	 */
+
+	/**
+	 * Create a new ShortBufferAccess from a ByteBuffer
+	 * 
+	 * @param buffer
+	 * @param isValid
+	 * @return
+	 */
+	public static ShortBufferAccess fromByteBuffer(ByteBuffer buffer, boolean isValid) {
+		return new ShortBufferAccess(buffer, isValid);
+	}
+
+	
+	/*
+	 * Bulk convenience methods
+	 * 
+	 * These are not trivial because the buffer should be duplicated
+	 * to prevent changing the current buffer state. The duplicated
+	 * buffer is returned for chained operations.
+	 */
+	
+	/**
+	 * Copy values into a {@link ShortArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see ShortBuffer#get(short[])
+	 */
+	public ShortBuffer getValues(final ShortArray array) {
+		return buffer.duplicate().get( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values into a {@link ShortArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see ShortBuffer#get(short[], int, int)
+	 */
+	public ShortBuffer getValues(final ShortArray array, int offset, int length) {
+		return buffer.duplicate().get( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from a {@link ShortArray}.
+	 * 
+	 * @param array
+	 * @return
+	 * @see ShortBuffer#put(ShortArray, int, int)
+	 */
+	public ShortBuffer setValues(final ShortArray array) {
+		return buffer.duplicate().put( array.getCurrentStorageArray() );
+	}
+	
+	/**
+	 * Copy values from a {@link ShortArray}.
+	 * 
+	 * @param array
+	 * @param offset
+	 * @param length
+	 * @return
+	 * @see ShortBuffer#put(short[], int, int)
+	 */
+	public ShortBuffer setValues(final ShortArray array, int offset, int length) {
+		return buffer.duplicate().put( array.getCurrentStorageArray(), offset, length );
+	}
+	
+	/**
+	 * Copy values from another ShortBufferAccess.
+	 * 
+	 * @param access
+	 * @return
+	 */
+	public ShortBuffer setValues(final ShortBufferAccess access) {
+		return buffer.duplicate().put( access.getCurrentStorageArray() );
+	}
+
+}

--- a/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
+++ b/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
@@ -84,7 +84,7 @@ public abstract class AbstractCellImg<
 	public A update( final Object cursor )
 	{
 		// directly get data?
-		return (A) ( ( CellImgSampler< C > ) cursor ).getCell().getData().createView(cursor);
+		return ( A ) ( ( CellImgSampler< C > ) cursor ).getCell().getData().createView( cursor );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
+++ b/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
@@ -38,6 +38,7 @@ import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.img.AbstractNativeImg;
 import net.imglib2.img.Img;
+import net.imglib2.img.basictypeaccess.DataAccess;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Fraction;
 
@@ -50,7 +51,7 @@ import net.imglib2.util.Fraction;
  */
 public abstract class AbstractCellImg<
 				T extends NativeType< T >,
-				A,
+				A extends DataAccess,
 				C extends Cell< A >,
 				I extends RandomAccessible< C > & IterableInterval< C > >
 		extends AbstractNativeImg< T, A >
@@ -83,7 +84,7 @@ public abstract class AbstractCellImg<
 	public A update( final Object cursor )
 	{
 		// directly get data?
-		return ( ( CellImgSampler< C > ) cursor ).getCell().getData();
+		return (A) ( ( CellImgSampler< C > ) cursor ).getCell().getData().createView(cursor);
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/Cell.java
+++ b/src/main/java/net/imglib2/img/cell/Cell.java
@@ -37,6 +37,7 @@ package net.imglib2.img.cell;
 import java.io.Serializable;
 
 import net.imglib2.Interval;
+import net.imglib2.img.basictypeaccess.DataAccess;
 import net.imglib2.util.IntervalIndexer;
 import net.imglib2.util.Intervals;
 
@@ -45,7 +46,7 @@ import net.imglib2.util.Intervals;
  *
  * @author Tobias Pietzsch
  */
-public class Cell< A > implements Interval, Serializable
+public class Cell< A extends DataAccess > implements Interval, Serializable
 {
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/net/imglib2/img/cell/Cell.java
+++ b/src/main/java/net/imglib2/img/cell/Cell.java
@@ -37,7 +37,6 @@ package net.imglib2.img.cell;
 import java.io.Serializable;
 
 import net.imglib2.Interval;
-import net.imglib2.img.basictypeaccess.DataAccess;
 import net.imglib2.util.IntervalIndexer;
 import net.imglib2.util.Intervals;
 
@@ -46,7 +45,7 @@ import net.imglib2.util.Intervals;
  *
  * @author Tobias Pietzsch
  */
-public class Cell< A extends DataAccess > implements Interval, Serializable
+public class Cell< A > implements Interval, Serializable
 {
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/net/imglib2/img/cell/CellImg.java
+++ b/src/main/java/net/imglib2/img/cell/CellImg.java
@@ -34,11 +34,12 @@
 package net.imglib2.img.cell;
 
 import net.imglib2.img.ImgFactory;
+import net.imglib2.img.basictypeaccess.DataAccess;
 import net.imglib2.img.list.ListImg;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Fraction;
 
-public class CellImg< T extends NativeType< T >, A > extends AbstractCellImg< T, A, Cell< A >, ListImg< Cell< A > > >
+public class CellImg< T extends NativeType< T >, A extends DataAccess > extends AbstractCellImg< T, A, Cell< A >, ListImg< Cell< A > > >
 {
 	private final CellImgFactory< T > factory;
 

--- a/src/main/java/net/imglib2/img/cell/LazyCellImg.java
+++ b/src/main/java/net/imglib2/img/cell/LazyCellImg.java
@@ -35,6 +35,7 @@ package net.imglib2.img.cell;
 
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
+import net.imglib2.img.basictypeaccess.DataAccess;
 import net.imglib2.img.cell.LazyCellImg.LazyCells;
 import net.imglib2.img.list.AbstractLongListImg;
 import net.imglib2.type.NativeType;
@@ -53,7 +54,7 @@ import net.imglib2.util.Fraction;
  *
  * @author Tobias Pietzsch
  */
-public class LazyCellImg< T extends NativeType< T >, A >
+public class LazyCellImg< T extends NativeType< T >, A extends DataAccess >
 		extends AbstractCellImg< T, A, Cell< A >, LazyCells< Cell< A > > >
 {
 	@FunctionalInterface

--- a/src/main/java/net/imglib2/img/planar/PlanarImg.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImg.java
@@ -116,7 +116,7 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 	public A update( final Object c )
 	{
 		final int i = ( ( PlanarContainerSampler ) c ).getCurrentSliceIndex();
-		return (A) mirror.get( i < 0 ? 0 : ( i >= numSlices ? numSlices - 1 : i ) ).createView(c);
+		return ( A ) mirror.get( i < 0 ? 0 : ( i >= numSlices ? numSlices - 1 : i ) ).createView( c );
 	}
 
 	/**
@@ -342,7 +342,7 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 	/**
 	 * How many slices has a PlanarImg with the given dimensions?
 	 */
-	public static int numberOfSlices( long[] dimensions )
+	public static int numberOfSlices( final long[] dimensions )
 	{
 		int s = 1;
 		for ( int d = 2; d < dimensions.length; ++d )
@@ -352,39 +352,39 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 
 	// -- Helper methods --
 
-	private static int[] longToIntArray( long[] dim )
+	private static int[] longToIntArray( final long[] dim )
 	{
-		int[] dimensions = new int[ dim.length ];
+		final int[] dimensions = new int[ dim.length ];
 		for ( int d = 0; d < dim.length; ++d )
 			dimensions[ d ] = ( int ) dim[ d ];
 		return dimensions;
 	}
 
-	private static int[] computeSliceSteps( long[] dimensions )
+	private static int[] computeSliceSteps( final long[] dimensions )
 	{
 		final int n = dimensions.length;
 		if ( n <= 2 )
 			return null;
-		int[] sliceSteps = new int[ n ];
+		final int[] sliceSteps = new int[ n ];
 		sliceSteps[ 2 ] = 1;
 		for ( int i = 3; i < n; ++i )
 			sliceSteps[ i ] = ( int ) dimensions[ i - 1 ] * sliceSteps[ i - 1 ];
 		return sliceSteps;
 	}
 
-	private static < A > List< A > emptySlices( long[] dim )
+	private static < A > List< A > emptySlices( final long[] dim )
 	{
-		int numSlices = numberOfSlices( dim );
-		List< A > mirror = new ArrayList<>( numSlices );
+		final int numSlices = numberOfSlices( dim );
+		final List< A > mirror = new ArrayList<>( numSlices );
 		for ( int i = 0; i < numSlices; ++i )
 			mirror.add( null );
 		return mirror;
 	}
 
-	private static < A extends ArrayDataAccess< A > > List< A > createSlices( A creator, long[] dim, Fraction entitiesPerPixel )
+	private static < A extends ArrayDataAccess< A > > List< A > createSlices( final A creator, final long[] dim, final Fraction entitiesPerPixel )
 	{
-		int numSlices = numberOfSlices( dim );
-		List< A > mirror = new ArrayList<>( numSlices );
+		final int numSlices = numberOfSlices( dim );
+		final List< A > mirror = new ArrayList<>( numSlices );
 		final int pixelsPerPlane = (int) (( ( dim.length > 1 ) ? dim[ 1 ] : 1 ) * dim[ 0 ]);
 		final int numEntitiesPerSlice = ( int ) entitiesPerPixel.mulCeil( pixelsPerPlane );
 		for ( int i = 0; i < numSlices; ++i )

--- a/src/main/java/net/imglib2/img/planar/PlanarImg.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImg.java
@@ -111,11 +111,12 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 		public int getCurrentSliceIndex();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public A update( final Object c )
 	{
 		final int i = ( ( PlanarContainerSampler ) c ).getCurrentSliceIndex();
-		return mirror.get( i < 0 ? 0 : ( i >= numSlices ? numSlices - 1 : i ) );
+		return (A) mirror.get( i < 0 ? 0 : ( i >= numSlices ? numSlices - 1 : i ) ).createView(c);
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/sparse/NtreeAccess.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeAccess.java
@@ -34,10 +34,17 @@
 
 package net.imglib2.img.sparse;
 
-public interface NtreeAccess< L extends Comparable< L >, A extends NtreeAccess< L, A > >
+import net.imglib2.img.basictypeaccess.DataAccess;
+import net.imglib2.img.sparse.NtreeImg.PositionProvider;
+
+public interface NtreeAccess< L extends Comparable< L >, A extends NtreeAccess< L, A > > extends DataAccess
 {
 
 	Ntree< L > getCurrentStorageNtree();
 
 	A createInstance( long[] pos );
+	
+	public default A createView(Object updater) {
+		return createInstance( ( ( PositionProvider ) updater ).getPosition() );
+	}
 }

--- a/src/main/java/net/imglib2/img/sparse/NtreeAccess.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeAccess.java
@@ -43,8 +43,10 @@ public interface NtreeAccess< L extends Comparable< L >, A extends NtreeAccess< 
 	Ntree< L > getCurrentStorageNtree();
 
 	A createInstance( long[] pos );
-	
-	public default A createView(Object updater) {
+
+	@Override
+	public default A createView( final Object updater )
+	{
 		return createInstance( ( ( PositionProvider ) updater ).getPosition() );
 	}
 }

--- a/src/main/java/net/imglib2/img/sparse/NtreeImg.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeImg.java
@@ -79,7 +79,7 @@ public final class NtreeImg< T extends NativeType< T >, A extends NtreeAccess< ?
 	@Override
 	public A update( final Object updater )
 	{
-		return data.createView(updater);
+		return data.createView( updater );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/sparse/NtreeImg.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeImg.java
@@ -79,7 +79,7 @@ public final class NtreeImg< T extends NativeType< T >, A extends NtreeAccess< ?
 	@Override
 	public A update( final Object updater )
 	{
-		return data.createInstance( ( ( PositionProvider ) updater ).getPosition() );
+		return data.createView(updater);
 	}
 
 	@Override


### PR DESCRIPTION
# Buffer-backed access (full implementation)

These changes complete #278 and fixes #5 

7cc0468 implements a lightweight interface `DataAccess` with a `createView(Object)` method as per the Twitter discussion. It also includes a default implementation that just returns `this`. The interface definition returns type `Object`, which seems better than my attempt to parameterize generics across the entire `Access` tree.

6f851db contains the `BufferAccess` interface and its implementations. Per @hanslovsky's design in #278 `BufferAccess` implements `ArrayDataAccess` and `VolatileAccess`. The concrete classes share a common `AbstractBufferAccess`.

The `net.imglib2.img.basictypeaccess.nio` tree is as follows:

* BufferAccess implements VolatileAccess, ArrayDataAccess
    * AbstractBufferAccess
        * ByteBufferAccess
        * CharBufferAccess
        * FloatBufferAccess
        * DoubleBufferAccess
        * IntBufferAccess
        * ShortBufferAccess
        * LongBufferAccess

## Answers to open questions in #278 

### General
1. `ArrayDataAccess` is implemented as follows
    * `createArray( int numEntities )` allocates a new `java.nio.Buffer` based on whether the current one `isDirect` or not and if the current `Access` `isValid`
    * `getCurrentStorageArray()` returns the raw `Buffer` without duplicating it
    * `getArrayLength()` is returns `Buffer.limit()` (as opposed to `Buffer.capacity()` as in #278)
2. `VolatileAccess` is implemented with support from `AbstractBufferAccess`
3. All concrete classes store a type-specific `Buffer`
    * Per https://github.com/imglib/imglib2/pull/278#issuecomment-565815728 , all concrete classes can also be constructed from a `java.nio.ByteBuffer` and contain a `fromByteBuffer` static method.

### Specific
1. As in https://github.com/imglib/imglib2/pull/278#issuecomment-565822116 and item 1 above, `createArray( int numEntities )` allocates a `Buffer` that has the same directness as the current `Buffer`

## Differences to imglib[1] NIO*Array

The current implementation differs from the previous NIO*Array (e.g. [`NIOLongArray`](https://github.com/fiji/legacy-imglib1/blob/master/src/main/java/mpicbg/imglib/container/basictypecontainer/array/NIOLongArray.java) :
1. The constructor receives a `java.nio.Buffer` directly rather than array. The user can wrap (e.g. `LongBuffer.wrap`) an array if needed.
2. `getCurrentStorageArray` returns a `BufferAccess` rather than an `Array`

## New Items

1. I named the classes `LongBufferAccess` rather than `NIOLongArray` or `LongBufferLongAccess`. The buffers are distinct from arrays. Also the `Buffer` type and `Access` type are always the same in this implementation.
2. I proxied in the bulk relative `get` and `put` methods of `java.nio.LongBuffer` as `getValues` and `setValues` that allows the user to quickly copy in or out data using the corresponding `Array` access (e.g. `AbstractLongArray` as of f5609a6). This is mainly a convenience and could be dropped.
3. `Buffer.duplicate()` is only used in `DataAccess.createView(Object)` and in the bulk `getValues` and `setValues` methods. `Buffer.duplicate()` only actually exists in Java 9+ but is implemented in the concrete classes in Java 8 (e.g. `LongBuffer`)

## Change Log

* f5609a6 Changed to using the `Abstract*Array` types rather than `*Array`.