### PR TITLE
RealPointSampleList should not crash when calling jumpFwd(0) - it does when it sits at -1 (initialized)

### DIFF
--- a/src/main/java/net/imglib2/RealPointSampleList.java
+++ b/src/main/java/net/imglib2/RealPointSampleList.java
@@ -122,6 +122,9 @@ public class RealPointSampleList< T > implements IterableRealInterval< T >
 		@Override
 		public void jumpFwd( final long steps )
 		{
+			if ( steps == 0 )
+				return;
+
 			index += steps;
 			position = coordinates.get( index );
 			sample = samples.get( index );


### PR DESCRIPTION
As far as I checked all other Cursors do not crash when calling jumpFwd(0) on a just created cursor. But there is the overhead of an if - however jumpFwd shouldn't be called that often, mostly to initialize parallel processing.