### PR TITLE
Use Index object for NativeTypes instead of index fields

### DIFF
--- a/src/main/java/net/imglib2/img/array/AbstractArrayCursor.java
+++ b/src/main/java/net/imglib2/img/array/AbstractArrayCursor.java
@@ -36,6 +36,7 @@ package net.imglib2.img.array;
 
 import net.imglib2.AbstractCursorInt;
 import net.imglib2.Cursor;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.IntervalIndexer;
 
@@ -68,6 +69,8 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 	 */
 	protected final T type;
 
+	private final Index index;
+
 	/**
 	 * Source image
 	 */
@@ -89,11 +92,12 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 
 		this.img = cursor.img;
 		this.type = img.createLinkedType();
+		this.index = type.index();
 		this.offset = cursor.offset;
 		this.size = cursor.size;
 		this.lastIndex = cursor.lastIndex;
 
-		type.updateIndex( cursor.type.getIndex() );
+		index.set( cursor.index.get() );
 		type.updateContainer( this );
 	}
 
@@ -109,6 +113,7 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 		super( img.numDimensions() );
 
 		this.type = img.createLinkedType();
+		this.index = type.index();
 		this.img = img;
 		this.lastIndex = offset + size - 1;
 		this.offset = offset;
@@ -126,25 +131,25 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 	@Override
 	public boolean hasNext()
 	{
-		return type.getIndex() < lastIndex;
+		return index.get() < lastIndex;
 	}
 
 	@Override
 	public void jumpFwd( final long steps )
 	{
-		type.incIndex( ( int ) steps );
+		index.inc( ( int ) steps );
 	}
 
 	@Override
 	public void fwd()
 	{
-		type.incIndex();
+		index.inc();
 	}
 
 	@Override
 	public void reset()
 	{
-		type.updateIndex( offset - 1 );
+		index.set( offset - 1 );
 		type.updateContainer( this );
 	}
 
@@ -157,12 +162,12 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 	@Override
 	public int getIntPosition( final int dim )
 	{
-		return IntervalIndexer.indexToPosition( type.getIndex(), img.dim, dim );
+		return IntervalIndexer.indexToPosition( index.get(), img.dim, dim );
 	}
 
 	@Override
 	public void localize( final int[] position )
 	{
-		IntervalIndexer.indexToPosition( type.getIndex(), img.dim, position );
+		IntervalIndexer.indexToPosition( index.get(), img.dim, position );
 	}
 }

--- a/src/main/java/net/imglib2/img/array/AbstractArrayCursor.java
+++ b/src/main/java/net/imglib2/img/array/AbstractArrayCursor.java
@@ -69,7 +69,7 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 	 */
 	protected final T type;
 
-	private final Index index;
+	private final Index typeIndex;
 
 	/**
 	 * Source image
@@ -92,12 +92,12 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 
 		this.img = cursor.img;
 		this.type = img.createLinkedType();
-		this.index = type.index();
+		this.typeIndex = type.index();
 		this.offset = cursor.offset;
 		this.size = cursor.size;
 		this.lastIndex = cursor.lastIndex;
 
-		index.set( cursor.index.get() );
+		typeIndex.set( cursor.typeIndex.get() );
 		type.updateContainer( this );
 	}
 
@@ -113,7 +113,7 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 		super( img.numDimensions() );
 
 		this.type = img.createLinkedType();
-		this.index = type.index();
+		this.typeIndex = type.index();
 		this.img = img;
 		this.lastIndex = offset + size - 1;
 		this.offset = offset;
@@ -131,25 +131,25 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 	@Override
 	public boolean hasNext()
 	{
-		return index.get() < lastIndex;
+		return typeIndex.get() < lastIndex;
 	}
 
 	@Override
 	public void jumpFwd( final long steps )
 	{
-		index.inc( ( int ) steps );
+		typeIndex.inc( ( int ) steps );
 	}
 
 	@Override
 	public void fwd()
 	{
-		index.inc();
+		typeIndex.inc();
 	}
 
 	@Override
 	public void reset()
 	{
-		index.set( offset - 1 );
+		typeIndex.set( offset - 1 );
 		type.updateContainer( this );
 	}
 
@@ -162,12 +162,12 @@ public abstract class AbstractArrayCursor< T extends NativeType< T > > extends A
 	@Override
 	public int getIntPosition( final int dim )
 	{
-		return IntervalIndexer.indexToPosition( index.get(), img.dim, dim );
+		return IntervalIndexer.indexToPosition( typeIndex.get(), img.dim, dim );
 	}
 
 	@Override
 	public void localize( final int[] position )
 	{
-		IntervalIndexer.indexToPosition( index.get(), img.dim, position );
+		IntervalIndexer.indexToPosition( typeIndex.get(), img.dim, position );
 	}
 }

--- a/src/main/java/net/imglib2/img/array/AbstractArrayLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/array/AbstractArrayLocalizingCursor.java
@@ -70,7 +70,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	 */
 	protected final T type;
 
-	private final Index index;
+	private final Index typeIndex;
 
 	/**
 	 * The underlying source {@link ArrayImg}.
@@ -99,7 +99,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 
 		this.img = cursor.img;
 		this.type = img.createLinkedType();
-		this.index = type.index();
+		this.typeIndex = type.index();
 		this.offset = cursor.offset;
 		this.size = cursor.size;
 
@@ -112,7 +112,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 			max[ d ] = cursor.max[ d ];
 		}
 
-		index.set( cursor.index.get() );
+		typeIndex.set( cursor.typeIndex.get() );
 		type.updateContainer( this );
 	}
 
@@ -132,7 +132,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 		this.size = size;
 
 		this.type = img.createLinkedType();
-		this.index = type.index();
+		this.typeIndex = type.index();
 		this.lastIndex = offset + size - 1;
 
 		max = new int[ n ];
@@ -157,7 +157,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public boolean hasNext()
 	{
-		return index.get() < lastIndex;
+		return typeIndex.get() < lastIndex;
 	}
 
 	/**
@@ -166,7 +166,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public void fwd()
 	{
-		index.inc();
+		typeIndex.inc();
 
 //		 for ( int d = 0; d < n; ++d )
 //		 {
@@ -207,8 +207,8 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public void jumpFwd( final long steps )
 	{
-		index.inc( ( int ) steps );
-		IntervalIndexer.indexToPosition( index.get(), img.dim, position );
+		typeIndex.inc( ( int ) steps );
+		IntervalIndexer.indexToPosition( typeIndex.get(), img.dim, position );
 	}
 
 	/**
@@ -217,7 +217,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public void reset()
 	{
-		index.set( offset - 1 );
+		typeIndex.set( offset - 1 );
 
 		IntervalIndexer.indexToPosition( offset, img.dim, position );
 		position[ 0 ]--;

--- a/src/main/java/net/imglib2/img/array/AbstractArrayLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/array/AbstractArrayLocalizingCursor.java
@@ -36,6 +36,7 @@ package net.imglib2.img.array;
 
 import net.imglib2.AbstractLocalizingCursorInt;
 import net.imglib2.Cursor;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.IntervalIndexer;
 
@@ -69,6 +70,8 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	 */
 	protected final T type;
 
+	private final Index index;
+
 	/**
 	 * The underlying source {@link ArrayImg}.
 	 */
@@ -96,6 +99,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 
 		this.img = cursor.img;
 		this.type = img.createLinkedType();
+		this.index = type.index();
 		this.offset = cursor.offset;
 		this.size = cursor.size;
 
@@ -108,7 +112,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 			max[ d ] = cursor.max[ d ];
 		}
 
-		type.updateIndex( cursor.type.getIndex() );
+		index.set( cursor.index.get() );
 		type.updateContainer( this );
 	}
 
@@ -128,6 +132,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 		this.size = size;
 
 		this.type = img.createLinkedType();
+		this.index = type.index();
 		this.lastIndex = offset + size - 1;
 
 		max = new int[ n ];
@@ -152,7 +157,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public boolean hasNext()
 	{
-		return type.getIndex() < lastIndex;
+		return index.get() < lastIndex;
 	}
 
 	/**
@@ -161,7 +166,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public void fwd()
 	{
-		type.incIndex();
+		index.inc();
 
 //		 for ( int d = 0; d < n; ++d )
 //		 {
@@ -202,8 +207,8 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public void jumpFwd( final long steps )
 	{
-		type.incIndex( ( int ) steps );
-		IntervalIndexer.indexToPosition( type.getIndex(), img.dim, position );
+		index.inc( ( int ) steps );
+		IntervalIndexer.indexToPosition( index.get(), img.dim, position );
 	}
 
 	/**
@@ -212,11 +217,11 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public void reset()
 	{
-		type.updateIndex( offset - 1 );
+		index.set( offset - 1 );
 
 		IntervalIndexer.indexToPosition( offset, img.dim, position );
 		position[ 0 ]--;
 
-		type.updateContainer( this );
+		type.updateContainer( this ); // TODO: This is unnecessary. Remove.
 	}
 }

--- a/src/main/java/net/imglib2/img/array/ArrayRandomAccess.java
+++ b/src/main/java/net/imglib2/img/array/ArrayRandomAccess.java
@@ -37,6 +37,7 @@ package net.imglib2.img.array;
 import net.imglib2.AbstractLocalizableInt;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -52,6 +53,8 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 {
 	protected final T type;
 
+	private final Index index;
+
 	final ArrayImg< T, ? > img;
 
 	protected ArrayRandomAccess( final ArrayRandomAccess< T > randomAccess )
@@ -60,16 +63,16 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 
 		this.img = randomAccess.img;
 		this.type = img.createLinkedType();
+		this.index = type.index();
 
-		int index = 0;
+		index.set( 0 );
 		for ( int d = 0; d < n; d++ )
 		{
 			position[ d ] = randomAccess.position[ d ];
-			index += position[ d ] * img.steps[ d ];
+			index.inc( position[ d ] * img.steps[ d ] );
 		}
 
 		type.updateContainer( this );
-		type.updateIndex( index );
 	}
 
 	public ArrayRandomAccess( final ArrayImg< T, ? > container )
@@ -78,12 +81,13 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 
 		this.img = container;
 		this.type = container.createLinkedType();
+		this.index = type.index();
 
+		index.set( 0 );
 		for ( int d = 0; d < n; d++ )
 			position[ d ] = 0;
 
 		type.updateContainer( this );
-		type.updateIndex( 0 );
 	}
 
 	@Override
@@ -95,116 +99,116 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	@Override
 	public void fwd( final int d )
 	{
-		type.incIndex( img.steps[ d ] );
+		index.inc( img.steps[ d ] );
 		++position[ d ];
 	}
 
 	@Override
 	public void bck( final int d )
 	{
-		type.decIndex( img.steps[ d ] );
+		index.dec( img.steps[ d ] );
 		--position[ d ];
 	}
 
 	@Override
 	public void move( final int distance, final int d )
 	{
-		type.incIndex( img.steps[ d ] * distance );
+		index.inc( img.steps[ d ] * distance );
 		position[ d ] += distance;
 	}
 
 	@Override
 	public void move( final long distance, final int d )
 	{
-		type.incIndex( img.steps[ d ] * ( int ) distance );
+		index.inc( img.steps[ d ] * ( int ) distance );
 		position[ d ] += distance;
 	}
 
 	@Override
 	public void move( final Localizable localizable )
 	{
-		int index = 0;
+		int move = 0;
 		for ( int d = 0; d < n; ++d )
 		{
 			final int distance = localizable.getIntPosition( d );
 			position[ d ] += distance;
-			index += distance * img.steps[ d ];
+			move += distance * img.steps[ d ];
 		}
-		type.incIndex( index );
+		index.inc( move );
 	}
 
 	@Override
 	public void move( final int[] distance )
 	{
-		int index = 0;
+		int move = 0;
 		for ( int d = 0; d < n; ++d )
 		{
 			position[ d ] += distance[ d ];
-			index += distance[ d ] * img.steps[ d ];
+			move += distance[ d ] * img.steps[ d ];
 		}
-		type.incIndex( index );
+		index.inc( move );
 	}
 
 	@Override
 	public void move( final long[] distance )
 	{
-		int index = 0;
+		int move = 0;
 		for ( int d = 0; d < n; ++d )
 		{
 			position[ d ] += distance[ d ];
-			index += distance[ d ] * img.steps[ d ];
+			move += distance[ d ] * img.steps[ d ];
 		}
-		type.incIndex( index );
+		index.inc( move );
 	}
 
 	@Override
 	public void setPosition( final Localizable localizable )
 	{
-		int index = 0;
+		int i = 0;
 		for ( int d = 0; d < n; ++d )
 		{
 			position[ d ] = localizable.getIntPosition( d );
-			index += position[ d ] * img.steps[ d ];
+			i += position[ d ] * img.steps[ d ];
 		}
-		type.updateIndex( index );
+		index.set( i );
 	}
 
 	@Override
 	public void setPosition( final int[] pos )
 	{
-		int index = 0;
+		int i = 0;
 		for ( int d = 0; d < n; ++d )
 		{
 			position[ d ] = pos[ d ];
-			index += pos[ d ] * img.steps[ d ];
+			i += pos[ d ] * img.steps[ d ];
 		}
-		type.updateIndex( index );
+		index.set( i );
 	}
 
 	@Override
 	public void setPosition( final long[] pos )
 	{
-		int index = 0;
+		int i = 0;
 		for ( int d = 0; d < n; ++d )
 		{
 			final int p = ( int ) pos[ d ];
 			position[ d ] = p;
-			index += p * img.steps[ d ];
+			i += p * img.steps[ d ];
 		}
-		type.updateIndex( index );
+		index.set( i );
 	}
 
 	@Override
 	public void setPosition( final int pos, final int d )
 	{
-		type.incIndex( ( pos - position[ d ] ) * img.steps[ d ] );
+		index.inc( ( pos - position[ d ] ) * img.steps[ d ] );
 		position[ d ] = pos;
 	}
 
 	@Override
 	public void setPosition( final long pos, final int d )
 	{
-		type.incIndex( ( ( int ) pos - position[ d ] ) * img.steps[ d ] );
+		index.inc( ( ( int ) pos - position[ d ] ) * img.steps[ d ] );
 		position[ d ] = ( int ) pos;
 	}
 
@@ -227,7 +231,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void fwdDim0()
 	{
-		type.incIndex();
+		index.inc();
 		++position[ 0 ];
 	}
 
@@ -236,7 +240,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void bckDim0()
 	{
-		type.decIndex();
+		index.dec();
 		--position[ 0 ];
 	}
 
@@ -248,7 +252,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void moveDim0( final int distance )
 	{
-		type.incIndex( distance );
+		index.inc( distance );
 		position[ 0 ] += distance;
 	}
 
@@ -260,7 +264,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void move( final long distance )
 	{
-		type.incIndex( ( int ) distance );
+		index.inc( ( int ) distance );
 		position[ 0 ] += distance;
 	}
 
@@ -275,7 +279,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void setPositionDim0( final int pos )
 	{
-		type.updateIndex( pos );
+		index.set( pos );
 		position[ 0 ] = pos;
 	}
 
@@ -290,7 +294,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void setPositionDim0( final long pos )
 	{
-		type.updateIndex( ( int ) pos );
+		index.set( ( int ) pos );
 		position[ 0 ] = ( int ) pos;
 	}
 }

--- a/src/main/java/net/imglib2/img/array/ArrayRandomAccess.java
+++ b/src/main/java/net/imglib2/img/array/ArrayRandomAccess.java
@@ -53,7 +53,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 {
 	protected final T type;
 
-	private final Index index;
+	private final Index typeIndex;
 
 	final ArrayImg< T, ? > img;
 
@@ -63,13 +63,13 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 
 		this.img = randomAccess.img;
 		this.type = img.createLinkedType();
-		this.index = type.index();
+		this.typeIndex = type.index();
 
-		index.set( 0 );
+		typeIndex.set( 0 );
 		for ( int d = 0; d < n; d++ )
 		{
 			position[ d ] = randomAccess.position[ d ];
-			index.inc( position[ d ] * img.steps[ d ] );
+			typeIndex.inc( position[ d ] * img.steps[ d ] );
 		}
 
 		type.updateContainer( this );
@@ -81,9 +81,9 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 
 		this.img = container;
 		this.type = container.createLinkedType();
-		this.index = type.index();
+		this.typeIndex = type.index();
 
-		index.set( 0 );
+		typeIndex.set( 0 );
 		for ( int d = 0; d < n; d++ )
 			position[ d ] = 0;
 
@@ -99,28 +99,28 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	@Override
 	public void fwd( final int d )
 	{
-		index.inc( img.steps[ d ] );
+		typeIndex.inc( img.steps[ d ] );
 		++position[ d ];
 	}
 
 	@Override
 	public void bck( final int d )
 	{
-		index.dec( img.steps[ d ] );
+		typeIndex.dec( img.steps[ d ] );
 		--position[ d ];
 	}
 
 	@Override
 	public void move( final int distance, final int d )
 	{
-		index.inc( img.steps[ d ] * distance );
+		typeIndex.inc( img.steps[ d ] * distance );
 		position[ d ] += distance;
 	}
 
 	@Override
 	public void move( final long distance, final int d )
 	{
-		index.inc( img.steps[ d ] * ( int ) distance );
+		typeIndex.inc( img.steps[ d ] * ( int ) distance );
 		position[ d ] += distance;
 	}
 
@@ -134,7 +134,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 			position[ d ] += distance;
 			move += distance * img.steps[ d ];
 		}
-		index.inc( move );
+		typeIndex.inc( move );
 	}
 
 	@Override
@@ -146,7 +146,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 			position[ d ] += distance[ d ];
 			move += distance[ d ] * img.steps[ d ];
 		}
-		index.inc( move );
+		typeIndex.inc( move );
 	}
 
 	@Override
@@ -158,7 +158,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 			position[ d ] += distance[ d ];
 			move += distance[ d ] * img.steps[ d ];
 		}
-		index.inc( move );
+		typeIndex.inc( move );
 	}
 
 	@Override
@@ -170,7 +170,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 			position[ d ] = localizable.getIntPosition( d );
 			i += position[ d ] * img.steps[ d ];
 		}
-		index.set( i );
+		typeIndex.set( i );
 	}
 
 	@Override
@@ -182,7 +182,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 			position[ d ] = pos[ d ];
 			i += pos[ d ] * img.steps[ d ];
 		}
-		index.set( i );
+		typeIndex.set( i );
 	}
 
 	@Override
@@ -195,20 +195,20 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 			position[ d ] = p;
 			i += p * img.steps[ d ];
 		}
-		index.set( i );
+		typeIndex.set( i );
 	}
 
 	@Override
 	public void setPosition( final int pos, final int d )
 	{
-		index.inc( ( pos - position[ d ] ) * img.steps[ d ] );
+		typeIndex.inc( ( pos - position[ d ] ) * img.steps[ d ] );
 		position[ d ] = pos;
 	}
 
 	@Override
 	public void setPosition( final long pos, final int d )
 	{
-		index.inc( ( ( int ) pos - position[ d ] ) * img.steps[ d ] );
+		typeIndex.inc( ( ( int ) pos - position[ d ] ) * img.steps[ d ] );
 		position[ d ] = ( int ) pos;
 	}
 
@@ -231,7 +231,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void fwdDim0()
 	{
-		index.inc();
+		typeIndex.inc();
 		++position[ 0 ];
 	}
 
@@ -240,7 +240,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void bckDim0()
 	{
-		index.dec();
+		typeIndex.dec();
 		--position[ 0 ];
 	}
 
@@ -252,7 +252,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void moveDim0( final int distance )
 	{
-		index.inc( distance );
+		typeIndex.inc( distance );
 		position[ 0 ] += distance;
 	}
 
@@ -264,7 +264,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void move( final long distance )
 	{
-		index.inc( ( int ) distance );
+		typeIndex.inc( ( int ) distance );
 		position[ 0 ] += distance;
 	}
 
@@ -279,7 +279,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void setPositionDim0( final int pos )
 	{
-		index.set( pos );
+		typeIndex.set( pos );
 		position[ 0 ] = pos;
 	}
 
@@ -294,7 +294,7 @@ public class ArrayRandomAccess< T extends NativeType< T > > extends AbstractLoca
 	 */
 	public void setPositionDim0( final long pos )
 	{
-		index.set( ( int ) pos );
+		typeIndex.set( ( int ) pos );
 		position[ 0 ] = ( int ) pos;
 	}
 }

--- a/src/main/java/net/imglib2/img/cell/CellCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellCursor.java
@@ -36,6 +36,7 @@ package net.imglib2.img.cell;
 
 import net.imglib2.AbstractCursor;
 import net.imglib2.Cursor;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -48,6 +49,8 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 		implements AbstractCellImg.CellImgSampler< C >
 {
 	protected final T type;
+
+	protected final Index i;
 
 	protected final Cursor< C > cursorOnCells;
 
@@ -69,13 +72,14 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 		super( cursor.numDimensions() );
 
 		this.type = cursor.type.duplicateTypeOnSameNativeImg();
+		i = type.index();
 		this.cursorOnCells = cursor.cursorOnCells.copyCursor();
 		isNotLastCell = cursor.isNotLastCell;
 		lastIndexInCell = cursor.lastIndexInCell;
 		index = cursor.index;
 
 		type.updateContainer( this );
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	public CellCursor( final AbstractCellImg< T, ?, C, ? > img )
@@ -83,6 +87,7 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 		super( img.numDimensions() );
 
 		this.type = img.createLinkedType();
+		i = type.index();
 		this.cursorOnCells = img.getCells().cursor();
 
 		reset();
@@ -130,7 +135,7 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 			lastIndexInCell = ( int ) ( getCell().size() - 1 );
 		}
 		index = ( int ) newIndex;
-		type.updateIndex( index );
+		i.set( index );
 		type.updateContainer( this );
 	}
 
@@ -142,7 +147,7 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 			moveToNextCell();
 			index = 0;
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -150,7 +155,7 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 	{
 		cursorOnCells.reset();
 		moveToNextCell();
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/CellCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellCursor.java
@@ -60,7 +60,7 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 	 * The current index of the type. It is faster to duplicate this here than
 	 * to access it through type.getIndex().
 	 */
-	protected int index;
+	protected int typeIndex;
 
 	/**
 	 * Caches cursorOnCells.hasNext().
@@ -76,10 +76,10 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 		this.cursorOnCells = cursor.cursorOnCells.copyCursor();
 		isNotLastCell = cursor.isNotLastCell;
 		lastIndexInCell = cursor.lastIndexInCell;
-		index = cursor.index;
+		typeIndex = cursor.typeIndex;
 
 		type.updateContainer( this );
-		i.set( index );
+		i.set( typeIndex );
 	}
 
 	public CellCursor( final AbstractCellImg< T, ?, C, ? > img )
@@ -120,13 +120,13 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 	@Override
 	public boolean hasNext()
 	{
-		return ( index < lastIndexInCell ) || isNotLastCell;
+		return ( typeIndex < lastIndexInCell ) || isNotLastCell;
 	}
 
 	@Override
 	public void jumpFwd( final long steps )
 	{
-		long newIndex = index + steps;
+		long newIndex = typeIndex + steps;
 		while ( newIndex > lastIndexInCell )
 		{
 			newIndex -= lastIndexInCell + 1;
@@ -134,20 +134,20 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 			isNotLastCell = cursorOnCells.hasNext();
 			lastIndexInCell = ( int ) ( getCell().size() - 1 );
 		}
-		index = ( int ) newIndex;
-		i.set( index );
+		typeIndex = ( int ) newIndex;
+		i.set( typeIndex );
 		type.updateContainer( this );
 	}
 
 	@Override
 	public void fwd()
 	{
-		if ( ++index > lastIndexInCell )
+		if ( ++typeIndex > lastIndexInCell )
 		{
 			moveToNextCell();
-			index = 0;
+			typeIndex = 0;
 		}
-		i.set( index );
+		i.set( typeIndex );
 	}
 
 	@Override
@@ -155,7 +155,7 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 	{
 		cursorOnCells.reset();
 		moveToNextCell();
-		i.set( index );
+		i.set( typeIndex );
 	}
 
 	@Override
@@ -167,13 +167,13 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 	@Override
 	public long getLongPosition( final int dim )
 	{
-		return getCell().indexToGlobalPosition( index, dim );
+		return getCell().indexToGlobalPosition( typeIndex, dim );
 	}
 
 	@Override
 	public void localize( final long[] position )
 	{
-		getCell().indexToGlobalPosition( index, position );
+		getCell().indexToGlobalPosition( typeIndex, position );
 	}
 
 	/**
@@ -185,7 +185,7 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 		cursorOnCells.fwd();
 		isNotLastCell = cursorOnCells.hasNext();
 		lastIndexInCell = ( int ) ( getCell().size() - 1 );
-		index = -1;
+		typeIndex = -1;
 		type.updateContainer( this );
 	}
 }

--- a/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
@@ -36,6 +36,7 @@ package net.imglib2.img.cell;
 
 import net.imglib2.AbstractLocalizingCursor;
 import net.imglib2.Cursor;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -48,6 +49,8 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 	implements AbstractCellImg.CellImgSampler< C >
 {
 	protected final T type;
+
+	protected final Index i;
 
 	protected final Cursor< C > cursorOnCells;
 
@@ -73,6 +76,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		super( cursor.numDimensions() );
 
 		this.type = cursor.type.duplicateTypeOnSameNativeImg();
+		i = type.index();
 		this.cursorOnCells = cursor.cursorOnCells.copyCursor();
 		this.currentCellMin = cursor.currentCellMin;
 		this.currentCellMax = cursor.currentCellMax;
@@ -84,7 +88,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		index = cursor.index;
 
 		type.updateContainer( this );
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	public CellLocalizingCursor( final AbstractCellImg< T, ?, C, ? > img )
@@ -92,6 +96,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		super( img.numDimensions() );
 
 		this.type = img.createLinkedType();
+		i = type.index();
 		this.cursorOnCells = img.getCells().cursor();
 		this.currentCellMin = null;
 		this.currentCellMax = null;
@@ -148,7 +153,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		index = ( int ) newIndex;
 		cell.indexToGlobalPosition( index, position );
 
-		type.updateIndex( index );
+		i.set( index );
 		type.updateContainer( this );
 	}
 
@@ -160,7 +165,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 			moveToNextCell();
 			index = 0;
 		}
-		type.updateIndex( index );
+		i.set( index );
 
 		for ( int d = 0; d < n; ++d )
 		{
@@ -177,7 +182,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		cursorOnCells.reset();
 		moveToNextCell();
 		index = -1;
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
@@ -50,7 +50,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 {
 	protected final T type;
 
-	protected final Index i;
+	protected final Index typeIndex;
 
 	protected final Cursor< C > cursorOnCells;
 
@@ -76,7 +76,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		super( cursor.numDimensions() );
 
 		this.type = cursor.type.duplicateTypeOnSameNativeImg();
-		i = type.index();
+		typeIndex = type.index();
 		this.cursorOnCells = cursor.cursorOnCells.copyCursor();
 		this.currentCellMin = cursor.currentCellMin;
 		this.currentCellMax = cursor.currentCellMax;
@@ -88,7 +88,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		index = cursor.index;
 
 		type.updateContainer( this );
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	public CellLocalizingCursor( final AbstractCellImg< T, ?, C, ? > img )
@@ -96,7 +96,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		super( img.numDimensions() );
 
 		this.type = img.createLinkedType();
-		i = type.index();
+		typeIndex = type.index();
 		this.cursorOnCells = img.getCells().cursor();
 		this.currentCellMin = null;
 		this.currentCellMax = null;
@@ -153,7 +153,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		index = ( int ) newIndex;
 		cell.indexToGlobalPosition( index, position );
 
-		i.set( index );
+		typeIndex.set( index );
 		type.updateContainer( this );
 	}
 
@@ -165,7 +165,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 			moveToNextCell();
 			index = 0;
 		}
-		i.set( index );
+		typeIndex.set( index );
 
 		for ( int d = 0; d < n; ++d )
 		{
@@ -182,7 +182,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		cursorOnCells.reset();
 		moveToNextCell();
 		index = -1;
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/cell/CellRandomAccess.java
+++ b/src/main/java/net/imglib2/img/cell/CellRandomAccess.java
@@ -37,6 +37,7 @@ package net.imglib2.img.cell;
 import net.imglib2.AbstractLocalizable;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -52,6 +53,8 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		implements RandomAccess< T >, AbstractCellImg.CellImgSampler< C >
 {
 	protected final T type;
+
+	protected final Index i;
 
 	protected final CellGrid grid;
 
@@ -84,6 +87,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		super( randomAccess.numDimensions() );
 
 		type = randomAccess.type.duplicateTypeOnSameNativeImg();
+		i = type.index();
 		grid = randomAccess.grid;
 		randomAccessOnCells = randomAccess.randomAccessOnCells.copyRandomAccess();
 
@@ -102,7 +106,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		index = randomAccess.index;
 		if ( !isOutOfBounds )
 			type.updateContainer( this );
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	public CellRandomAccess( final AbstractCellImg< T, ?, C, ? > img )
@@ -110,6 +114,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		super( img.numDimensions() );
 
 		type = img.createLinkedType();
+		i = type.index();
 		grid = img.getCellGrid();
 		randomAccessOnCells = img.getCells().randomAccess();
 
@@ -164,7 +169,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.fwd( d );
 			updatePosition( position[ d ] >= dimensions[ d ] );
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -176,7 +181,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.bck( d );
 			updatePosition( position[ d ] < 0 );
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -189,7 +194,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.setPosition( position[ d ] / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -202,7 +207,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.setPosition( position[ d ] / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -238,7 +243,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -272,7 +277,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -306,7 +311,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -319,7 +324,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.setPosition( pos / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -332,7 +337,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.setPosition( pos / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -368,7 +373,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -387,7 +392,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				position[ d ] = pos[ d ];
 			}
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	private void setPos2( final int[] pos, final int d0 )
@@ -439,7 +444,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/cell/CellRandomAccess.java
+++ b/src/main/java/net/imglib2/img/cell/CellRandomAccess.java
@@ -54,7 +54,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 {
 	protected final T type;
 
-	protected final Index i;
+	protected final Index typeIndex;
 
 	protected final CellGrid grid;
 
@@ -87,7 +87,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		super( randomAccess.numDimensions() );
 
 		type = randomAccess.type.duplicateTypeOnSameNativeImg();
-		i = type.index();
+		typeIndex = type.index();
 		grid = randomAccess.grid;
 		randomAccessOnCells = randomAccess.randomAccessOnCells.copyRandomAccess();
 
@@ -106,7 +106,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		index = randomAccess.index;
 		if ( !isOutOfBounds )
 			type.updateContainer( this );
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	public CellRandomAccess( final AbstractCellImg< T, ?, C, ? > img )
@@ -114,7 +114,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		super( img.numDimensions() );
 
 		type = img.createLinkedType();
-		i = type.index();
+		typeIndex = type.index();
 		grid = img.getCellGrid();
 		randomAccessOnCells = img.getCells().randomAccess();
 
@@ -169,7 +169,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.fwd( d );
 			updatePosition( position[ d ] >= dimensions[ d ] );
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -181,7 +181,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.bck( d );
 			updatePosition( position[ d ] < 0 );
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -194,7 +194,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.setPosition( position[ d ] / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -207,7 +207,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.setPosition( position[ d ] / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -243,7 +243,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -277,7 +277,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -311,7 +311,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -324,7 +324,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.setPosition( pos / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -337,7 +337,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			randomAccessOnCells.setPosition( pos / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -373,7 +373,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -392,7 +392,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				position[ d ] = pos[ d ];
 			}
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	private void setPos2( final int[] pos, final int d0 )
@@ -444,7 +444,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/planar/PlanarCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarCursor.java
@@ -50,7 +50,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 {
 	protected final T type;
 
-	protected final Index i;
+	protected final Index typeIndex;
 
 	protected final PlanarImg< T, ? > container;
 
@@ -70,7 +70,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 
 		container = cursor.container;
 		this.type = container.createLinkedType();
-		i = type.index();
+		typeIndex = type.index();
 
 		lastIndex = cursor.lastIndex;
 		lastSliceIndex = cursor.lastSliceIndex;
@@ -78,7 +78,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 		index = cursor.index;
 
 		type.updateContainer( this );
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	public PlanarCursor( final PlanarImg< T, ? > container )
@@ -86,7 +86,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 		super( container.numDimensions() );
 
 		this.type = container.createLinkedType();
-		this.i = type.index();
+		this.typeIndex = type.index();
 		this.container = container;
 
 		lastIndex = ( ( n > 1 ) ? container.dimensions[ 1 ] : 1 ) * container.dimensions[ 0 ] - 1;
@@ -140,7 +140,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 			++sliceIndex;
 			type.updateContainer( this );
 		}
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -155,7 +155,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 			type.updateContainer( this );
 		}
 		index = ( int ) newIndex;
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	@Override
@@ -163,7 +163,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 	{
 		sliceIndex = 0;
 		index = -1;
-		i.set( -1 );
+		typeIndex.set( -1 );
 		type.updateContainer( this );
 	}
 

--- a/src/main/java/net/imglib2/img/planar/PlanarCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarCursor.java
@@ -35,6 +35,7 @@
 package net.imglib2.img.planar;
 
 import net.imglib2.AbstractCursorInt;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -48,6 +49,8 @@ import net.imglib2.type.NativeType;
 public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt< T > implements PlanarImg.PlanarContainerSampler
 {
 	protected final T type;
+
+	protected final Index i;
 
 	protected final PlanarImg< T, ? > container;
 
@@ -67,6 +70,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 
 		container = cursor.container;
 		this.type = container.createLinkedType();
+		i = type.index();
 
 		lastIndex = cursor.lastIndex;
 		lastSliceIndex = cursor.lastSliceIndex;
@@ -74,7 +78,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 		index = cursor.index;
 
 		type.updateContainer( this );
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	public PlanarCursor( final PlanarImg< T, ? > container )
@@ -82,6 +86,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 		super( container.numDimensions() );
 
 		this.type = container.createLinkedType();
+		this.i = type.index();
 		this.container = container;
 
 		lastIndex = ( ( n > 1 ) ? container.dimensions[ 1 ] : 1 ) * container.dimensions[ 0 ] - 1;
@@ -117,7 +122,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 	/**
 	 * Note: This test is fragile in a sense that it returns true for elements
 	 * after the last element as well.
-	 * 
+	 *
 	 * @return false for the last element
 	 */
 	@Override
@@ -135,7 +140,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 			++sliceIndex;
 			type.updateContainer( this );
 		}
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -150,7 +155,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 			type.updateContainer( this );
 		}
 		index = ( int ) newIndex;
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	@Override
@@ -158,7 +163,7 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 	{
 		sliceIndex = 0;
 		index = -1;
-		type.updateIndex( -1 );
+		i.set( -1 );
 		type.updateContainer( this );
 	}
 

--- a/src/main/java/net/imglib2/img/planar/PlanarCursor1D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarCursor1D.java
@@ -51,20 +51,20 @@ public class PlanarCursor1D< T extends NativeType< T > > extends PlanarCursor< T
 	@Override
 	public boolean hasNext()
 	{
-		return type.getIndex() < lastIndex;
+		return i.get() < lastIndex;
 	}
 
 	@Override
 	public void localize( final int[] position )
 	{
-		position[ 0 ] = type.getIndex();
+		position[ 0 ] = i.get();
 	}
 
 	@Override
 	public int getIntPosition( final int dim )
 	{
 		if ( dim == 0 )
-			return type.getIndex();
+			return i.get();
 		return 0;
 	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarCursor1D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarCursor1D.java
@@ -51,20 +51,20 @@ public class PlanarCursor1D< T extends NativeType< T > > extends PlanarCursor< T
 	@Override
 	public boolean hasNext()
 	{
-		return i.get() < lastIndex;
+		return typeIndex.get() < lastIndex;
 	}
 
 	@Override
 	public void localize( final int[] position )
 	{
-		position[ 0 ] = i.get();
+		position[ 0 ] = typeIndex.get();
 	}
 
 	@Override
 	public int getIntPosition( final int dim )
 	{
 		if ( dim == 0 )
-			return i.get();
+			return typeIndex.get();
 		return 0;
 	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarCursor2D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarCursor2D.java
@@ -53,19 +53,19 @@ public class PlanarCursor2D< T extends NativeType< T > > extends PlanarCursor< T
 	@Override
 	public boolean hasNext()
 	{
-		return type.getIndex() < lastIndex;
+		return i.get() < lastIndex;
 	}
 
 	@Override
 	public void fwd()
 	{
-		type.incIndex();
+		i.inc();
 	}
 
 	@Override
 	public void localize( final int[] position )
 	{
-		final int indexInSlice = type.getIndex();
+		final int indexInSlice = i.get();
 		final int dim0 = container.dimensions[ 0 ];
 		position[ 1 ] = indexInSlice / dim0;
 		position[ 0 ] = indexInSlice - position[ 1 ] * dim0;
@@ -74,7 +74,7 @@ public class PlanarCursor2D< T extends NativeType< T > > extends PlanarCursor< T
 	@Override
 	public int getIntPosition( final int dim )
 	{
-		final int indexInSlice = type.getIndex();
+		final int indexInSlice = i.get();
 		final int dim0 = container.dimensions[ 0 ];
 		final int pos1 = indexInSlice / dim0;
 		if ( dim == 0 )

--- a/src/main/java/net/imglib2/img/planar/PlanarCursor2D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarCursor2D.java
@@ -53,19 +53,19 @@ public class PlanarCursor2D< T extends NativeType< T > > extends PlanarCursor< T
 	@Override
 	public boolean hasNext()
 	{
-		return i.get() < lastIndex;
+		return typeIndex.get() < lastIndex;
 	}
 
 	@Override
 	public void fwd()
 	{
-		i.inc();
+		typeIndex.inc();
 	}
 
 	@Override
 	public void localize( final int[] position )
 	{
-		final int indexInSlice = i.get();
+		final int indexInSlice = typeIndex.get();
 		final int dim0 = container.dimensions[ 0 ];
 		position[ 1 ] = indexInSlice / dim0;
 		position[ 0 ] = indexInSlice - position[ 1 ] * dim0;
@@ -74,7 +74,7 @@ public class PlanarCursor2D< T extends NativeType< T > > extends PlanarCursor< T
 	@Override
 	public int getIntPosition( final int dim )
 	{
-		final int indexInSlice = i.get();
+		final int indexInSlice = typeIndex.get();
 		final int dim0 = container.dimensions[ 0 ];
 		final int pos1 = indexInSlice / dim0;
 		if ( dim == 0 )

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
@@ -50,7 +50,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 {
 	protected final T type;
 
-	protected final Index i;
+	protected final Index typeIndex;
 
 	protected final PlanarImg< T, ? > container;
 
@@ -76,7 +76,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 
 		container = cursor.container;
 		this.type = container.createLinkedType();
-		i = type.index();
+		typeIndex = type.index();
 
 		lastIndex = cursor.lastIndex;
 		lastSliceIndex = cursor.lastSliceIndex;
@@ -92,7 +92,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 		index = cursor.index;
 
 		type.updateContainer( this );
-		i.set( index );
+		typeIndex.set( index );
 	}
 
 	public PlanarLocalizingCursor( final PlanarImg< T, ? > container )
@@ -100,7 +100,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 		super( container.numDimensions() );
 
 		this.type = container.createLinkedType();
-		i = type.index();
+		typeIndex = type.index();
 		this.container = container;
 
 		lastIndex = ( ( n > 1 ) ? container.dimensions[ 1 ] : 1 ) * container.dimensions[ 0 ] - 1;
@@ -158,7 +158,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 			++sliceIndex;
 			type.updateContainer( this );
 		}
-		i.set( index );
+		typeIndex.set( index );
 
 		for ( int d = 0; d < n; ++d )
 		{
@@ -181,7 +181,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 			type.updateContainer( this );
 		}
 		index = ( int ) newIndex;
-		i.set( index );
+		typeIndex.set( index );
 		container.indexToGlobalPosition( sliceIndex, index, position );
 	}
 
@@ -194,7 +194,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 
 		sliceIndex = 0;
 		index = -1;
-		i.set( -1 );
+		typeIndex.set( -1 );
 		type.updateContainer( this );
 	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
@@ -35,6 +35,7 @@
 package net.imglib2.img.planar;
 
 import net.imglib2.AbstractLocalizingCursorInt;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -48,6 +49,8 @@ import net.imglib2.type.NativeType;
 public class PlanarLocalizingCursor< T extends NativeType< T > > extends AbstractLocalizingCursorInt< T > implements PlanarImg.PlanarContainerSampler
 {
 	protected final T type;
+
+	protected final Index i;
 
 	protected final PlanarImg< T, ? > container;
 
@@ -73,6 +76,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 
 		container = cursor.container;
 		this.type = container.createLinkedType();
+		i = type.index();
 
 		lastIndex = cursor.lastIndex;
 		lastSliceIndex = cursor.lastSliceIndex;
@@ -88,7 +92,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 		index = cursor.index;
 
 		type.updateContainer( this );
-		type.updateIndex( index );
+		i.set( index );
 	}
 
 	public PlanarLocalizingCursor( final PlanarImg< T, ? > container )
@@ -96,6 +100,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 		super( container.numDimensions() );
 
 		this.type = container.createLinkedType();
+		i = type.index();
 		this.container = container;
 
 		lastIndex = ( ( n > 1 ) ? container.dimensions[ 1 ] : 1 ) * container.dimensions[ 0 ] - 1;
@@ -135,7 +140,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 	/**
 	 * Note: This test is fragile in a sense that it returns true for elements
 	 * after the last element as well.
-	 * 
+	 *
 	 * @return false for the last element
 	 */
 	@Override
@@ -153,7 +158,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 			++sliceIndex;
 			type.updateContainer( this );
 		}
-		type.updateIndex( index );
+		i.set( index );
 
 		for ( int d = 0; d < n; ++d )
 		{
@@ -176,7 +181,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 			type.updateContainer( this );
 		}
 		index = ( int ) newIndex;
-		type.updateIndex( index );
+		i.set( index );
 		container.indexToGlobalPosition( sliceIndex, index, position );
 	}
 
@@ -189,7 +194,7 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 
 		sliceIndex = 0;
 		index = -1;
-		type.updateIndex( -1 );
+		i.set( -1 );
 		type.updateContainer( this );
 	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor1D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor1D.java
@@ -61,13 +61,13 @@ public class PlanarLocalizingCursor1D< T extends NativeType< T > > extends Plana
 	@Override
 	public boolean hasNext()
 	{
-		return i.get() < lastIndex;
+		return typeIndex.get() < lastIndex;
 	}
 
 	@Override
 	public void fwd()
 	{
-		i.inc();
+		typeIndex.inc();
 		++position[ 0 ];
 	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor1D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor1D.java
@@ -61,13 +61,13 @@ public class PlanarLocalizingCursor1D< T extends NativeType< T > > extends Plana
 	@Override
 	public boolean hasNext()
 	{
-		return type.getIndex() < lastIndex;
+		return i.get() < lastIndex;
 	}
 
 	@Override
 	public void fwd()
 	{
-		type.incIndex();
+		i.inc();
 		++position[ 0 ];
 	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor2D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor2D.java
@@ -61,13 +61,13 @@ public class PlanarLocalizingCursor2D< T extends NativeType< T > > extends Plana
 	@Override
 	public boolean hasNext()
 	{
-		return i.get() < lastIndex;
+		return typeIndex.get() < lastIndex;
 	}
 
 	@Override
 	public void fwd()
 	{
-		i.inc();
+		typeIndex.inc();
 
 		if ( ++position[ 0 ] > max[ 0 ] )
 		{

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor2D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor2D.java
@@ -61,13 +61,13 @@ public class PlanarLocalizingCursor2D< T extends NativeType< T > > extends Plana
 	@Override
 	public boolean hasNext()
 	{
-		return type.getIndex() < lastIndex;
+		return i.get() < lastIndex;
 	}
 
 	@Override
 	public void fwd()
 	{
-		type.incIndex();
+		i.inc();
 
 		if ( ++position[ 0 ] > max[ 0 ] )
 		{

--- a/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetCursor.java
@@ -36,6 +36,7 @@ package net.imglib2.img.planar;
 
 import net.imglib2.AbstractCursorInt;
 import net.imglib2.Interval;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -54,6 +55,8 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	 * Access to the type
 	 */
 	private final T type;
+
+	private final Index index;
 
 	/**
 	 * Container
@@ -77,7 +80,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 
 	/**
 	 * Copy Constructor
-	 * 
+	 *
 	 * @param cursor - the cursor to copy from.
 	 */
 	protected PlanarPlaneSubsetCursor( final PlanarPlaneSubsetCursor< T > cursor )
@@ -86,18 +89,19 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 
 		container = cursor.container;
 		this.type = container.createLinkedType();
+		index = type.index();
 
 		sliceIndex = cursor.sliceIndex;
 		planeSize = cursor.planeSize;
 		lastPlaneIndex = cursor.lastPlaneIndex;
 
 		type.updateContainer( this );
-		type.updateIndex( cursor.type.getIndex() );
+		index.set( cursor.index.get() );
 	}
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param container - the container this cursor shall work on.
 	 * @param interval - the interval to iterate over.
 	 */
@@ -106,12 +110,13 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 		super( container.numDimensions() );
 
 		this.type = container.createLinkedType();
+		index = type.index();
 
 		this.container = container;
 
 		this.planeSize = ( ( n > 1 ) ? ( int ) interval.dimension( 1 ) : 1 )
 				* ( int ) interval.dimension( 0 );
-		
+
 		this.lastPlaneIndex = planeSize - 1;
 
 		this.sliceIndex = ( int ) ( offset( interval ) / planeSize );
@@ -161,7 +166,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final boolean hasNext()
 	{
-		return type.getIndex() < lastPlaneIndex;
+		return index.get() < lastPlaneIndex;
 	}
 
 	/**
@@ -170,7 +175,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final void fwd()
 	{
-		type.incIndex();
+		index.inc();
 	}
 
 	/**
@@ -179,7 +184,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final void jumpFwd( final long steps )
 	{
-		type.incIndex( ( int ) steps );
+		index.inc( ( int ) steps );
 	}
 
 	/**
@@ -189,7 +194,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	public final void reset()
 	{
 		// Set index inside the slice
-		type.updateIndex( -1 );
+		index.set( -1 );
 		type.updateContainer( this );
 	}
 
@@ -208,7 +213,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final void localize( final int[] position )
 	{
-		container.indexToGlobalPosition( sliceIndex, type.getIndex(), position );
+		container.indexToGlobalPosition( sliceIndex, index.get(), position );
 	}
 
 	/**
@@ -217,7 +222,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final int getIntPosition( final int dim )
 	{
-		return container.indexToGlobalPosition( sliceIndex, type.getIndex(), dim );
+		return container.indexToGlobalPosition( sliceIndex, index.get(), dim );
 	}
 
 	private long offset(final Interval interval) {

--- a/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetCursor.java
@@ -56,7 +56,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	 */
 	private final T type;
 
-	private final Index index;
+	private final Index typeIndex;
 
 	/**
 	 * Container
@@ -89,14 +89,14 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 
 		container = cursor.container;
 		this.type = container.createLinkedType();
-		index = type.index();
+		typeIndex = type.index();
 
 		sliceIndex = cursor.sliceIndex;
 		planeSize = cursor.planeSize;
 		lastPlaneIndex = cursor.lastPlaneIndex;
 
 		type.updateContainer( this );
-		index.set( cursor.index.get() );
+		typeIndex.set( cursor.typeIndex.get() );
 	}
 
 	/**
@@ -110,7 +110,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 		super( container.numDimensions() );
 
 		this.type = container.createLinkedType();
-		index = type.index();
+		typeIndex = type.index();
 
 		this.container = container;
 
@@ -166,7 +166,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final boolean hasNext()
 	{
-		return index.get() < lastPlaneIndex;
+		return typeIndex.get() < lastPlaneIndex;
 	}
 
 	/**
@@ -175,7 +175,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final void fwd()
 	{
-		index.inc();
+		typeIndex.inc();
 	}
 
 	/**
@@ -184,7 +184,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final void jumpFwd( final long steps )
 	{
-		index.inc( ( int ) steps );
+		typeIndex.inc( ( int ) steps );
 	}
 
 	/**
@@ -194,7 +194,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	public final void reset()
 	{
 		// Set index inside the slice
-		index.set( -1 );
+		typeIndex.set( -1 );
 		type.updateContainer( this );
 	}
 
@@ -213,7 +213,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final void localize( final int[] position )
 	{
-		container.indexToGlobalPosition( sliceIndex, index.get(), position );
+		container.indexToGlobalPosition( sliceIndex, typeIndex.get(), position );
 	}
 
 	/**
@@ -222,7 +222,7 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	@Override
 	public final int getIntPosition( final int dim )
 	{
-		return container.indexToGlobalPosition( sliceIndex, index.get(), dim );
+		return container.indexToGlobalPosition( sliceIndex, typeIndex.get(), dim );
 	}
 
 	private long offset(final Interval interval) {

--- a/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetLocalizingCursor.java
@@ -35,6 +35,7 @@ package net.imglib2.img.planar;
 
 import net.imglib2.AbstractLocalizingCursorInt;
 import net.imglib2.Interval;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -54,6 +55,8 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	 * Access to the type
 	 */
 	private final T type;
+
+	private final Index index;
 
 	/**
 	 * Container
@@ -86,6 +89,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 
 		container = cursor.container;
 		this.type = container.createLinkedType();
+		index = type.index();
 
 		sliceIndex = cursor.sliceIndex;
 		lastIndexPlane = cursor.lastIndexPlane;
@@ -96,7 +100,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 			position[ d ] = cursor.position[ d ];
 
 		type.updateContainer( this );
-		type.updateIndex( cursor.type.getIndex() );
+		index.set( cursor.index.get() );
 	}
 
 	/**
@@ -112,6 +116,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 		super( container.numDimensions() );
 
 		this.type = container.createLinkedType();
+		index = type.index();
 
 		this.container = container;
 
@@ -172,7 +177,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public final boolean hasNext()
 	{
-		return type.getIndex() < lastIndexPlane;
+		return index.get() < lastIndexPlane;
 	}
 
 	/**
@@ -181,7 +186,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public final void fwd()
 	{
-		type.incIndex();
+		index.inc();
 		if ( ++position[ 0 ] > maxX && n > 1 )
 		{
 			position[ 0 ] = 0;
@@ -195,8 +200,8 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public final void jumpFwd( final long steps )
 	{
-		type.incIndex( ( int ) steps );
-		updatePositionFromIndex( type.getIndex() );
+		index.inc( ( int ) steps );
+		updatePositionFromIndex( index.get() );
 	}
 
 	private void updatePositionFromIndex( final int index )
@@ -217,8 +222,8 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public final void reset()
 	{
-		type.updateIndex( -1 );
-		updatePositionFromIndex( type.getIndex() );
+		index.set( -1 );
+		updatePositionFromIndex( index.get() );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetLocalizingCursor.java
@@ -56,7 +56,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	 */
 	private final T type;
 
-	private final Index index;
+	private final Index typeIndex;
 
 	/**
 	 * Container
@@ -79,7 +79,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 
 	/**
 	 * Copy Constructor
-	 * 
+	 *
 	 * @param cursor
 	 *            PlanarPlaneSubsetLocalizingCursor to copy from
 	 */
@@ -89,7 +89,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 
 		container = cursor.container;
 		this.type = container.createLinkedType();
-		index = type.index();
+		typeIndex = type.index();
 
 		sliceIndex = cursor.sliceIndex;
 		lastIndexPlane = cursor.lastIndexPlane;
@@ -100,7 +100,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 			position[ d ] = cursor.position[ d ];
 
 		type.updateContainer( this );
-		index.set( cursor.index.get() );
+		typeIndex.set( cursor.typeIndex.get() );
 	}
 
 	/**
@@ -116,7 +116,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 		super( container.numDimensions() );
 
 		this.type = container.createLinkedType();
-		index = type.index();
+		typeIndex = type.index();
 
 		this.container = container;
 
@@ -177,7 +177,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public final boolean hasNext()
 	{
-		return index.get() < lastIndexPlane;
+		return typeIndex.get() < lastIndexPlane;
 	}
 
 	/**
@@ -186,7 +186,7 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public final void fwd()
 	{
-		index.inc();
+		typeIndex.inc();
 		if ( ++position[ 0 ] > maxX && n > 1 )
 		{
 			position[ 0 ] = 0;
@@ -200,8 +200,8 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public final void jumpFwd( final long steps )
 	{
-		index.inc( ( int ) steps );
-		updatePositionFromIndex( index.get() );
+		typeIndex.inc( ( int ) steps );
+		updatePositionFromIndex( typeIndex.get() );
 	}
 
 	private void updatePositionFromIndex( final int index )
@@ -222,8 +222,8 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	@Override
 	public final void reset()
 	{
-		index.set( -1 );
-		updatePositionFromIndex( index.get() );
+		typeIndex.set( -1 );
+		updatePositionFromIndex( typeIndex.get() );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/planar/PlanarRandomAccess.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarRandomAccess.java
@@ -57,7 +57,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 
 	final protected T type;
 
-	final protected Index index;
+	final protected Index typeIndex;
 
 	protected int sliceIndex;
 
@@ -73,9 +73,9 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 			position[ d ] = randomAccess.position[ d ];
 
 		type = randomAccess.type.duplicateTypeOnSameNativeImg();
-		index = type.index();
+		typeIndex = type.index();
 		type.updateContainer( this );
-		index.set( randomAccess.index.get() );
+		typeIndex.set( randomAccess.typeIndex.get() );
 	}
 
 	public PlanarRandomAccess( final PlanarImg< T, ? > container )
@@ -86,8 +86,8 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 		width = ( int ) container.dimension( 0 );
 
 		type = container.createLinkedType();
-		index = type.index();
-		index.set( 0 );
+		typeIndex = type.index();
+		typeIndex.set( 0 );
 		type.updateContainer( this );
 	}
 
@@ -121,9 +121,9 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 		++position[ d ];
 
 		if ( d == 0 )
-			index.inc();
+			typeIndex.inc();
 		else if ( d == 1 )
-			index.inc( width );
+			typeIndex.inc( width );
 		else
 		{
 			sliceIndex += sliceSteps[ d ];
@@ -137,9 +137,9 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 		--position[ d ];
 
 		if ( d == 0 )
-			index.dec();
+			typeIndex.dec();
 		else if ( d == 1 )
-			index.dec( width );
+			typeIndex.dec( width );
 		else
 		{
 			sliceIndex -= sliceSteps[ d ];
@@ -154,11 +154,11 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 
 		if ( d == 0 )
 		{
-			index.inc( distance );
+			typeIndex.inc( distance );
 		}
 		else if ( d == 1 )
 		{
-			index.inc( distance * width );
+			typeIndex.inc( distance * width );
 		}
 		else
 		{
@@ -178,7 +178,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	{
 		final int d0 = localizable.getIntPosition( 0 );
 		final int d1 = localizable.getIntPosition( 1 );
-		index.inc( d0 + d1 * width );
+		typeIndex.inc( d0 + d1 * width );
 		position[ 0 ] += d0;
 		position[ 1 ] += d1;
 
@@ -206,7 +206,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	@Override
 	public void move( final int[] distance )
 	{
-		index.inc( distance[ 0 ] + distance[ 1 ] * width );
+		typeIndex.inc( distance[ 0 ] + distance[ 1 ] * width );
 		position[ 0 ] += distance[ 0 ];
 		position[ 1 ] += distance[ 1 ];
 
@@ -234,7 +234,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	@Override
 	public void move( final long[] distance )
 	{
-		index.inc( ( int ) distance[ 0 ] + ( int ) distance[ 1 ] * width );
+		typeIndex.inc( ( int ) distance[ 0 ] + ( int ) distance[ 1 ] * width );
 		position[ 0 ] += ( int ) distance[ 0 ];
 		position[ 1 ] += ( int ) distance[ 1 ];
 
@@ -264,11 +264,11 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	{
 		if ( d == 0 )
 		{
-			index.inc( pos - position[ 0 ] );
+			typeIndex.inc( pos - position[ 0 ] );
 		}
 		else if ( d == 1 )
 		{
-			index.inc( ( pos - position[ 1 ] ) * width );
+			typeIndex.inc( ( pos - position[ 1 ] ) * width );
 		}
 		else
 		{
@@ -290,7 +290,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	{
 		final int p0 = localizable.getIntPosition( 0 );
 		final int p1 = localizable.getIntPosition( 1 );
-		index.set( p0 + p1 * width );
+		typeIndex.set( p0 + p1 * width );
 		position[ 0 ] = p0;
 		position[ 1 ] = p1;
 
@@ -319,7 +319,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	@Override
 	public void setPosition( final int[] pos )
 	{
-		index.set( pos[ 0 ] + pos[ 1 ] * width );
+		typeIndex.set( pos[ 0 ] + pos[ 1 ] * width );
 		position[ 0 ] = pos[ 0 ];
 		position[ 1 ] = pos[ 1 ];
 
@@ -346,7 +346,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	@Override
 	public void setPosition( final long[] pos )
 	{
-		index.set( ( int ) pos[ 0 ] + ( int ) pos[ 1 ] * width );
+		typeIndex.set( ( int ) pos[ 0 ] + ( int ) pos[ 1 ] * width );
 		position[ 0 ] = ( int ) pos[ 0 ];
 		position[ 1 ] = ( int ) pos[ 1 ];
 

--- a/src/main/java/net/imglib2/img/planar/PlanarRandomAccess.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarRandomAccess.java
@@ -37,6 +37,7 @@ package net.imglib2.img.planar;
 import net.imglib2.AbstractLocalizableInt;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
@@ -56,6 +57,8 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 
 	final protected T type;
 
+	final protected Index index;
+
 	protected int sliceIndex;
 
 	protected PlanarRandomAccess( final PlanarRandomAccess< T > randomAccess )
@@ -70,8 +73,9 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 			position[ d ] = randomAccess.position[ d ];
 
 		type = randomAccess.type.duplicateTypeOnSameNativeImg();
+		index = type.index();
 		type.updateContainer( this );
-		type.updateIndex( randomAccess.type.getIndex() );
+		index.set( randomAccess.index.get() );
 	}
 
 	public PlanarRandomAccess( final PlanarImg< T, ? > container )
@@ -82,7 +86,8 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 		width = ( int ) container.dimension( 0 );
 
 		type = container.createLinkedType();
-		type.updateIndex( 0 );
+		index = type.index();
+		index.set( 0 );
 		type.updateContainer( this );
 	}
 
@@ -116,9 +121,9 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 		++position[ d ];
 
 		if ( d == 0 )
-			type.incIndex();
+			index.inc();
 		else if ( d == 1 )
-			type.incIndex( width );
+			index.inc( width );
 		else
 		{
 			sliceIndex += sliceSteps[ d ];
@@ -132,9 +137,9 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 		--position[ d ];
 
 		if ( d == 0 )
-			type.decIndex();
+			index.dec();
 		else if ( d == 1 )
-			type.decIndex( width );
+			index.dec( width );
 		else
 		{
 			sliceIndex -= sliceSteps[ d ];
@@ -149,11 +154,11 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 
 		if ( d == 0 )
 		{
-			type.incIndex( distance );
+			index.inc( distance );
 		}
 		else if ( d == 1 )
 		{
-			type.incIndex( distance * width );
+			index.inc( distance * width );
 		}
 		else
 		{
@@ -173,7 +178,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	{
 		final int d0 = localizable.getIntPosition( 0 );
 		final int d1 = localizable.getIntPosition( 1 );
-		type.incIndex( d0 + d1 * width );
+		index.inc( d0 + d1 * width );
 		position[ 0 ] += d0;
 		position[ 1 ] += d1;
 
@@ -201,7 +206,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	@Override
 	public void move( final int[] distance )
 	{
-		type.incIndex( distance[ 0 ] + distance[ 1 ] * width );
+		index.inc( distance[ 0 ] + distance[ 1 ] * width );
 		position[ 0 ] += distance[ 0 ];
 		position[ 1 ] += distance[ 1 ];
 
@@ -229,7 +234,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	@Override
 	public void move( final long[] distance )
 	{
-		type.incIndex( ( int ) distance[ 0 ] + ( int ) distance[ 1 ] * width );
+		index.inc( ( int ) distance[ 0 ] + ( int ) distance[ 1 ] * width );
 		position[ 0 ] += ( int ) distance[ 0 ];
 		position[ 1 ] += ( int ) distance[ 1 ];
 
@@ -259,11 +264,11 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	{
 		if ( d == 0 )
 		{
-			type.incIndex( pos - position[ 0 ] );
+			index.inc( pos - position[ 0 ] );
 		}
 		else if ( d == 1 )
 		{
-			type.incIndex( ( pos - position[ 1 ] ) * width );
+			index.inc( ( pos - position[ 1 ] ) * width );
 		}
 		else
 		{
@@ -285,7 +290,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	{
 		final int p0 = localizable.getIntPosition( 0 );
 		final int p1 = localizable.getIntPosition( 1 );
-		type.updateIndex( p0 + p1 * width );
+		index.set( p0 + p1 * width );
 		position[ 0 ] = p0;
 		position[ 1 ] = p1;
 
@@ -314,7 +319,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	@Override
 	public void setPosition( final int[] pos )
 	{
-		type.updateIndex( pos[ 0 ] + pos[ 1 ] * width );
+		index.set( pos[ 0 ] + pos[ 1 ] * width );
 		position[ 0 ] = pos[ 0 ];
 		position[ 1 ] = pos[ 1 ];
 
@@ -341,7 +346,7 @@ public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLoc
 	@Override
 	public void setPosition( final long[] pos )
 	{
-		type.updateIndex( ( int ) pos[ 0 ] + ( int ) pos[ 1 ] * width );
+		index.set( ( int ) pos[ 0 ] + ( int ) pos[ 1 ] * width );
 		position[ 0 ] = ( int ) pos[ 0 ];
 		position[ 1 ] = ( int ) pos[ 1 ];
 

--- a/src/main/java/net/imglib2/img/planar/PlanarRandomAccess1D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarRandomAccess1D.java
@@ -57,21 +57,21 @@ public class PlanarRandomAccess1D< T extends NativeType< T > > extends PlanarRan
 	public void fwd( final int dim )
 	{
 		++position[ 0 ];
-		type.incIndex();
+		index.inc();
 	}
 
 	@Override
 	public void bck( final int dim )
 	{
 		--position[ 0 ];
-		type.decIndex();
+		index.dec();
 	}
 
 	@Override
 	public void move( final int distance, final int d )
 	{
 		position[ 0 ] += distance;
-		type.incIndex( distance );
+		index.inc( distance );
 	}
 
 	@Override
@@ -79,27 +79,27 @@ public class PlanarRandomAccess1D< T extends NativeType< T > > extends PlanarRan
 	{
 		final int distance = localizable.getIntPosition( 0 );
 		position[ 0 ] += distance;
-		type.incIndex( distance );
+		index.inc( distance );
 	}
 
 	@Override
 	public void move( final int[] distance )
 	{
 		position[ 0 ] += distance[ 0 ];
-		type.incIndex( distance[ 0 ] );
+		index.inc( distance[ 0 ] );
 	}
 
 	@Override
 	public void move( final long[] distance )
 	{
 		position[ 0 ] += ( int ) distance[ 0 ];
-		type.incIndex( ( int ) distance[ 0 ] );
+		index.inc( ( int ) distance[ 0 ] );
 	}
 
 	@Override
 	public void setPosition( final int pos, final int dim )
 	{
-		type.updateIndex( pos );
+		index.set( pos );
 		position[ 0 ] = pos;
 	}
 
@@ -107,21 +107,21 @@ public class PlanarRandomAccess1D< T extends NativeType< T > > extends PlanarRan
 	public void setPosition( final Localizable localizable )
 	{
 		final int pos = localizable.getIntPosition( 0 );
-		type.updateIndex( pos );
+		index.set( pos );
 		this.position[ 0 ] = pos;
 	}
 
 	@Override
 	public void setPosition( final int[] position )
 	{
-		type.updateIndex( position[ 0 ] );
+		index.set( position[ 0 ] );
 		this.position[ 0 ] = position[ 0 ];
 	}
 
 	@Override
 	public void setPosition( final long[] position )
 	{
-		type.updateIndex( ( int ) position[ 0 ] );
+		index.set( ( int ) position[ 0 ] );
 		this.position[ 0 ] = ( int ) position[ 0 ];
 	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarRandomAccess1D.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarRandomAccess1D.java
@@ -57,21 +57,21 @@ public class PlanarRandomAccess1D< T extends NativeType< T > > extends PlanarRan
 	public void fwd( final int dim )
 	{
 		++position[ 0 ];
-		index.inc();
+		typeIndex.inc();
 	}
 
 	@Override
 	public void bck( final int dim )
 	{
 		--position[ 0 ];
-		index.dec();
+		typeIndex.dec();
 	}
 
 	@Override
 	public void move( final int distance, final int d )
 	{
 		position[ 0 ] += distance;
-		index.inc( distance );
+		typeIndex.inc( distance );
 	}
 
 	@Override
@@ -79,27 +79,27 @@ public class PlanarRandomAccess1D< T extends NativeType< T > > extends PlanarRan
 	{
 		final int distance = localizable.getIntPosition( 0 );
 		position[ 0 ] += distance;
-		index.inc( distance );
+		typeIndex.inc( distance );
 	}
 
 	@Override
 	public void move( final int[] distance )
 	{
 		position[ 0 ] += distance[ 0 ];
-		index.inc( distance[ 0 ] );
+		typeIndex.inc( distance[ 0 ] );
 	}
 
 	@Override
 	public void move( final long[] distance )
 	{
 		position[ 0 ] += ( int ) distance[ 0 ];
-		index.inc( ( int ) distance[ 0 ] );
+		typeIndex.inc( ( int ) distance[ 0 ] );
 	}
 
 	@Override
 	public void setPosition( final int pos, final int dim )
 	{
-		index.set( pos );
+		typeIndex.set( pos );
 		position[ 0 ] = pos;
 	}
 
@@ -107,21 +107,21 @@ public class PlanarRandomAccess1D< T extends NativeType< T > > extends PlanarRan
 	public void setPosition( final Localizable localizable )
 	{
 		final int pos = localizable.getIntPosition( 0 );
-		index.set( pos );
+		typeIndex.set( pos );
 		this.position[ 0 ] = pos;
 	}
 
 	@Override
 	public void setPosition( final int[] position )
 	{
-		index.set( position[ 0 ] );
+		typeIndex.set( position[ 0 ] );
 		this.position[ 0 ] = position[ 0 ];
 	}
 
 	@Override
 	public void setPosition( final long[] position )
 	{
-		index.set( ( int ) position[ 0 ] );
+		typeIndex.set( ( int ) position[ 0 ] );
 		this.position[ 0 ] = ( int ) position[ 0 ];
 	}
 }

--- a/src/main/java/net/imglib2/type/AbstractBit64Type.java
+++ b/src/main/java/net/imglib2/type/AbstractBit64Type.java
@@ -79,7 +79,6 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 	public AbstractBit64Type( final long value, final int nBits )
 	{
 		this( ( NativeImg< ?, ? extends LongAccess > ) null, nBits );
-		updateIndex( 0 );
 		dataAccess = new LongArray( 1 );
 		setBits( value );
 	}
@@ -88,7 +87,6 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 	public AbstractBit64Type( final LongAccess access, final int nBits )
 	{
 		this( ( NativeImg< ?, ? extends LongAccess > ) null, nBits );
-		updateIndex( 0 );
 		dataAccess = access;
 	}
 
@@ -104,7 +102,7 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 	 * @return
 	 */
 	protected long getBits() {
-		final long k = i * nBits;
+		final long k = i.get() * nBits;
 		final int i1 = (int)(k >>> 6); // k / 64;
 		final long shift = k & 63; // Same as k % 64;
 		final long v = dataAccess.getValue(i1);
@@ -134,7 +132,7 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 	 * @param value
 	 */
 	protected void setBits( final long value ) {
-		final long k = i * nBits;
+		final long k = i.get() * nBits;
 		final int i1 = (int)(k >>> 6); // k / 64;
 		final long shift = k & 63; // Same as k % 64;
 		final long safeValue = value & mask;

--- a/src/main/java/net/imglib2/type/AbstractBitType.java
+++ b/src/main/java/net/imglib2/type/AbstractBitType.java
@@ -48,7 +48,7 @@ import net.imglib2.util.Fraction;
 public abstract class AbstractBitType< T extends AbstractBitType< T > > implements NativeType< T >
 {
 	// Maximum count is Integer.MAX_VALUE * (64 / getBitsPerPixel())
-	protected long i = 0;
+	protected final Index i;
 
 	// the number of bits per pixel
 	protected final int nBits;
@@ -64,6 +64,7 @@ public abstract class AbstractBitType< T extends AbstractBitType< T > > implemen
 			final NativeImg< ?, ? extends LongAccess > bitStorage,
 			final int nBits )
 	{
+		i = new Index();
 		img = bitStorage;
 		this.nBits = nBits;
 	}
@@ -75,43 +76,13 @@ public abstract class AbstractBitType< T extends AbstractBitType< T > > implemen
 	}
 
 	@Override
+	public Index index()
+	{
+		return i;
+	}
+
+	@Override
 	public abstract NativeTypeFactory< T, LongAccess > getNativeTypeFactory();
-
-	@Override
-	public int getIndex()
-	{
-		return ( int ) i;
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
-	}
 
 	@Override
 	public Fraction getEntitiesPerPixel()

--- a/src/main/java/net/imglib2/type/AbstractNativeType.java
+++ b/src/main/java/net/imglib2/type/AbstractNativeType.java
@@ -36,48 +36,23 @@ package net.imglib2.type;
 
 /**
  * TODO
- * 
+ *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
 public abstract class AbstractNativeType< T extends AbstractNativeType< T >> implements NativeType< T >
 {
-	protected int i = 0;
+	protected final Index i;
 
-	@Override
-	public void updateIndex( final int j )
+	protected AbstractNativeType()
 	{
-		this.i = j;
+		i = new Index();
 	}
 
 	@Override
-	public int getIndex()
+	public Index index()
 	{
 		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/Index.java
+++ b/src/main/java/net/imglib2/type/Index.java
@@ -4,31 +4,69 @@ public final class Index
 {
 	private int i = 0;
 
+	/**
+	 * Get the index.
+	 * <p>
+	 * This is used by accessors (e.g., a {@code Cursor}) to position {@code
+	 * NativeType}s in the container, and by {@code NativeType}s to determine
+	 * the offset into the underlying primitive array, where the value of the
+	 * type is stored.
+	 */
 	public int get()
 	{
 		return i;
 	}
 
+	/**
+	 * Set the index to {@code index}.
+	 * <p>
+	 * This is used by accessors (e.g., a {@code Cursor}) to position {@code
+	 * NativeType}s in the container.
+	 */
 	public void set( final int index)
 	{
 		i = index;
 	}
 
+	/**
+	 * Increment the index.
+	 * <p>
+	 * This is used by accessors (e.g., a {@code Cursor}) to position {@code
+	 * NativeType}s in the container.
+	 */
 	public void inc()
 	{
 		++i;
 	}
 
+	/**
+	 * Increase the index by {@code decrement} steps.
+	 * <p>
+	 * This is used by accessors (e.g., a {@code Cursor}) to position {@code
+	 * NativeType}s in the container.
+	 */
 	public void inc( final int increment )
 	{
 		i += increment;
 	}
 
+	/**
+	 * Decrement the index.
+	 * <p>
+	 * This is used by accessors (e.g., a {@code Cursor}) to position {@code
+	 * NativeType}s in the container.
+	 */
 	public void dec()
 	{
 		--i;
 	}
 
+	/**
+	 * Decrease the index by {@code decrement} steps.
+	 * <p>
+	 * This is used by accessors (e.g., a {@code Cursor}) to position {@code
+	 * NativeType}s in the container.
+	 */
 	public void dec( final int decrement )
 	{
 		i -= decrement;

--- a/src/main/java/net/imglib2/type/Index.java
+++ b/src/main/java/net/imglib2/type/Index.java
@@ -1,0 +1,36 @@
+package net.imglib2.type;
+
+public final class Index
+{
+	private int i = 0;
+
+	public int get()
+	{
+		return i;
+	}
+
+	public void set( final int index)
+	{
+		i = index;
+	}
+
+	public void inc()
+	{
+		++i;
+	}
+
+	public void inc( final int increment )
+	{
+		i += increment;
+	}
+
+	public void dec()
+	{
+		--i;
+	}
+
+	public void dec( final int decrement )
+	{
+		i -= decrement;
+	}
+}

--- a/src/main/java/net/imglib2/type/NativeType.java
+++ b/src/main/java/net/imglib2/type/NativeType.java
@@ -79,7 +79,7 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * @return the number of storage type entities required to store one pixel
 	 *         value.
 	 */
-	public Fraction getEntitiesPerPixel();
+	Fraction getEntitiesPerPixel();
 
 	/**
 	 * Creates a new {@link NativeType} which stores in the same physical array.
@@ -88,9 +88,9 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * @return a new {@link NativeType} instance working on the same
 	 *         {@link NativeImg}
 	 */
-	public T duplicateTypeOnSameNativeImg();
+	T duplicateTypeOnSameNativeImg();
 
-	public NativeTypeFactory< T, ? > getNativeTypeFactory();
+	NativeTypeFactory< T, ? > getNativeTypeFactory();
 
 	/**
 	 * This method is used by an accessor (e.g., a {@link Cursor}) to request an
@@ -126,7 +126,7 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 *            reference to an accessor which can be passed on to the
 	 *            container (which will know what to do with it).
 	 */
-	public void updateContainer( Object c );
+	void updateContainer( Object c );
 
 	/**
 	 * Set the index into the current data array.
@@ -138,7 +138,7 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * @param i
 	 *            the new array index
 	 */
-	public void updateIndex( final int i );
+	void updateIndex( final int i );
 
 	/**
 	 * Get the current index into the current data array.
@@ -149,7 +149,7 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 *
 	 * @return the current index into the underlying data array
 	 */
-	public int getIndex();
+	int getIndex();
 
 	/**
 	 * Increment the index into the current data array.
@@ -158,7 +158,7 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * This is used by accessors (e.g., a {@link Cursor}) to position the
 	 * {@link NativeType} in the container.
 	 */
-	public void incIndex();
+	void incIndex();
 
 	/**
 	 * Increases the index into the current data array by {@code increment}
@@ -171,7 +171,7 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * @param increment
 	 *            how many steps
 	 */
-	public void incIndex( final int increment );
+	void incIndex( final int increment );
 
 	/**
 	 * Decrement the index into the current data array.
@@ -180,7 +180,7 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * This is used by accessors (e.g., a {@link Cursor}) to position the
 	 * {@link NativeType} in the container.
 	 */
-	public void decIndex();
+	void decIndex();
 
 	/**
 	 * Decrease the index into the current data array by {@code decrement}
@@ -193,5 +193,5 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * @param decrement
 	 *            how many steps
 	 */
-	public void decIndex( final int decrement );
+	void decIndex( final int decrement );
 }

--- a/src/main/java/net/imglib2/type/NativeType.java
+++ b/src/main/java/net/imglib2/type/NativeType.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -128,6 +128,8 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 */
 	void updateContainer( Object c );
 
+	Index index();
+
 	/**
 	 * Set the index into the current data array.
 	 *
@@ -138,7 +140,11 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * @param i
 	 *            the new array index
 	 */
-	void updateIndex( final int i );
+	@Deprecated
+	default void updateIndex( final int i )
+	{
+		index().set( i );
+	}
 
 	/**
 	 * Get the current index into the current data array.
@@ -149,7 +155,11 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 *
 	 * @return the current index into the underlying data array
 	 */
-	int getIndex();
+	@Deprecated
+	default int getIndex()
+	{
+		return index().get();
+	}
 
 	/**
 	 * Increment the index into the current data array.
@@ -158,7 +168,11 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * This is used by accessors (e.g., a {@link Cursor}) to position the
 	 * {@link NativeType} in the container.
 	 */
-	void incIndex();
+	@Deprecated
+	default void incIndex()
+	{
+		index().inc();
+	}
 
 	/**
 	 * Increases the index into the current data array by {@code increment}
@@ -171,7 +185,11 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * @param increment
 	 *            how many steps
 	 */
-	void incIndex( final int increment );
+	@Deprecated
+	default void incIndex( final int increment )
+	{
+		index().inc( increment );
+	}
 
 	/**
 	 * Decrement the index into the current data array.
@@ -180,7 +198,11 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * This is used by accessors (e.g., a {@link Cursor}) to position the
 	 * {@link NativeType} in the container.
 	 */
-	void decIndex();
+	@Deprecated
+	default void decIndex()
+	{
+		index().dec();
+	}
 
 	/**
 	 * Decrease the index into the current data array by {@code decrement}
@@ -193,5 +215,9 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 * @param decrement
 	 *            how many steps
 	 */
-	void decIndex( final int decrement );
+	@Deprecated
+	default void decIndex( final int decrement )
+	{
+		index().dec( decrement );
+	}
 }

--- a/src/main/java/net/imglib2/type/NativeType.java
+++ b/src/main/java/net/imglib2/type/NativeType.java
@@ -128,17 +128,16 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	 */
 	void updateContainer( Object c );
 
+	/**
+	 * Get the (modifiable) index into the current data array. The returned
+	 * instance will always be the same for the same Type.
+	 */
 	Index index();
 
 	/**
 	 * Set the index into the current data array.
-	 *
-	 * <p>
-	 * This is used by accessors (e.g., a {@link Cursor}) to position the
-	 * {@link NativeType} in the container.
-	 *
-	 * @param i
-	 *            the new array index
+	 * @deprecated Use {@code index().set(int)} instead. If possible, request the
+	 * {@code index()} object only once and re-use it.
 	 */
 	@Deprecated
 	default void updateIndex( final int i )
@@ -148,12 +147,8 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 
 	/**
 	 * Get the current index into the current data array.
-	 *
-	 * <p>
-	 * This is used by accessors (e.g., a {@link Cursor}) to position the
-	 * {@link NativeType} in the container.
-	 *
-	 * @return the current index into the underlying data array
+	 * @deprecated Use {@code index().get()} instead. If possible, request the
+	 * {@code index()} object only once and re-use it.
 	 */
 	@Deprecated
 	default int getIndex()
@@ -163,10 +158,8 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 
 	/**
 	 * Increment the index into the current data array.
-	 *
-	 * <p>
-	 * This is used by accessors (e.g., a {@link Cursor}) to position the
-	 * {@link NativeType} in the container.
+	 * @deprecated Use {@code index().inc()} instead. If possible, request the
+	 * {@code index()} object only once and re-use it.
 	 */
 	@Deprecated
 	default void incIndex()
@@ -177,13 +170,8 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	/**
 	 * Increases the index into the current data array by {@code increment}
 	 * steps.
-	 *
-	 * <p>
-	 * This is used by accessors (e.g., a {@link Cursor}) to position the
-	 * {@link NativeType} in the container.
-	 *
-	 * @param increment
-	 *            how many steps
+	 * @deprecated Use {@code index().inc(int)} instead. If possible, request the
+	 * {@code index()} object only once and re-use it.
 	 */
 	@Deprecated
 	default void incIndex( final int increment )
@@ -193,10 +181,8 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 
 	/**
 	 * Decrement the index into the current data array.
-	 *
-	 * <p>
-	 * This is used by accessors (e.g., a {@link Cursor}) to position the
-	 * {@link NativeType} in the container.
+	 * @deprecated Use {@code index().dec()} instead. If possible, request the
+	 * {@code index()} object only once and re-use it.
 	 */
 	@Deprecated
 	default void decIndex()
@@ -207,13 +193,8 @@ public interface NativeType< T extends NativeType< T > > extends Type< T >
 	/**
 	 * Decrease the index into the current data array by {@code decrement}
 	 * steps.
-	 *
-	 * <p>
-	 * This is used by accessors (e.g., a {@link Cursor}) to position the
-	 * {@link NativeType} in the container.
-	 *
-	 * @param decrement
-	 *            how many steps
+	 * @deprecated Use {@code index().dec(int)} instead. If possible, request the
+	 * {@code index()} object only once and re-use it.
 	 */
 	@Deprecated
 	default void decIndex( final int decrement )

--- a/src/main/java/net/imglib2/type/label/BasePairCharType.java
+++ b/src/main/java/net/imglib2/type/label/BasePairCharType.java
@@ -113,12 +113,12 @@ public class BasePairCharType extends AbstractNativeType< BasePairCharType > imp
 
 	public char getChar()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	public void setChar( final char f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -136,7 +136,7 @@ public class BasePairCharType extends AbstractNativeType< BasePairCharType > imp
 	@Override
 	public void set( final BasePairCharType c )
 	{
-		dataAccess.setValue( i, c.getChar() );
+		dataAccess.setValue( i.get(), c.getChar() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/logic/BitType.java
+++ b/src/main/java/net/imglib2/type/logic/BitType.java
@@ -40,6 +40,7 @@ import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.LongAccess;
 import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.type.BooleanType;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.numeric.IntegerType;
@@ -56,7 +57,7 @@ import net.imglib2.util.Util;
 public class BitType extends AbstractIntegerType< BitType > implements BooleanType< BitType >, NativeType< BitType >, IntegerType< BitType >
 {
 	// Maximum count is Integer.MAX_VALUE * (64 / getBitsPerPixel())
-	protected int i = 0;
+	protected final Index i;
 
 	final protected NativeImg< ?, ? extends LongAccess > img;
 
@@ -66,6 +67,7 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	// this is the constructor if you want it to read from an array
 	public BitType( final NativeImg< ?, ? extends LongAccess > bitStorage )
 	{
+		i = new Index();
 		img = bitStorage;
 	}
 
@@ -97,6 +99,12 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	}
 
 	@Override
+	public Index index()
+	{
+		return i;
+	}
+
+	@Override
 	public BitType duplicateTypeOnSameNativeImg()
 	{
 		return new BitType( img );
@@ -113,7 +121,8 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	@Override
 	public boolean get()
 	{
-		return 1 == ( ( dataAccess.getValue( i >>> 6 ) >>> ( ( i & 63 ) ) ) & 1l );
+		final int j = i.get();
+		return 1 == ( ( dataAccess.getValue( j >>> 6 ) >>> ( ( j & 63 ) ) ) & 1l );
 	}
 
 	// Crops value to within mask
@@ -125,8 +134,9 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 		final long shift = k % 64;
 		*/
 		// Same as above, minus one multiplication, plus one shift to multiply the reminder by 2
-		final int i1 = i >>> 6; // Same as i / 64
-		final long bit = 1l << (i & 63);
+		final int j = i.get();
+		final int i1 = j >>> 6; // Same as i / 64
+		final long bit = 1l << (j & 63);
 		synchronized ( dataAccess )
 		{
 			// Clear or set the bit
@@ -314,42 +324,6 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	public Fraction getEntitiesPerPixel()
 	{
 		return new Fraction(1, 64);
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		this.i = index;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/logic/NativeBoolType.java
+++ b/src/main/java/net/imglib2/type/logic/NativeBoolType.java
@@ -40,6 +40,7 @@ import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.BooleanAccess;
 import net.imglib2.img.basictypeaccess.array.BooleanArray;
 import net.imglib2.type.BooleanType;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.numeric.integer.AbstractIntegerType;
@@ -53,7 +54,7 @@ import net.imglib2.util.Util;
  */
 public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implements BooleanType< NativeBoolType >, NativeType< NativeBoolType >
 {
-	int i = 0;
+	final Index i;
 
 	final protected NativeImg< ?, ? extends BooleanAccess > img;
 
@@ -63,12 +64,14 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 	// this is the constructor if you want it to read from an array
 	public NativeBoolType( final NativeImg< ?, ? extends BooleanAccess > boolStorage )
 	{
+		i = new Index();
 		img = boolStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public NativeBoolType( final boolean value )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = new BooleanArray( 1 );
 		set( value );
@@ -77,6 +80,7 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 	// this is the constructor if you want to specify the dataAccess
 	public NativeBoolType( final BooleanAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -113,6 +117,12 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 		dataAccess = img.update( c );
 	}
 
+	@Override
+	public Index index()
+	{
+		return i;
+	}
+
 	/**
 	 * Returns the primitive boolean value that is used to store this type.
 	 *
@@ -121,7 +131,7 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 	@Override
 	public boolean get()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -130,7 +140,7 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 	@Override
 	public void set( final boolean f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -207,42 +217,6 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 	public String toString()
 	{
 		return "" + get();
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/ARGBType.java
+++ b/src/main/java/net/imglib2/type/numeric/ARGBType.java
@@ -144,12 +144,12 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 
 	public int get()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	public void set( final int f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -201,7 +201,7 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 
 		set( rgba( red( value1 ) - red( value2 ), green( value1 ) - green( value2 ), blue( value1 ) - blue( value2 ), alpha( value1 ) - alpha( value2 ) ) );
 	}
-	
+
 	@Override
 	public void pow( final ARGBType c )
 	{
@@ -212,9 +212,9 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 						Math.pow( red( value1 ), red( value2 ) ),
 						Math.pow( green( value1 ), green( value2 ) ),
 						Math.pow( blue( value1 ), blue( value2 ) ),
-						Math.pow( alpha( value1 ), alpha( value2 ) ) ) );		
+						Math.pow( alpha( value1 ), alpha( value2 ) ) ) );
 	}
-	
+
 	@Override
 	public void pow( final double power )
 	{

--- a/src/main/java/net/imglib2/type/numeric/NativeARGBDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/NativeARGBDoubleType.java
@@ -37,6 +37,7 @@ package net.imglib2.type.numeric;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.DoubleAccess;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
@@ -47,9 +48,7 @@ import net.imglib2.util.Fraction;
  */
 public class NativeARGBDoubleType extends AbstractARGBDoubleType< NativeARGBDoubleType > implements NativeType< NativeARGBDoubleType >
 {
-	private int i = 0;
-
-	private int ai = 0, ri = 1, gi = 2, bi = 3;
+	private final Index i;
 
 	final protected NativeImg< ?, ? extends DoubleAccess > img;
 
@@ -57,11 +56,13 @@ public class NativeARGBDoubleType extends AbstractARGBDoubleType< NativeARGBDoub
 
 	public NativeARGBDoubleType( final NativeImg< ?, ? extends DoubleAccess > img )
 	{
+		i = new Index();
 		this.img = img;
 	}
 
 	public NativeARGBDoubleType( final double a, final double r, final double g, final double b )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = new DoubleArray( 4 );
 		set( a, r, g, b );
@@ -69,6 +70,7 @@ public class NativeARGBDoubleType extends AbstractARGBDoubleType< NativeARGBDoub
 
 	public NativeARGBDoubleType( final DoubleAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -82,6 +84,12 @@ public class NativeARGBDoubleType extends AbstractARGBDoubleType< NativeARGBDoub
 	public void updateContainer( final Object c )
 	{
 		dataAccess = img.update( c );
+	}
+
+	@Override
+	public Index index()
+	{
+		return i;
 	}
 
 	@Override
@@ -101,58 +109,67 @@ public class NativeARGBDoubleType extends AbstractARGBDoubleType< NativeARGBDoub
 	@Override
 	public double getA()
 	{
+		final int ai = i.get() << 2;
 		return dataAccess.getValue( ai );
 	}
 
 	@Override
 	public double getR()
 	{
-		return dataAccess.getValue( ri );
+		final int ai = i.get() << 2;
+		return dataAccess.getValue( ai + 1 );
 	}
 
 	@Override
 	public double getG()
 	{
-		return dataAccess.getValue( gi );
+		final int ai = i.get() << 2;
+		return dataAccess.getValue( ai + 2 );
 	}
 
 	@Override
 	public double getB()
 	{
-		return dataAccess.getValue( bi );
+		final int ai = i.get() << 2;
+		return dataAccess.getValue( ai + 3 );
 	}
 
 	@Override
 	public void setA( final double a )
 	{
+		final int ai = i.get() << 2;
 		dataAccess.setValue( ai, a );
 	}
 
 	@Override
 	public void setR( final double r )
 	{
-		dataAccess.setValue( ri, r );
+		final int ai = i.get() << 2;
+		dataAccess.setValue( ai + 1, r );
 	}
 
 	@Override
 	public void setG( final double g )
 	{
-		dataAccess.setValue( gi, g );
+		final int ai = i.get() << 2;
+		dataAccess.setValue( ai + 2, g );
 	}
 
 	@Override
 	public void setB( final double b )
 	{
-		dataAccess.setValue( bi, b );
+		final int ai = i.get() << 2;
+		dataAccess.setValue( ai + 3, b );
 	}
 
 	@Override
 	public void set( final double a, final double r, final double g, final double b )
 	{
+		final int ai = i.get() << 2;
 		dataAccess.setValue( ai, a );
-		dataAccess.setValue( ri, r );
-		dataAccess.setValue( gi, g );
-		dataAccess.setValue( bi, b );
+		dataAccess.setValue( ai + 1, r );
+		dataAccess.setValue( ai + 2, g );
+		dataAccess.setValue( ai + 3, b );
 	}
 
 	public void set( final ARGBDoubleType c )
@@ -176,65 +193,5 @@ public class NativeARGBDoubleType extends AbstractARGBDoubleType< NativeARGBDoub
 	public Fraction getEntitiesPerPixel()
 	{
 		return new Fraction( 4, 1 );
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		this.i = index;
-		ai = i * 4;
-		ri = ai + 1;
-		gi = ai + 2;
-		bi = ai + 3;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-		ai += 4;
-		ri += 4;
-		gi += 4;
-		bi += 4;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-
-		final int inc2 = increment * 4;
-		ai += inc2;
-		ri += inc2;
-		gi += inc2;
-		bi += inc2;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-		ai -= 4;
-		ri -= 4;
-		gi -= 4;
-		bi -= 4;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
-
-		final int dec2 = decrement * 4;
-		ai -= dec2;
-		ri -= dec2;
-		gi -= dec2;
-		bi -= dec2;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
@@ -37,6 +37,7 @@ package net.imglib2.type.numeric.complex;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.DoubleAccess;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
@@ -49,7 +50,7 @@ import net.imglib2.util.Fraction;
  */
 public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > implements NativeType< ComplexDoubleType >
 {
-	private int i = 0;
+	private final Index i;
 
 	// the indices for real and imaginary value
 	private int realI = 0, imaginaryI = 1;
@@ -62,12 +63,14 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 	// this is the constructor if you want it to read from an array
 	public ComplexDoubleType( final NativeImg< ?, ? extends DoubleAccess > complexfloatStorage )
 	{
+		i = new Index();
 		img = complexfloatStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public ComplexDoubleType( final double r, final double i )
 	{
+		this.i = new Index();
 		img = null;
 		dataAccess = new DoubleArray( 2 );
 		set( r, i );
@@ -76,6 +79,7 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 	// this is the constructor if you want to specify the dataAccess
 	public ComplexDoubleType( final DoubleAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -90,6 +94,12 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 	public void updateContainer( final Object c )
 	{
 		dataAccess = img.update( c );
+	}
+
+	@Override
+	public Index index()
+	{
+		return i;
 	}
 
 	@Override
@@ -109,55 +119,56 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 	@Override
 	public float getRealFloat()
 	{
-		return ( float ) dataAccess.getValue( realI );
+		return ( float ) dataAccess.getValue( i.get() << 1 );
 	}
 
 	@Override
 	public double getRealDouble()
 	{
-		return dataAccess.getValue( realI );
+		return dataAccess.getValue( i.get() << 1 );
 	}
 
 	@Override
 	public float getImaginaryFloat()
 	{
-		return ( float ) dataAccess.getValue( imaginaryI );
+		return ( float ) dataAccess.getValue( ( i.get() << 1 ) + 1 );
 	}
 
 	@Override
 	public double getImaginaryDouble()
 	{
-		return dataAccess.getValue( imaginaryI );
+		return dataAccess.getValue( ( i.get() << 1 ) + 1 );
 	}
 
 	@Override
 	public void setReal( final float r )
 	{
-		dataAccess.setValue( realI, r );
+		dataAccess.setValue( i.get() << 1, r );
 	}
 
 	@Override
 	public void setReal( final double r )
 	{
-		dataAccess.setValue( realI, r );
+		dataAccess.setValue( i.get() << 1, r );
 	}
 
 	@Override
 	public void setImaginary( final float i )
 	{
-		dataAccess.setValue( imaginaryI, i );
+		dataAccess.setValue( ( this.i.get() << 1 ) + 1, i );
 	}
 
 	@Override
 	public void setImaginary( final double i )
 	{
-		dataAccess.setValue( imaginaryI, i );
+		dataAccess.setValue( ( this.i.get() << 1 ) + 1, i );
 	}
 
 	public void set( final double r, final double i )
 	{
-		dataAccess.setValue( realI, r );
-		dataAccess.setValue( imaginaryI, i );
+		final int j = this.i.get() << 1;
+		dataAccess.setValue( j, r );
+		dataAccess.setValue( j + 1, i );
 	}
 
 	@Override
@@ -183,54 +194,5 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 	public Fraction getEntitiesPerPixel()
 	{
 		return new Fraction( 2, 1 );
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		this.i = index;
-		realI = index * 2;
-		imaginaryI = index * 2 + 1;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-		realI += 2;
-		imaginaryI += 2;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-
-		final int inc2 = 2 * increment;
-		realI += inc2;
-		imaginaryI += inc2;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-		realI -= 2;
-		imaginaryI -= 2;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
-		final int dec2 = 2 * decrement;
-		realI -= dec2;
-		imaginaryI -= dec2;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
@@ -37,6 +37,7 @@ package net.imglib2.type.numeric.complex;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.FloatAccess;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.numeric.real.FloatType;
@@ -51,10 +52,7 @@ import net.imglib2.util.Util;
  */
 public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > implements NativeType< ComplexFloatType >
 {
-	private int i = 0;
-
-	// the indices for real and imaginary number
-	private int realI = 0, imaginaryI = 1;
+	private final Index i;
 
 	final protected NativeImg< ?, ? extends FloatAccess > img;
 
@@ -64,12 +62,14 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	// this is the constructor if you want it to read from an array
 	public ComplexFloatType( final NativeImg< ?, ? extends FloatAccess > complexfloatStorage )
 	{
+		i = new Index();
 		img = complexfloatStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public ComplexFloatType( final float r, final float i )
 	{
+		this.i = new Index();
 		img = null;
 		dataAccess = new FloatArray( 2 );
 		set( r, i );
@@ -78,6 +78,7 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	// this is the constructor if you want to specify the dataAccess
 	public ComplexFloatType( final FloatAccess access )
 	{
+		this.i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -92,6 +93,12 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	public void updateContainer( final Object c )
 	{
 		dataAccess = img.update( c );
+	}
+
+	@Override
+	public Index index()
+	{
+		return i;
 	}
 
 	@Override
@@ -111,55 +118,56 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	@Override
 	public float getRealFloat()
 	{
-		return dataAccess.getValue( realI );
+		return dataAccess.getValue( i.get() << 1 );
 	}
 
 	@Override
 	public double getRealDouble()
 	{
-		return dataAccess.getValue( realI );
+		return dataAccess.getValue( i.get() << 1 );
 	}
 
 	@Override
 	public float getImaginaryFloat()
 	{
-		return dataAccess.getValue( imaginaryI );
+		return dataAccess.getValue( ( i.get() << 1 ) + 1 );
 	}
 
 	@Override
 	public double getImaginaryDouble()
 	{
-		return dataAccess.getValue( imaginaryI );
+		return dataAccess.getValue( ( i.get() << 1 ) + 1 );
 	}
 
 	@Override
 	public void setReal( final float r )
 	{
-		dataAccess.setValue( realI, r );
+		dataAccess.setValue( i.get() << 1, r );
 	}
 
 	@Override
 	public void setReal( final double r )
 	{
-		dataAccess.setValue( realI, ( float ) r );
+		dataAccess.setValue( i.get() << 1, ( float ) r );
 	}
 
 	@Override
 	public void setImaginary( final float i )
 	{
-		dataAccess.setValue( imaginaryI, i );
+		dataAccess.setValue( ( this.i.get() << 1 ) + 1, i );
 	}
 
 	@Override
 	public void setImaginary( final double i )
 	{
-		dataAccess.setValue( imaginaryI, ( float ) i );
+		dataAccess.setValue( ( this.i.get() << 1 ) + 1, ( float ) i );
 	}
 
 	public void set( final float r, final float i )
 	{
-		dataAccess.setValue( realI, r );
-		dataAccess.setValue( imaginaryI, i );
+		final int j = this.i.get() << 1;
+		dataAccess.setValue( j, r );
+		dataAccess.setValue( j + 1, i );
 	}
 
 	@Override
@@ -239,55 +247,6 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	public Fraction getEntitiesPerPixel()
 	{
 		return new Fraction( 2, 1 );
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		this.i = index;
-		realI = index * 2;
-		imaginaryI = index * 2 + 1;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-		realI += 2;
-		imaginaryI += 2;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-
-		final int inc2 = 2 * increment;
-		realI += inc2;
-		imaginaryI += inc2;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-		realI -= 2;
-		imaginaryI -= 2;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
-		final int dec2 = 2 * decrement;
-		realI -= dec2;
-		imaginaryI -= dec2;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericByteType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericByteType.java
@@ -37,6 +37,7 @@ package net.imglib2.type.numeric.integer;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.ByteAccess;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
@@ -50,7 +51,7 @@ import net.imglib2.util.Util;
  */
 public abstract class GenericByteType< T extends GenericByteType< T > > extends AbstractIntegerType< T > implements NativeType< T >
 {
-	int i = 0;
+	final Index i;
 
 	final protected NativeImg< ?, ? extends ByteAccess > img;
 
@@ -60,12 +61,14 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	// this is the constructor if you want it to read from an array
 	public GenericByteType( final NativeImg< ?, ? extends ByteAccess > byteStorage )
 	{
+		i = new Index();
 		img = byteStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public GenericByteType( final byte value )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = new ByteArray( 1 );
 		setByte( value );
@@ -74,6 +77,7 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	// this is the constructor if you want to specify the dataAccess
 	public GenericByteType( final ByteAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -97,6 +101,12 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	}
 
 	@Override
+	public Index index()
+	{
+		return i;
+	}
+
+	@Override
 	public abstract NativeTypeFactory< T, ByteAccess > getNativeTypeFactory();
 
 	/**
@@ -105,7 +115,7 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	@Deprecated
 	protected byte getValue()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -114,7 +124,7 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	@Deprecated
 	protected void setValue( final byte f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	/**
@@ -124,7 +134,7 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	 */
 	public byte getByte()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -132,7 +142,7 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	 */
 	public void setByte( final byte f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -213,42 +223,6 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	public String toString()
 	{
 		return "" + getByte();
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericIntType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericIntType.java
@@ -37,6 +37,7 @@ package net.imglib2.type.numeric.integer;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.IntAccess;
 import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
@@ -50,7 +51,7 @@ import net.imglib2.util.Util;
  */
 public abstract class GenericIntType< T extends GenericIntType< T > > extends AbstractIntegerType< T > implements NativeType< T >
 {
-	int i = 0;
+	final Index i;
 
 	final protected NativeImg< ?, ? extends IntAccess > img;
 
@@ -60,12 +61,14 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	// this is the constructor if you want it to read from an array
 	public GenericIntType( final NativeImg< ?, ? extends IntAccess > intStorage )
 	{
+		i = new Index();
 		img = intStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public GenericIntType( final int value )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = new IntArray( 1 );
 		setInt( value );
@@ -74,6 +77,7 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	// this is the constructor if you want to specify the dataAccess
 	public GenericIntType( final IntAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -97,6 +101,12 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	}
 
 	@Override
+	public Index index()
+	{
+		return i;
+	}
+
+	@Override
 	public abstract NativeTypeFactory< T, IntAccess > getNativeTypeFactory();
 
 	/**
@@ -105,7 +115,7 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	@Deprecated
 	protected int getValue()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -114,7 +124,7 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	@Deprecated
 	protected void setValue( final int f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	/**
@@ -124,7 +134,7 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	 */
 	public int getInt()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -132,7 +142,7 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	 */
 	public void setInt( final int f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -176,14 +186,14 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 		final int a = getInt();
 		setInt( a - c.getInt() );
 	}
-	
+
 	@Override
 	public void pow( final T c )
 	{
 		final int a = getInt();
 		setReal( Math.pow( a, c.getInt() ) );
 	}
-	
+
 	@Override
 	public void pow( final double power )
 	{
@@ -227,42 +237,6 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	public String toString()
 	{
 		return "" + getInt();
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericLongType.java
@@ -36,6 +36,7 @@ package net.imglib2.type.numeric.integer;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.LongAccess;
 import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
@@ -48,7 +49,7 @@ import net.imglib2.util.Util;
  */
 public abstract class GenericLongType< T extends GenericLongType< T > > extends AbstractIntegerType< T > implements NativeType< T >
 {
-	int i = 0;
+	final Index i;
 
 	final protected NativeImg< ?, ? extends LongAccess > img;
 
@@ -58,12 +59,14 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	// this is the constructor if you want it to read from an array
 	public GenericLongType( final NativeImg< ?, ? extends LongAccess > longStorage )
 	{
+		i = new Index();
 		img = longStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public GenericLongType( final long value )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = new LongArray( 1 );
 		setLong( value );
@@ -72,6 +75,7 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	// this is the constructor if you want to specify the dataAccess
 	public GenericLongType( final LongAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -95,6 +99,12 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	}
 
 	@Override
+	public Index index()
+	{
+		return i;
+	}
+
+	@Override
 	public abstract NativeTypeFactory< T, LongAccess > getNativeTypeFactory();
 
 	/**
@@ -103,7 +113,7 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	@Deprecated
 	protected long getValue()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -112,7 +122,7 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	@Deprecated
 	protected void setValue( final long f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	/**
@@ -122,7 +132,7 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	 */
 	public long getLong()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -130,7 +140,7 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	 */
 	public void setLong( final long f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -205,42 +215,6 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	public String toString()
 	{
 		return "" + getLong();
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericShortType.java
@@ -37,6 +37,7 @@ package net.imglib2.type.numeric.integer;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.ShortAccess;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.numeric.IntegerType;
@@ -54,7 +55,7 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 		extends AbstractIntegerType< T >
 		implements NativeType< T >
 {
-	int i = 0;
+	final Index i;
 
 	final protected NativeImg< ?, ? extends ShortAccess > img;
 
@@ -64,12 +65,14 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	// this is the constructor if you want it to read from an array
 	public GenericShortType( final NativeImg< ?, ? extends ShortAccess > shortStorage )
 	{
+		i = new Index();
 		img = shortStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public GenericShortType( final short value )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = new ShortArray( 1 );
 		setShort( value );
@@ -78,6 +81,7 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	// this is the constructor if you want to specify the dataAccess
 	public GenericShortType( final ShortAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -101,6 +105,12 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	}
 
 	@Override
+	public Index index()
+	{
+		return i;
+	}
+
+	@Override
 	public abstract NativeTypeFactory< T, ShortAccess > getNativeTypeFactory();
 
 	/**
@@ -109,7 +119,7 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	@Deprecated
 	protected short getValue()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -118,7 +128,7 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	@Deprecated
 	protected void setValue( final short f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	/**
@@ -128,7 +138,7 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	 */
 	public short getShort()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -136,7 +146,7 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	 */
 	public void setShort( final short f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -217,42 +227,6 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	public String toString()
 	{
 		return "" + getShort();
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/LongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/LongType.java
@@ -95,7 +95,7 @@ public class LongType extends GenericLongType< LongType >
 
 	public void set( final long f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
@@ -40,6 +40,7 @@ import java.math.BigInteger;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.LongAccess;
 import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.Type;
@@ -59,7 +60,7 @@ import net.imglib2.util.Util;
  */
 public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType > implements NativeType< Unsigned128BitType >
 {
-	private int i = 0;
+	private final Index i;
 
 	final protected NativeImg< ?, ? extends LongAccess > img;
 
@@ -72,6 +73,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	// this is the constructor if you want it to read from an array
 	public Unsigned128BitType( final NativeImg< ?, ? extends LongAccess > bitStorage )
 	{
+		i = new Index();
 		img = bitStorage;
 	}
 
@@ -108,6 +110,12 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	public void updateContainer( final Object c )
 	{
 		dataAccess = img.update( c );
+	}
+
+	@Override
+	public Index index()
+	{
+		return i;
 	}
 
 	@Override
@@ -152,7 +160,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	 */
 	public void set( final byte[] bytes )
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		int b = bytes.length - 1;
 		for ( int offset = 0; offset < 2; ++offset )
 		{
@@ -168,7 +176,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 
 	public BigInteger get()
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		intoBytes( dataAccess.getValue( k ), dataAccess.getValue( k + 1 ) );
 		return new BigInteger( bytes );
 	}
@@ -180,7 +188,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 
 	public void set( final long lower, final long upper )
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		dataAccess.setValue( k, lower );
 		dataAccess.setValue( k + 1, upper );
 	}
@@ -189,14 +197,14 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public int getInteger()
 	{
-		return ( int ) ( dataAccess.getValue( i * 2 ) & 0xffffffffL );
+		return ( int ) ( dataAccess.getValue( i.get() * 2 ) & 0xffffffffL );
 	}
 
 	/** Return the lowest 64 bits, like {@link BigInteger#intValue()}. */
 	@Override
 	public long getIntegerLong()
 	{
-		return dataAccess.getValue( i * 2 );
+		return dataAccess.getValue( i.get() * 2 );
 	}
 
 	@Override
@@ -214,7 +222,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public double getRealDouble()
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		final long lower = dataAccess.getValue( k );
 		final long upper = dataAccess.getValue( k + 1 );
 		return UnsignedLongType.unsignedLongToDouble( lower ) +
@@ -224,7 +232,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public void setInteger( final int value )
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		dataAccess.setValue( k, value );
 		dataAccess.setValue( k + 1, 0 );
 	}
@@ -232,7 +240,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public void setInteger( final long value )
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		dataAccess.setValue( k, value );
 		dataAccess.setValue( k + 1, 0 );
 	}
@@ -291,42 +299,6 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	}
 
 	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
-	}
-
-	@Override
 	public Unsigned128BitType createVariable()
 	{
 		return new Unsigned128BitType();
@@ -336,7 +308,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	public Unsigned128BitType copy()
 	{
 		final Unsigned128BitType copy = new Unsigned128BitType();
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		copy.set( dataAccess.getValue( k ), dataAccess.getValue( k + 1 ) );
 		return copy;
 	}
@@ -356,7 +328,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public void inc()
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		final long lower = dataAccess.getValue( k );
 		if ( 0xffffffffffffffffL == lower )
 		{
@@ -380,7 +352,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public void dec()
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		final long lower = dataAccess.getValue( k );
 		if ( 0 == lower )
 		{
@@ -457,13 +429,13 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	{
 		set( get().divide( t.get() ).toByteArray() );
 	}
-	
+
 	@Override
 	public void pow( final Unsigned128BitType t )
 	{
 		throw new UnsupportedOperationException( "pow is not yet supported for Unsigned128BitType" );
 	}
-	
+
 	@Override
 	public void pow( final double power )
 	{
@@ -473,22 +445,24 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public int compareTo( final Unsigned128BitType t )
 	{
-		final long upper1 = dataAccess.getValue( i * 2 + 1 );
-		final long upper2 = t.dataAccess.getValue( t.i * 2 + 1 );
+		final int j = i.get();
+		final int tj = t.i.get();
+		final long upper1 = dataAccess.getValue( j * 2 + 1 );
+		final long upper2 = t.dataAccess.getValue( tj * 2 + 1 );
 		final int compareUpper = Long.compareUnsigned( upper1, upper2 );
 		if ( compareUpper != 0 )
 			return compareUpper;
 
-		final long lower1 = dataAccess.getValue( i * 2 );
-		final long lower2 = t.dataAccess.getValue( t.i * 2 );
+		final long lower1 = dataAccess.getValue( j * 2 );
+		final long lower2 = t.dataAccess.getValue( tj * 2 );
 		return Long.compareUnsigned( lower1, lower2 );
 	}
 
 	@Override
 	public boolean valueEquals( final Unsigned128BitType t )
 	{
-		final int k = i * 2;
-		final int kt = t.i * 2;
+		final int k = i.get() * 2;
+		final int kt = t.i.get() * 2;
 
 		return ( dataAccess.getValue( k ) == t.dataAccess.getValue( kt ) ) &&
 				( dataAccess.getValue( k + 1 ) == t.dataAccess.getValue( kt + 1 ) );
@@ -503,7 +477,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public int hashCode()
 	{
-		final int k = i * 2;
+		final int k = i.get() * 2;
 		final int hash1 = Long.hashCode( dataAccess.getValue( k + 1 ) );
 		final int hash2 = Long.hashCode( dataAccess.getValue( k ) );
 		return Util.combineHash( hash1, hash2 );

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned12BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned12BitType.java
@@ -97,7 +97,8 @@ public class Unsigned12BitType extends AbstractIntegerBitType< Unsigned12BitType
 	@Override
 	public long get()
 	{
-		final long k = i * 12;
+		long j = i.get();
+		final long k = j * 12;
 		final int i1 = ( int ) ( k >>> 6 ); // k / 64;
 		final long shift = k & 63; // k % 64;
 		final long v = dataAccess.getValue( i1 );
@@ -121,7 +122,8 @@ public class Unsigned12BitType extends AbstractIntegerBitType< Unsigned12BitType
 	@Override
 	public void set( final long value )
 	{
-		final long k = i * 12;
+		long j = i.get();
+		final long k = j * 12;
 		final int i1 = ( int ) ( k >>> 6 ); // k / 64;
 		final long shift = k & 63; // k % 64;
 		final long safeValue = value & mask;

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned2BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned2BitType.java
@@ -104,7 +104,8 @@ public class Unsigned2BitType extends AbstractIntegerBitType< Unsigned2BitType >
 		//return (dataAccess.getValue((int)(i >>> 5)) >>> ((i % 32) << 1)) & mask;
 		// Even less operations
 		// div 32 == shr 5
-		return ( dataAccess.getValue( ( int ) ( i >>> 5 ) ) >>> ( ( i & 31 ) << 1 ) ) & mask;
+		final long j = i.get();
+		return ( dataAccess.getValue( ( int ) ( j >>> 5 ) ) >>> ( ( j & 31 ) << 1 ) ) & mask;
 	}
 
 	// Crops value to within mask
@@ -117,8 +118,9 @@ public class Unsigned2BitType extends AbstractIntegerBitType< Unsigned2BitType >
 		final long shift = k % 64;
 		*/
 		// Same as above, minus one multiplication, plus one shift to multiply the reminder by 2
-		final int i1 = ( int ) ( i >>> 5 ); // Same as (i * 2) / 64 = (i << 1) >>> 6
-		final long shift = ( i << 1 ) & 63; // Same as (i * 2) % 64
+		final long j = i.get();
+		final int i1 = ( int ) ( j >>> 5 ); // Same as (i * 2) / 64 = (i << 1) >>> 6
+		final long shift = ( j << 1 ) & 63; // Same as (i * 2) % 64
 		// Clear the bits first, then or the masked value
 
 		final long bitsToRetain = ~( mask << shift );

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned4BitType.java
@@ -96,7 +96,8 @@ public class Unsigned4BitType extends AbstractIntegerBitType< Unsigned4BitType >
 	@Override
 	public long get()
 	{
-		return ( dataAccess.getValue( ( int ) ( i >>> 4 ) ) >>> ( ( i & 15 ) << 2 ) ) & mask;
+		final long j = index().get();
+		return ( dataAccess.getValue( ( int ) ( j >>> 4 ) ) >>> ( ( j & 15 ) << 2 ) ) & mask;
 	}
 
 	// Crops value to within mask
@@ -109,8 +110,9 @@ public class Unsigned4BitType extends AbstractIntegerBitType< Unsigned4BitType >
 		final long shift = k % 64;
 		*/
 		// Same as above minus one multiplication, plus one shift (to multiply by 4)
-		final int i1 = ( int ) ( i >>> 4 ); // Same as (i * 4) / 64 = ((i << 2) >>> 6)
-		final long shift = ( i << 2 ) & 63; // Same as (i * 4) % 64
+		final long j = index().get();
+		final int i1 = ( int ) ( j >>> 4 ); // Same as (i * 4) / 64 = ((i << 2) >>> 6)
+		final long shift = ( j << 2 ) & 63; // Same as (i * 4) % 64
 		// Clear the bits first, then or the masked value
 
 		final long bitsToRetain = ~( mask << shift );

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
@@ -218,7 +218,7 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 	 */
 	public long get()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	/**
@@ -234,7 +234,7 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 
 	public void set( final long value )
 	{
-		dataAccess.setValue( i, value );
+		dataAccess.setValue( i.get(), value );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/real/DoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/DoubleType.java
@@ -37,6 +37,7 @@ package net.imglib2.type.numeric.real;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.DoubleAccess;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
@@ -49,7 +50,7 @@ import net.imglib2.util.Fraction;
  */
 public class DoubleType extends AbstractRealType< DoubleType > implements NativeType< DoubleType >
 {
-	private int i = 0;
+	private final Index i;
 
 	final protected NativeImg< ?, ? extends DoubleAccess > img;
 
@@ -59,12 +60,14 @@ public class DoubleType extends AbstractRealType< DoubleType > implements Native
 	// this is the constructor if you want it to read from an array
 	public DoubleType( final NativeImg< ?, ? extends DoubleAccess > doubleStorage )
 	{
+		i = new Index();
 		img = doubleStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public DoubleType( final double value )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = new DoubleArray( 1 );
 		set( value );
@@ -73,6 +76,7 @@ public class DoubleType extends AbstractRealType< DoubleType > implements Native
 	// this is the constructor if you want to specify the dataAccess
 	public DoubleType( final DoubleAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -87,6 +91,12 @@ public class DoubleType extends AbstractRealType< DoubleType > implements Native
 	public void updateContainer( final Object c )
 	{
 		dataAccess = img.update( c );
+	}
+
+	@Override
+	public Index index()
+	{
+		return i;
 	}
 
 	@Override
@@ -105,12 +115,12 @@ public class DoubleType extends AbstractRealType< DoubleType > implements Native
 
 	public double get()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	public void set( final double f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -171,42 +181,6 @@ public class DoubleType extends AbstractRealType< DoubleType > implements Native
 	public Fraction getEntitiesPerPixel()
 	{
 		return new Fraction();
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/real/FloatType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/FloatType.java
@@ -37,6 +37,7 @@ package net.imglib2.type.numeric.real;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.FloatAccess;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
@@ -50,7 +51,7 @@ import net.imglib2.util.Util;
  */
 public class FloatType extends AbstractRealType< FloatType > implements NativeType< FloatType >
 {
-	private int i = 0;
+	private final Index i;
 
 	final protected NativeImg< ?, ? extends FloatAccess > img;
 
@@ -60,12 +61,14 @@ public class FloatType extends AbstractRealType< FloatType > implements NativeTy
 	// this is the constructor if you want it to read from an array
 	public FloatType( final NativeImg< ?, ? extends FloatAccess > floatStorage )
 	{
+		i = new Index();
 		img = floatStorage;
 	}
 
 	// this is the constructor if you want it to be a variable
 	public FloatType( final float value )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = new FloatArray( 1 );
 		set( value );
@@ -74,6 +77,7 @@ public class FloatType extends AbstractRealType< FloatType > implements NativeTy
 	// this is the constructor if you want to specify the dataAccess
 	public FloatType( final FloatAccess access )
 	{
+		i = new Index();
 		img = null;
 		dataAccess = access;
 	}
@@ -88,6 +92,12 @@ public class FloatType extends AbstractRealType< FloatType > implements NativeTy
 	public void updateContainer( final Object c )
 	{
 		dataAccess = img.update( c );
+	}
+
+	@Override
+	public Index index()
+	{
+		return i;
 	}
 
 	@Override
@@ -106,12 +116,12 @@ public class FloatType extends AbstractRealType< FloatType > implements NativeTy
 
 	public float get()
 	{
-		return dataAccess.getValue( i );
+		return dataAccess.getValue( i.get() );
 	}
 
 	public void set( final float f )
 	{
-		dataAccess.setValue( i, f );
+		dataAccess.setValue( i.get(), f );
 	}
 
 	@Override
@@ -240,42 +250,6 @@ public class FloatType extends AbstractRealType< FloatType > implements NativeTy
 	public Fraction getEntitiesPerPixel()
 	{
 		return new Fraction();
-	}
-
-	@Override
-	public void updateIndex( final int index )
-	{
-		i = index;
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return i;
-	}
-
-	@Override
-	public void incIndex()
-	{
-		++i;
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		i += increment;
-	}
-
-	@Override
-	public void decIndex()
-	{
-		--i;
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		i -= decrement;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNativeNumericType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNativeNumericType.java
@@ -34,6 +34,7 @@
 
 package net.imglib2.type.volatiles;
 
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.util.Fraction;
@@ -66,38 +67,8 @@ public abstract class AbstractVolatileNativeNumericType< N extends NumericType< 
 	}
 
 	@Override
-	public void updateIndex( final int i )
+	public Index index()
 	{
-		t.updateIndex( i );
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return t.getIndex();
-	}
-
-	@Override
-	public void incIndex()
-	{
-		t.incIndex();
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		t.incIndex( increment );
-	}
-
-	@Override
-	public void decIndex()
-	{
-		t.decIndex();
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		t.decIndex( decrement );
+		return t.index();
 	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNativeRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNativeRealType.java
@@ -34,6 +34,7 @@
 
 package net.imglib2.type.volatiles;
 
+import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Fraction;
@@ -65,38 +66,8 @@ public abstract class AbstractVolatileNativeRealType< R extends RealType< R > & 
 	}
 
 	@Override
-	public void updateIndex( final int i )
+	public Index index()
 	{
-		t.updateIndex( i );
-	}
-
-	@Override
-	public int getIndex()
-	{
-		return t.getIndex();
-	}
-
-	@Override
-	public void incIndex()
-	{
-		t.incIndex();
-	}
-
-	@Override
-	public void incIndex( final int increment )
-	{
-		t.incIndex( increment );
-	}
-
-	@Override
-	public void decIndex()
-	{
-		t.decIndex();
-	}
-
-	@Override
-	public void decIndex( final int decrement )
-	{
-		t.decIndex( decrement );
+		return t.index();
 	}
 }

--- a/src/test/java/net/imglib2/img/array/ArrayRandomAccessBenchmark.java
+++ b/src/test/java/net/imglib2/img/array/ArrayRandomAccessBenchmark.java
@@ -1,0 +1,117 @@
+package net.imglib2.img.array;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.img.Img;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class ArrayRandomAccessBenchmark
+{
+	@Param( value = { "false", "true" } )
+	private boolean slowdown;
+
+	@Setup
+	public void setup()
+	{
+		if ( slowdown )
+		{
+			spoil( new FloatType() );
+			spoil( new DoubleType() );
+			spoil( new UnsignedShortType() );
+			spoil( new UnsignedByteType() );
+			spoil( new ShortType() );
+			spoil( new ByteType() );
+			spoil( new UnsignedIntType() );
+			spoil( new IntType() );
+		}
+	}
+
+	public < T extends NativeType< T > & RealType< T > > double spoil( final T type )
+	{
+		final Img< T > img = new ArrayImgFactory<>( type ).create( 1000, 1000 );
+		return doSum1( img );
+	}
+
+	private final Img< IntType > img = new ArrayImgFactory<>( new IntType() ).create( 1000, 1000 );
+
+	@Benchmark
+	public Object sum()
+	{
+		return doSum( img );
+	}
+
+	public < T extends RealType< T > > double doSum( RandomAccessible< T > img )
+	{
+		double sum = 0;
+		RandomAccess< T > ra = img.randomAccess();
+		ra.setPosition( 0, 1 );
+		for ( int y = 0; y < 1000; y++ )
+		{
+			ra.setPosition( 0, 0 );
+			for ( int x = 0; x < 1000; x++ )
+			{
+				sum += ra.get().getRealDouble();
+				ra.fwd( 0 );
+			}
+			ra.fwd( 1 );
+		}
+		return sum + ra.getIntPosition( 0 );
+	}
+
+	public < T extends RealType< T > > double doSum1( RandomAccessible< T > img )
+	{
+		double sum = 0;
+		RandomAccess< T > ra = img.randomAccess();
+		ra.setPosition( 0, 1 );
+		for ( int y = 0; y < 1000; y++ )
+		{
+			ra.setPosition( 0, 0 );
+			for ( int x = 0; x < 1000; x++ )
+			{
+				sum += ra.get().getRealDouble();
+				ra.fwd( 0 );
+			}
+			ra.fwd( 1 );
+		}
+		return sum + ra.getIntPosition( 0 );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder()
+				.include( ArrayRandomAccessBenchmark.class.getSimpleName() )
+				.build();
+		new Runner( options ).run();
+	}
+}


### PR DESCRIPTION
This addresses a polymorphism issue discovered by @maarzt:
There are multiple implementations of `NativeType.incIndex()` etc, and when using e.g. a `RandomAccess` to move over images of different types, this slows things down. Also in the case that the type is always the same at the call site.

The problem is illustrated by [this benchmark](https://github.com/imglib/imglib2/blob/nativetypes/src/test/java/net/imglib2/img/array/ArrayRandomAccessBenchmark.java) where pixels of a 1000x1000 image are summed using a `ArrayRandomAccess`. If different types than the one of the image have been observed ***anywhere else in the program*** this operation slows down by 4x. This can be traced to `NativeType.updateIndex()` etc. This is obviously a problem for *a lot* of things using imglib.

```
    Benchmark                       (slowdown)  Mode  Cnt  Score   Error  Units
    ArrayRandomAccessBenchmark.sum       false  avgt   10  0.982 ± 0.011  ms/op
    ArrayRandomAccessBenchmark.sum        true  avgt   10  3.942 ± 0.102  ms/op
```

This PR introduces an `Index` class that is used by all `NativeType` implementations to store their index.
Accessors can directly obtain (and cache) this object and use it to modify the types index.
This solves the issue:

```
    Benchmark                       (slowdown)  Mode  Cnt  Score   Error  Units
    ArrayRandomAccessBenchmark.sum       false  avgt   10  1.052 ± 0.019  ms/op
    ArrayRandomAccessBenchmark.sum        true  avgt   10  1.046 ± 0.019  ms/op
```

(As far as I can tell, using the `Index` object instead of a primitive `int` field does not cause performance overhead.)

The only issue with this is that the types deriving from `AbstractBitType` had a `long` index before and now, through `Index`, implicitly have `int` indexes.  This means that while you could create an `AbstractBitType` that would run on primitive arrays of more than `Integer.MAX_VALUE` *bits* before, you no longer can. I don't think this is an actual issue. As far as I can tell, it never really would work in any concrete use case because the `int` index assumption is baked in deeply in all Accessors etc.
I suggest that we just live with it for now.

If there are actual use cases that bypass images and accessors and do something directly with those types, I would suggest that we simply create a parallel class hierarchy explicitly for those scenarios.