### PR TITLE
numElements returns zero for empty Intervals

### DIFF
--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -545,13 +545,16 @@ public class Intervals
 	 *
 	 * Create a {@link FinalInterval} that represents that interval.
 	 *
+	 * May produce unexpected results for empty {@link Interval}s. Use {@link union} if
+	 * either input interval could be empty.
+	 *
 	 * @param intervalA
 	 *            input interval
 	 * @param intervalB
 	 *            input interval
 	 * @return union of input intervals
 	 */
-	public static FinalInterval union( final Interval intervalA, final Interval intervalB )
+	public static FinalInterval unionUnsafe( final Interval intervalA, final Interval intervalB )
 	{
 		assert intervalA.numDimensions() == intervalB.numDimensions();
 
@@ -569,6 +572,66 @@ public class Intervals
 	/**
 	 * Compute the smallest interval that contains both input intervals.
 	 *
+	 * Create a {@link FinalInterval} that represents that interval.
+	 *
+	 * @param intervalA
+	 *            input interval
+	 * @param intervalB
+	 *            input interval
+	 * @return union of input intervals
+	 */
+	public static FinalInterval union( final Interval intervalA, final Interval intervalB )
+	{
+		assert intervalA.numDimensions() == intervalB.numDimensions();
+
+		if( isEmpty( intervalA ))
+			return new FinalInterval( intervalB );
+		else if( isEmpty( intervalB ))
+			return new FinalInterval( intervalA );
+
+		final int n = intervalA.numDimensions();
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		for ( int d = 0; d < n; ++d )
+		{
+			min[ d ] = Math.min( intervalA.min( d ), intervalB.min( d ) );
+			max[ d ] = Math.max( intervalA.max( d ), intervalB.max( d ) );
+		}
+		return new FinalInterval( min, max );
+	}
+
+	/**
+	 * Compute the smallest interval that contains both input intervals.
+	 *
+	 * Create a {@link RealInterval} that represents that interval.
+	 *
+	 * May produce unexpected results for empty {@link RealInterval}s. Use {@link union} if
+	 * either input interval could be empty.
+	 *
+	 * @param intervalA
+	 *            input interval
+	 * @param intervalB
+	 *            input interval
+	 * @return union of input intervals
+	 */
+	public static FinalRealInterval unionUnsafe( final RealInterval intervalA, final RealInterval intervalB )
+	{
+		assert intervalA.numDimensions() == intervalB.numDimensions();
+
+		final int n = intervalA.numDimensions();
+		final double[] min = new double[ n ];
+		final double[] max = new double[ n ];
+		for ( int d = 0; d < n; ++d )
+		{
+			min[ d ] = Math.min( intervalA.realMin( d ), intervalB.realMin( d ) );
+			max[ d ] = Math.max( intervalA.realMax( d ), intervalB.realMax( d ) );
+		}
+		return new FinalRealInterval( min, max );
+	}
+
+	/**
+	 * Compute the smallest interval that contains both input intervals.
+	 *
 	 * Create a {@link RealInterval} that represents that interval.
 	 *
 	 * @param intervalA
@@ -580,6 +643,11 @@ public class Intervals
 	public static FinalRealInterval union( final RealInterval intervalA, final RealInterval intervalB )
 	{
 		assert intervalA.numDimensions() == intervalB.numDimensions();
+
+		if( isEmpty( intervalA ))
+			return new FinalRealInterval( intervalB );
+		else if( isEmpty( intervalB ))
+			return new FinalRealInterval( intervalA );
 
 		final int n = intervalA.numDimensions();
 		final double[] min = new double[ n ];

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -589,15 +589,7 @@ public class Intervals
 		else if( isEmpty( intervalB ))
 			return new FinalInterval( intervalA );
 
-		final int n = intervalA.numDimensions();
-		final long[] min = new long[ n ];
-		final long[] max = new long[ n ];
-		for ( int d = 0; d < n; ++d )
-		{
-			min[ d ] = Math.min( intervalA.min( d ), intervalB.min( d ) );
-			max[ d ] = Math.max( intervalA.max( d ), intervalB.max( d ) );
-		}
-		return new FinalInterval( min, max );
+		return unionUnsafe( intervalA, intervalB );
 	}
 
 	/**
@@ -649,15 +641,7 @@ public class Intervals
 		else if( isEmpty( intervalB ))
 			return new FinalRealInterval( intervalA );
 
-		final int n = intervalA.numDimensions();
-		final double[] min = new double[ n ];
-		final double[] max = new double[ n ];
-		for ( int d = 0; d < n; ++d )
-		{
-			min[ d ] = Math.min( intervalA.realMin( d ), intervalB.realMin( d ) );
-			max[ d ] = Math.max( intervalA.realMax( d ), intervalB.realMax( d ) );
-		}
-		return new FinalRealInterval( min, max );
+		return unionUnsafe( intervalA, intervalB );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -756,10 +756,10 @@ public class Intervals
 	 */
 	public static long numElements( final Dimensions interval )
 	{
-		long numPixels = interval.dimension( 0 ) > 0 ? interval.dimension( 0 ) : 0;
+		long numPixels = Math.max( interval.dimension( 0 ), 0 );
 		final int n = interval.numDimensions();
 		for ( int d = 1; d < n; ++d )
-			numPixels *= interval.dimension( d ) > 0 ? interval.dimension( d ) : 0;
+			numPixels *= Math.max( interval.dimension( d ), 0 );
 		return numPixels;
 	}
 
@@ -772,9 +772,9 @@ public class Intervals
 	 */
 	public static long numElements( final int... dimensions )
 	{
-		long numPixels = dimensions[ 0 ] > 0 ? dimensions[ 0 ] : 0;
+		long numPixels = Math.max( dimensions[ 0 ], 0 );
 		for ( int d = 1; d < dimensions.length; ++d )
-			numPixels *= dimensions[ d ] > 0 ? dimensions[ d ] : 0;
+			numPixels *= Math.max( dimensions[ d ], 0 );
 		return numPixels;
 	}
 
@@ -787,9 +787,9 @@ public class Intervals
 	 */
 	public static long numElements( final long... dimensions )
 	{
-		long numPixels = dimensions[ 0 ] > 0 ? dimensions[ 0 ] : 0;
+		long numPixels = Math.max( dimensions[ 0 ], 0 );
 		for ( int d = 1; d < dimensions.length; ++d )
-			numPixels *= dimensions[ d ] > 0 ? dimensions[ d ] : 0;
+			numPixels *= Math.max( dimensions[ d ], 0 );
 		return numPixels;
 	}
 

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -545,8 +545,8 @@ public class Intervals
 	 *
 	 * Create a {@link FinalInterval} that represents that interval.
 	 *
-	 * May produce unexpected results for empty {@link Interval}s. Use {@link union} if
-	 * either input interval could be empty.
+	 * May produce unexpected results for empty {@link Interval}s.
+	 * Use {@link #union(Interval, Interval)} if either input interval could be empty.
 	 *
 	 * @param intervalA
 	 *            input interval
@@ -605,8 +605,8 @@ public class Intervals
 	 *
 	 * Create a {@link RealInterval} that represents that interval.
 	 *
-	 * May produce unexpected results for empty {@link RealInterval}s. Use {@link union} if
-	 * either input interval could be empty.
+	 * May produce unexpected results for empty {@link RealInterval}s.
+	 * Use {@link #union(RealInterval, RealInterval)} if either input interval could be empty.
 	 *
 	 * @param intervalA
 	 *            input interval

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -756,10 +756,10 @@ public class Intervals
 	 */
 	public static long numElements( final Dimensions interval )
 	{
-		long numPixels = interval.dimension( 0 );
+		long numPixels = interval.dimension( 0 ) > 0 ? interval.dimension( 0 ) : 0;
 		final int n = interval.numDimensions();
 		for ( int d = 1; d < n; ++d )
-			numPixels *= interval.dimension( d );
+			numPixels *= interval.dimension( d ) > 0 ? interval.dimension( d ) : 0;
 		return numPixels;
 	}
 
@@ -772,9 +772,9 @@ public class Intervals
 	 */
 	public static long numElements( final int... dimensions )
 	{
-		long numPixels = dimensions[ 0 ];
+		long numPixels = dimensions[ 0 ] > 0 ? dimensions[ 0 ] : 0;
 		for ( int d = 1; d < dimensions.length; ++d )
-			numPixels *= dimensions[ d ];
+			numPixels *= dimensions[ d ] > 0 ? dimensions[ d ] : 0;
 		return numPixels;
 	}
 
@@ -787,9 +787,9 @@ public class Intervals
 	 */
 	public static long numElements( final long... dimensions )
 	{
-		long numPixels = dimensions[ 0 ];
+		long numPixels = dimensions[ 0 ] > 0 ? dimensions[ 0 ] : 0;
 		for ( int d = 1; d < dimensions.length; ++d )
-			numPixels *= dimensions[ d ];
+			numPixels *= dimensions[ d ] > 0 ? dimensions[ d ] : 0;
 		return numPixels;
 	}
 

--- a/src/test/java/net/imglib2/util/IntervalsTest.java
+++ b/src/test/java/net/imglib2/util/IntervalsTest.java
@@ -226,5 +226,8 @@ public class IntervalsTest
 		assertTrue( "self-intersection", Intervals.equals( a, aIa ));
 		assertTrue( "intersection order", Intervals.equals( bIa, aIb ));
 		assertEquals( "non-intersecting", 0, Intervals.numElements( aIc ));
+
+		assertFalse( "intersecting not empty", Intervals.isEmpty( aIb ));
+		assertTrue( "non-intersecting is empty", Intervals.isEmpty( aIc ));
 	}
 }

--- a/src/test/java/net/imglib2/util/IntervalsTest.java
+++ b/src/test/java/net/imglib2/util/IntervalsTest.java
@@ -230,4 +230,51 @@ public class IntervalsTest
 		assertFalse( "intersecting not empty", Intervals.isEmpty( aIb ));
 		assertTrue( "non-intersecting is empty", Intervals.isEmpty( aIc ));
 	}
+
+	@Test
+	public void testUnion()
+	{
+		final FinalInterval a = FinalInterval.createMinMax( 1, 2, 3, 4 );
+		final FinalInterval b = FinalInterval.createMinMax( 2, 3, 4, 5 );
+		final FinalInterval aUbTrue = FinalInterval.createMinMax( 1, 2, 4, 5 );
+
+		final FinalInterval aUa = Intervals.union( a, a );
+		assertTrue( "self-union", Intervals.equals( a, aUa ));
+
+		final FinalInterval aUb = Intervals.union( a, b );
+		final FinalInterval bUa = Intervals.union( a, b );
+		assertEquals( "union", aUbTrue, aUb );
+		assertEquals( "union commutes", aUbTrue, bUa );
+
+		final FinalInterval empty = FinalInterval.createMinMax( 0, 0, -1, -1 );
+		final FinalInterval aUempty = Intervals.union( a, empty );
+		assertEquals( "union with empty", a, aUempty );
+
+		final FinalInterval emptyUempty = Intervals.union( empty, empty );
+		assertEquals( "empty union empty", empty, emptyUempty );
+	}
+
+	@Test
+	public void testRealUnion()
+	{
+		final double eps = 1e-9;
+		final FinalRealInterval a = FinalRealInterval.createMinMax( 1.1, 2.2, 3.3, 4.4 );
+		final FinalRealInterval b = FinalRealInterval.createMinMax( 2.2, 3.3, 4.4, 5.5 );
+		final FinalRealInterval aUbTrue = FinalRealInterval.createMinMax( 1.1, 2.2, 4.4, 5.5 );
+
+		final FinalRealInterval aUa = Intervals.union( a, a );
+		assertTrue( "self-union", Intervals.equals( a, aUa ));
+
+		final FinalRealInterval aUb = Intervals.union( a, b );
+		final FinalRealInterval bUa = Intervals.union( a, b );
+		assertTrue( "union", Intervals.equals( aUbTrue, aUb, eps) );
+		assertTrue( "union commutes", Intervals.equals( aUbTrue, bUa, eps) );
+
+		final FinalRealInterval empty = FinalRealInterval.createMinMax( 0, 0, -1, -1 );
+		final FinalRealInterval aUempty = Intervals.union( a, empty );
+		assertTrue( "union with empty", Intervals.equals( a, aUempty, eps ));
+
+		final FinalRealInterval emptyUempty = Intervals.union( empty, empty );
+		assertTrue( "empty union empty", Intervals.equals( empty, emptyUempty, eps ));
+	}
 }

--- a/src/test/java/net/imglib2/util/IntervalsTest.java
+++ b/src/test/java/net/imglib2/util/IntervalsTest.java
@@ -36,6 +36,7 @@ package net.imglib2.util;
 
 import net.imglib2.Dimensions;
 import net.imglib2.FinalDimensions;
+import net.imglib2.FinalInterval;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.RealInterval;
@@ -43,6 +44,7 @@ import net.imglib2.test.ImgLib2Assert;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -207,5 +209,22 @@ public class IntervalsTest
 		final Dimensions differentDimensions = new FinalDimensions( 1, 3 );
 		assertTrue( Intervals.equalDimensions( dimensions, sameDimensions ) );
 		assertFalse( Intervals.equalDimensions( dimensions, differentDimensions ) );
+	}
+
+	@Test
+	public void testIntersection()
+	{
+		final Interval a = FinalInterval.createMinMax( 1, 2, 3, 4 );
+		final Interval b = FinalInterval.createMinMax( 2, 3, 4, 5 );
+		final Interval c = FinalInterval.createMinMax( 4, 5, 6, 7 );
+
+		final Interval aIa = Intervals.intersect( a, a );
+		final Interval aIb = Intervals.intersect( a, b );
+		final Interval bIa = Intervals.intersect( b, a );
+		final Interval aIc = Intervals.intersect( a, c );
+
+		assertTrue( "self-intersection", Intervals.equals( a, aIa ));
+		assertTrue( "intersection order", Intervals.equals( bIa, aIb ));
+		assertEquals( "non-intersecting", 0, Intervals.numElements( aIc ));
 	}
 }


### PR DESCRIPTION
Changes the implementation of `Intervals.numElements` so that it returns zero "empty" `Interval`s 
Where an `Interval` is "empty" if its `max(d)` < `min(d)` for any `d`

If we agree, then this definition should be documented.

see #300