### PR TITLE
Default implement a few methods, deprecate `copyCursor()`, and clean up.

### DIFF
--- a/src/main/java/net/imglib2/AbstractCursor.java
+++ b/src/main/java/net/imglib2/AbstractCursor.java
@@ -69,13 +69,6 @@ public abstract class AbstractCursor< T > extends AbstractEuclideanSpace impleme
 		tmp = new long[ n ];
 	}
 
-	@Override
-	public T next()
-	{
-		fwd();
-		return get();
-	}
-
 	/**
 	 * Highly recommended to override this with a more efficient version.
 	 * 

--- a/src/main/java/net/imglib2/AbstractCursor.java
+++ b/src/main/java/net/imglib2/AbstractCursor.java
@@ -70,12 +70,6 @@ public abstract class AbstractCursor< T > extends AbstractEuclideanSpace impleme
 	}
 
 	@Override
-	public void remove()
-	{
-		// NB: no action.
-	}
-
-	@Override
 	public T next()
 	{
 		fwd();

--- a/src/main/java/net/imglib2/AbstractCursor.java
+++ b/src/main/java/net/imglib2/AbstractCursor.java
@@ -145,7 +145,4 @@ public abstract class AbstractCursor< T > extends AbstractEuclideanSpace impleme
 
 	@Override
 	abstract public AbstractCursor< T > copy();
-
-	@Override
-	abstract public AbstractCursor< T > copyCursor();
 }

--- a/src/main/java/net/imglib2/AbstractCursor.java
+++ b/src/main/java/net/imglib2/AbstractCursor.java
@@ -69,18 +69,6 @@ public abstract class AbstractCursor< T > extends AbstractEuclideanSpace impleme
 		tmp = new long[ n ];
 	}
 
-	/**
-	 * Highly recommended to override this with a more efficient version.
-	 * 
-	 * @param steps
-	 */
-	@Override
-	public void jumpFwd( final long steps )
-	{
-		for ( long j = 0; j < steps; ++j )
-			fwd();
-	}
-
 	@Override
 	public void localize( final float[] pos )
 	{

--- a/src/main/java/net/imglib2/AbstractCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractCursorInt.java
@@ -73,13 +73,6 @@ public abstract class AbstractCursorInt< T > extends AbstractEuclideanSpace impl
 		tmp = new int[ n ];
 	}
 
-	@Override
-	public T next()
-	{
-		fwd();
-		return get();
-	}
-
 	/**
 	 * Highly recommended to override this with a more efficient version.
 	 * 

--- a/src/main/java/net/imglib2/AbstractCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractCursorInt.java
@@ -74,12 +74,6 @@ public abstract class AbstractCursorInt< T > extends AbstractEuclideanSpace impl
 	}
 
 	@Override
-	public void remove()
-	{
-		// NB: no action.
-	}
-
-	@Override
 	public T next()
 	{
 		fwd();

--- a/src/main/java/net/imglib2/AbstractCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractCursorInt.java
@@ -149,7 +149,4 @@ public abstract class AbstractCursorInt< T > extends AbstractEuclideanSpace impl
 
 	@Override
 	abstract public AbstractCursorInt< T > copy();
-
-	@Override
-	abstract public AbstractCursorInt< T > copyCursor();
 }

--- a/src/main/java/net/imglib2/AbstractCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractCursorInt.java
@@ -73,18 +73,6 @@ public abstract class AbstractCursorInt< T > extends AbstractEuclideanSpace impl
 		tmp = new int[ n ];
 	}
 
-	/**
-	 * Highly recommended to override this with a more efficient version.
-	 * 
-	 * @param steps
-	 */
-	@Override
-	public void jumpFwd( final long steps )
-	{
-		for ( long j = 0; j < steps; ++j )
-			fwd();
-	}
-
 	@Override
 	public void localize( final float[] pos )
 	{

--- a/src/main/java/net/imglib2/AbstractLocalizingCursor.java
+++ b/src/main/java/net/imglib2/AbstractLocalizingCursor.java
@@ -57,13 +57,6 @@ public abstract class AbstractLocalizingCursor< T > extends AbstractLocalizable 
 	}
 
 	@Override
-	public T next()
-	{
-		fwd();
-		return get();
-	}
-
-	@Override
 	public void jumpFwd( final long steps )
 	{
 		for ( long j = 0; j < steps; ++j )

--- a/src/main/java/net/imglib2/AbstractLocalizingCursor.java
+++ b/src/main/java/net/imglib2/AbstractLocalizingCursor.java
@@ -57,12 +57,5 @@ public abstract class AbstractLocalizingCursor< T > extends AbstractLocalizable 
 	}
 
 	@Override
-	public void jumpFwd( final long steps )
-	{
-		for ( long j = 0; j < steps; ++j )
-			fwd();
-	}
-
-	@Override
 	abstract public AbstractLocalizingCursor< T > copy();
 }

--- a/src/main/java/net/imglib2/AbstractLocalizingCursor.java
+++ b/src/main/java/net/imglib2/AbstractLocalizingCursor.java
@@ -78,7 +78,4 @@ public abstract class AbstractLocalizingCursor< T > extends AbstractLocalizable 
 
 	@Override
 	abstract public AbstractLocalizingCursor< T > copy();
-
-	@Override
-	abstract public AbstractLocalizingCursor< T > copyCursor();
 }

--- a/src/main/java/net/imglib2/AbstractLocalizingCursor.java
+++ b/src/main/java/net/imglib2/AbstractLocalizingCursor.java
@@ -57,12 +57,6 @@ public abstract class AbstractLocalizingCursor< T > extends AbstractLocalizable 
 	}
 
 	@Override
-	public void remove()
-	{
-		// NB: no action.
-	}
-
-	@Override
 	public T next()
 	{
 		fwd();

--- a/src/main/java/net/imglib2/AbstractLocalizingCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractLocalizingCursorInt.java
@@ -57,12 +57,6 @@ public abstract class AbstractLocalizingCursorInt< T > extends AbstractLocalizab
 	}
 
 	@Override
-	public void remove()
-	{
-		// NB: no action.
-	}
-
-	@Override
 	public T next()
 	{
 		fwd();

--- a/src/main/java/net/imglib2/AbstractLocalizingCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractLocalizingCursorInt.java
@@ -78,7 +78,4 @@ public abstract class AbstractLocalizingCursorInt< T > extends AbstractLocalizab
 
 	@Override
 	abstract public AbstractLocalizingCursorInt< T > copy();
-
-	@Override
-	abstract public AbstractLocalizingCursorInt< T > copyCursor();
 }

--- a/src/main/java/net/imglib2/AbstractLocalizingCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractLocalizingCursorInt.java
@@ -57,13 +57,6 @@ public abstract class AbstractLocalizingCursorInt< T > extends AbstractLocalizab
 	}
 
 	@Override
-	public T next()
-	{
-		fwd();
-		return get();
-	}
-
-	@Override
 	public void jumpFwd( final long steps )
 	{
 		for ( long j = 0; j < steps; ++j )

--- a/src/main/java/net/imglib2/AbstractLocalizingCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractLocalizingCursorInt.java
@@ -57,12 +57,5 @@ public abstract class AbstractLocalizingCursorInt< T > extends AbstractLocalizab
 	}
 
 	@Override
-	public void jumpFwd( final long steps )
-	{
-		for ( long j = 0; j < steps; ++j )
-			fwd();
-	}
-
-	@Override
 	abstract public AbstractLocalizingCursorInt< T > copy();
 }

--- a/src/main/java/net/imglib2/Cursor.java
+++ b/src/main/java/net/imglib2/Cursor.java
@@ -83,8 +83,16 @@ public interface Cursor< T > extends RealCursor< T >, Localizable
 	// we must avoid doing so for now. For details, see:
 	// http://bugs.sun.com/view_bug.do?bug_id=6656332
 	// The bug is fixed in JDK7.
+	/**
+	 * @deprecated Use {@link #copy()} instead
+	 */
+	@Deprecated
 	@Override
-	Cursor< T > copyCursor();
-//	@Override
-//	public Cursor< T > copy();
+	default Cursor< T > copyCursor()
+	{
+		return copy();
+	}
+
+	@Override
+	Cursor< T > copy();
 }

--- a/src/main/java/net/imglib2/Cursor.java
+++ b/src/main/java/net/imglib2/Cursor.java
@@ -84,7 +84,7 @@ public interface Cursor< T > extends RealCursor< T >, Localizable
 	// http://bugs.sun.com/view_bug.do?bug_id=6656332
 	// The bug is fixed in JDK7.
 	@Override
-	public Cursor< T > copyCursor();
+	Cursor< T > copyCursor();
 //	@Override
 //	public Cursor< T > copy();
 }

--- a/src/main/java/net/imglib2/Dimensions.java
+++ b/src/main/java/net/imglib2/Dimensions.java
@@ -77,7 +77,7 @@ public interface Dimensions extends EuclideanSpace
 	 *
 	 * @param d
 	 */
-	public long dimension( int d );
+	long dimension( int d );
 
 	/**
 	 * Allocates a new long array with the dimensions of this object.

--- a/src/main/java/net/imglib2/EuclideanSpace.java
+++ b/src/main/java/net/imglib2/EuclideanSpace.java
@@ -43,5 +43,5 @@ package net.imglib2;
 public interface EuclideanSpace
 {
 	/** Gets the space's number of dimensions. */
-	public int numDimensions();
+	int numDimensions();
 }

--- a/src/main/java/net/imglib2/Interval.java
+++ b/src/main/java/net/imglib2/Interval.java
@@ -63,7 +63,7 @@ public interface Interval extends RealInterval, Dimensions
 	 *            dimension
 	 * @return minimum in dimension d.
 	 */
-	long min( final int d );
+	long min( int d );
 
 	/**
 	 * Write the minimum of each dimension into long[].
@@ -96,7 +96,7 @@ public interface Interval extends RealInterval, Dimensions
 	 *            dimension
 	 * @return maximum in dimension d.
 	 */
-	long max( final int d );
+	long max( int d );
 
 	/**
 	 * Write the maximum of each dimension into long[].

--- a/src/main/java/net/imglib2/IterableInterval.java
+++ b/src/main/java/net/imglib2/IterableInterval.java
@@ -55,8 +55,8 @@ package net.imglib2;
 public interface IterableInterval< T > extends IterableRealInterval< T >, Interval
 {
 	@Override
-	public Cursor< T > cursor();
+	Cursor< T > cursor();
 
 	@Override
-	public Cursor< T > localizingCursor();
+	Cursor< T > localizingCursor();
 }

--- a/src/main/java/net/imglib2/IterableRealInterval.java
+++ b/src/main/java/net/imglib2/IterableRealInterval.java
@@ -68,7 +68,7 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 *
 	 * @return fast iterating iterator
 	 */
-	public RealCursor< T > cursor();
+	RealCursor< T > cursor();
 
 	/**
 	 * <p>
@@ -83,7 +83,7 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 *
 	 * @return fast localizing iterator
 	 */
-	public RealCursor< T > localizingCursor();
+	RealCursor< T > localizingCursor();
 
 	/**
 	 * <p>
@@ -93,12 +93,12 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 *
 	 * @return number of elements
 	 */
-	public long size();
+	long size();
 
 	/**
 	 * Get the first element of this {@link IterableRealInterval}. This is a
 	 * shortcut for <code>cursor().next()</code>.
-	 *
+	 * <p>
 	 * This can be used to create a new variable of type T using
 	 * <code>firstElement().createVariable()</code>, which is useful in generic
 	 * methods to store temporary results, e.g., a running sum over pixels in
@@ -106,7 +106,7 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 *
 	 * @return the first element in iteration order.
 	 */
-	public T firstElement();
+	T firstElement();
 
 	/**
 	 * Returns the iteration order of this {@link IterableRealInterval}. If the
@@ -122,5 +122,5 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 *
 	 * @return the iteration order of this {@link IterableRealInterval}.
 	 */
-	public Object iterationOrder();
+	Object iterationOrder();
 }

--- a/src/main/java/net/imglib2/IterableRealInterval.java
+++ b/src/main/java/net/imglib2/IterableRealInterval.java
@@ -106,7 +106,10 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 *
 	 * @return the first element in iteration order.
 	 */
-	T firstElement();
+	default T firstElement() // TODO: fix places where it is not necessary to implement this anymore
+	{
+		return iterator().next();
+	}
 
 	/**
 	 * Returns the iteration order of this {@link IterableRealInterval}. If the
@@ -123,4 +126,10 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 * @return the iteration order of this {@link IterableRealInterval}.
 	 */
 	Object iterationOrder();
+
+	@Override
+	default java.util.Iterator< T > iterator() // TODO: fix places where it is not necessary to implement this anymore
+	{
+		return cursor();
+	}
 }

--- a/src/main/java/net/imglib2/Iterator.java
+++ b/src/main/java/net/imglib2/Iterator.java
@@ -51,18 +51,18 @@ public interface Iterator
 	 * @param steps
 	 *            number of steps to move forward
 	 */
-	public void jumpFwd( long steps );
+	void jumpFwd( long steps );
 
 	/**
 	 * Move forward.
 	 */
-	public void fwd();
+	void fwd();
 
 	/**
 	 * Reset the {@link Iterator}, that is put it to where it would be if newly
 	 * created.
 	 */
-	public void reset();
+	void reset();
 
 	/**
 	 * Returns true if another step forward is possible.
@@ -70,5 +70,5 @@ public interface Iterator
 	 * @return true, if there is another step forward is possible, otherwise
 	 *         false
 	 */
-	public boolean hasNext();
+	boolean hasNext();
 }

--- a/src/main/java/net/imglib2/Iterator.java
+++ b/src/main/java/net/imglib2/Iterator.java
@@ -47,11 +47,17 @@ public interface Iterator
 {
 	/**
 	 * Move steps &times; forward.
-	 * 
+	 * <p>
+	 * Highly recommended to override this with a more efficient version.
+	 *
 	 * @param steps
 	 *            number of steps to move forward
 	 */
-	void jumpFwd( long steps );
+	default void jumpFwd( long steps )
+	{
+		for ( long j = 0; j < steps; ++j )
+			fwd();
+	};
 
 	/**
 	 * Move forward.

--- a/src/main/java/net/imglib2/KDTree.java
+++ b/src/main/java/net/imglib2/KDTree.java
@@ -75,7 +75,7 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 	final protected double[] max;
 
 	/**
-	 * A KDTreeNode that stores it's value as a reference.
+	 * A KDTreeNode that stores its value as a reference.
 	 */
 	protected final static class ValueNode< T > extends KDTreeNode< T >
 	{
@@ -125,7 +125,7 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 	}
 
 	/**
-	 * A KDTreeNode that stores it's value as a Sampler.
+	 * A KDTreeNode that stores its value as a Sampler.
 	 */
 	protected static final class SamplerNode< T > extends KDTreeNode< T >
 	{

--- a/src/main/java/net/imglib2/KDTree.java
+++ b/src/main/java/net/imglib2/KDTree.java
@@ -257,7 +257,7 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 		while ( cursor.hasNext() )
 		{
 			cursor.next();
-			values.add( cursor.copyCursor() );
+			values.add( cursor.copy() );
 		}
 		root = makeSamplerNode( values, 0, values.size() - 1, 0 );
 	}
@@ -715,13 +715,6 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 		{
 			// NB: no action.
 		}
-
-		@Override
-		public KDTreeCursor copyCursor()
-		{
-			return copy();
-		}
-
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/KDTree.java
+++ b/src/main/java/net/imglib2/KDTree.java
@@ -712,12 +712,6 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 	}
 
 	@Override
-	public KDTreeCursor iterator()
-	{
-		return new KDTreeCursor( this );
-	}
-
-	@Override
 	public KDTreeCursor cursor()
 	{
 		return new KDTreeCursor( this );
@@ -727,11 +721,5 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 	public KDTreeCursor localizingCursor()
 	{
 		return new KDTreeCursor( this );
-	}
-
-	@Override
-	public T firstElement()
-	{
-		return iterator().next();
 	}
 }

--- a/src/main/java/net/imglib2/KDTree.java
+++ b/src/main/java/net/imglib2/KDTree.java
@@ -709,12 +709,6 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 			fwd();
 			return get();
 		}
-
-		@Override
-		public void remove()
-		{
-			// NB: no action.
-		}
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/KDTree.java
+++ b/src/main/java/net/imglib2/KDTree.java
@@ -668,13 +668,6 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 		}
 
 		@Override
-		public void jumpFwd( final long steps )
-		{
-			for ( long i = 0; i < steps; ++i )
-				fwd();
-		}
-
-		@Override
 		public void fwd()
 		{
 			if ( nodes.isEmpty() )

--- a/src/main/java/net/imglib2/KDTree.java
+++ b/src/main/java/net/imglib2/KDTree.java
@@ -702,13 +702,6 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 		{
 			return !nodes.isEmpty();
 		}
-
-		@Override
-		public T next()
-		{
-			fwd();
-			return get();
-		}
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -148,7 +148,7 @@ public interface Localizable extends RealLocalizable
 	 *            dimension
 	 * @return dimension of current position
 	 */
-	public long getLongPosition( int d );
+	long getLongPosition( int d );
 
 	@Override
 	default float getFloatPosition( final int d )

--- a/src/main/java/net/imglib2/PointSampleList.java
+++ b/src/main/java/net/imglib2/PointSampleList.java
@@ -65,12 +65,6 @@ public class PointSampleList< T > extends AbstractInterval implements IterableIn
 		}
 
 		@Override
-		final public Cursor< T > copyCursor()
-		{
-			return copy();
-		}
-
-		@Override
 		public double getDoublePosition( final int d )
 		{
 			return position.getDoublePosition( d );

--- a/src/main/java/net/imglib2/PointSampleList.java
+++ b/src/main/java/net/imglib2/PointSampleList.java
@@ -160,12 +160,6 @@ public class PointSampleList< T > extends AbstractInterval implements IterableIn
 			fwd();
 			return sample;
 		}
-
-		@Override
-		public void remove()
-		{
-			/* Not yet implemented */
-		}
 	}
 
 	final protected ArrayList< Point > coordinates = new ArrayList< Point >();

--- a/src/main/java/net/imglib2/PointSampleList.java
+++ b/src/main/java/net/imglib2/PointSampleList.java
@@ -218,12 +218,6 @@ public class PointSampleList< T > extends AbstractInterval implements IterableIn
 	}
 
 	@Override
-	public T firstElement()
-	{
-		return samples.get( 0 );
-	}
-
-	@Override
 	public Cursor< T > localizingCursor()
 	{
 		return new PointSampleListCursor();
@@ -233,11 +227,5 @@ public class PointSampleList< T > extends AbstractInterval implements IterableIn
 	public long size()
 	{
 		return samples.size();
-	}
-
-	@Override
-	public Iterator< T > iterator()
-	{
-		return cursor();
 	}
 }

--- a/src/main/java/net/imglib2/Positionable.java
+++ b/src/main/java/net/imglib2/Positionable.java
@@ -49,7 +49,7 @@ public interface Positionable extends EuclideanSpace
 	 * @param d
 	 *            dimension
 	 */
-	public void fwd( int d );
+	void fwd( int d );
 
 	/**
 	 * Move by -1 in one dimension.
@@ -57,7 +57,7 @@ public interface Positionable extends EuclideanSpace
 	 * @param d
 	 *            dimension
 	 */
-	public void bck( int d );
+	void bck( int d );
 
 	/**
 	 * Move the element in one dimension for some distance.
@@ -67,7 +67,7 @@ public interface Positionable extends EuclideanSpace
 	 * @param d
 	 *            dimension
 	 */
-	public void move( int distance, int d );
+	void move( int distance, int d );
 
 	/**
 	 * Move the element in one dimension for some distance.
@@ -77,7 +77,7 @@ public interface Positionable extends EuclideanSpace
 	 * @param d
 	 *            dimension
 	 */
-	public void move( long distance, int d );
+	void move( long distance, int d );
 
 	/**
 	 * Move the element relative to its current location using an
@@ -87,7 +87,7 @@ public interface Positionable extends EuclideanSpace
 	 *            relative offset, {@link Localizable#numDimensions()} must be
 	 *            &ge; {@link #numDimensions()}
 	 */
-	public void move( Localizable distance );
+	void move( Localizable distance );
 
 	/**
 	 * Move the element relative to its current location using an int[] as
@@ -96,7 +96,7 @@ public interface Positionable extends EuclideanSpace
 	 * @param distance
 	 *            relative offset, length must be &ge; {@link #numDimensions()}
 	 */
-	public void move( int[] distance );
+	void move( int[] distance );
 
 	/**
 	 * Move the element relative to its current location using a long[] as
@@ -105,7 +105,7 @@ public interface Positionable extends EuclideanSpace
 	 * @param distance
 	 *            relative offset, length must be &ge; {@link #numDimensions()}
 	 */
-	public void move( long[] distance );
+	void move( long[] distance );
 
 	/**
 	 * Place the element at the same location as a given {@link Localizable}
@@ -114,7 +114,7 @@ public interface Positionable extends EuclideanSpace
 	 *            absolute position, {@link Localizable#numDimensions()} must be
 	 *            &ge; {@link #numDimensions()}
 	 */
-	public void setPosition( Localizable position );
+	void setPosition( Localizable position );
 
 	/**
 	 * Set the position of the element.
@@ -123,7 +123,7 @@ public interface Positionable extends EuclideanSpace
 	 *            absolute position, length must be &ge;
 	 *            {@link #numDimensions()}
 	 */
-	public void setPosition( int[] position );
+	void setPosition( int[] position );
 
 	/**
 	 * Set the position of the element.
@@ -132,7 +132,7 @@ public interface Positionable extends EuclideanSpace
 	 *            absolute position, length must be &ge;
 	 *            {@link #numDimensions()}
 	 */
-	public void setPosition( long[] position );
+	void setPosition( long[] position );
 
 	/**
 	 * Set the position of the element for one dimension.
@@ -142,7 +142,7 @@ public interface Positionable extends EuclideanSpace
 	 * @param d
 	 *            dimension
 	 */
-	public void setPosition( int position, int d );
+	void setPosition( int position, int d );
 
 	/**
 	 * Set the position of the element for one dimension.
@@ -152,5 +152,5 @@ public interface Positionable extends EuclideanSpace
 	 * @param d
 	 *            dimension
 	 */
-	public void setPosition( long position, int d );
+	void setPosition( long position, int d );
 }

--- a/src/main/java/net/imglib2/RandomAccess.java
+++ b/src/main/java/net/imglib2/RandomAccess.java
@@ -52,7 +52,7 @@ public interface RandomAccess< T > extends Localizable, Positionable, Sampler< T
 	// http://bugs.sun.com/view_bug.do?bug_id=6656332
 	// The bug is fixed in JDK7.
 	@Deprecated
-	public default RandomAccess< T > copyRandomAccess()
+	default RandomAccess< T > copyRandomAccess()
 	{
 		return copy();
 	}

--- a/src/main/java/net/imglib2/RandomAccessible.java
+++ b/src/main/java/net/imglib2/RandomAccessible.java
@@ -107,7 +107,7 @@ public interface RandomAccessible< T > extends EuclideanSpace
 	 *
 	 * @return random access sampler
 	 */
-	public RandomAccess< T > randomAccess();
+	RandomAccess< T > randomAccess();
 
 	/**
 	 * Create a random access sampler for integer coordinates.
@@ -125,7 +125,7 @@ public interface RandomAccessible< T > extends EuclideanSpace
 	 *
 	 * @return random access sampler
 	 */
-	public RandomAccess< T > randomAccess( Interval interval );
+	RandomAccess< T > randomAccess( Interval interval );
 
 	/**
 	 * Convenience method to query a {@link RandomAccessible} for the value at a

--- a/src/main/java/net/imglib2/RealCursor.java
+++ b/src/main/java/net/imglib2/RealCursor.java
@@ -83,7 +83,7 @@ public interface RealCursor< T > extends RealLocalizable, Sampler< T >, Iterator
 	// we must avoid doing so for now. For details, see:
 	// http://bugs.sun.com/view_bug.do?bug_id=6656332
 	// The bug is fixed in JDK7.
-	public RealCursor< T > copyCursor();
+	RealCursor< T > copyCursor();
 //@Override
 //public RealCursor< T > copy();
 }

--- a/src/main/java/net/imglib2/RealCursor.java
+++ b/src/main/java/net/imglib2/RealCursor.java
@@ -101,7 +101,7 @@ public interface RealCursor< T > extends RealLocalizable, Sampler< T >, Iterator
 	/**
 	 * Default implementation, calls {@link #fwd()} then {@link #get()}.
 	 * <p>
-	 * Note, that {@code hasNext()} is not checked before {@codw fwd()}.
+	 * Note, that {@code hasNext()} is not checked before {@code fwd()}.
 	 * If such a check is desired it should be implemented in {@code fwd()}
 	 * (throwing {@code NoSuchElementException}).
 	 */

--- a/src/main/java/net/imglib2/RealCursor.java
+++ b/src/main/java/net/imglib2/RealCursor.java
@@ -83,7 +83,15 @@ public interface RealCursor< T > extends RealLocalizable, Sampler< T >, Iterator
 	// we must avoid doing so for now. For details, see:
 	// http://bugs.sun.com/view_bug.do?bug_id=6656332
 	// The bug is fixed in JDK7.
-	RealCursor< T > copyCursor();
-//@Override
-//public RealCursor< T > copy();
+	/**
+	 * @deprecated Use {@link #copy()} instead
+	 */
+	@Deprecated
+	default RealCursor< T > copyCursor()
+	{
+		return copy();
+	}
+
+	@Override
+	RealCursor< T > copy();
 }

--- a/src/main/java/net/imglib2/RealCursor.java
+++ b/src/main/java/net/imglib2/RealCursor.java
@@ -34,6 +34,9 @@
 
 package net.imglib2;
 
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+
 /**
  * A RealCursor iterates over a set of RealLocalizable elements, for example
  * intensity values sampled at a finite set of arbitrary real positions.
@@ -94,4 +97,18 @@ public interface RealCursor< T > extends RealLocalizable, Sampler< T >, Iterator
 
 	@Override
 	RealCursor< T > copy();
+
+	/**
+	 * Default implementation, calls {@link #fwd()} then {@link #get()}.
+	 * <p>
+	 * Note, that {@code hasNext()} is not checked before {@codw fwd()}.
+	 * If such a check is desired it should be implemented in {@code fwd()}
+	 * (throwing {@code NoSuchElementException}).
+	 */
+	@Override
+	default T next()
+	{
+		fwd();
+		return get();
+	}
 }

--- a/src/main/java/net/imglib2/RealInterval.java
+++ b/src/main/java/net/imglib2/RealInterval.java
@@ -93,7 +93,7 @@ public interface RealInterval extends EuclideanSpace
 	 *            dimension
 	 * @return maximum in dimension d.
 	 */
-	double realMax( final int d );
+	double realMax( int d );
 
 	/**
 	 * Write the maximum of each dimension into double[].

--- a/src/main/java/net/imglib2/RealInterval.java
+++ b/src/main/java/net/imglib2/RealInterval.java
@@ -60,7 +60,7 @@ public interface RealInterval extends EuclideanSpace
 	 *            dimension
 	 * @return minimum in dimension d.
 	 */
-	public double realMin( int d );
+	double realMin( int d );
 
 	/**
 	 * Write the minimum of each dimension into double[].
@@ -93,7 +93,7 @@ public interface RealInterval extends EuclideanSpace
 	 *            dimension
 	 * @return maximum in dimension d.
 	 */
-	public double realMax( final int d );
+	double realMax( final int d );
 
 	/**
 	 * Write the maximum of each dimension into double[].

--- a/src/main/java/net/imglib2/RealLocalizable.java
+++ b/src/main/java/net/imglib2/RealLocalizable.java
@@ -146,5 +146,5 @@ public interface RealLocalizable extends EuclideanSpace
 	 *            dimension
 	 * @return dimension of current position
 	 */
-	public double getDoublePosition( int d );
+	double getDoublePosition( int d );
 }

--- a/src/main/java/net/imglib2/RealPointSampleList.java
+++ b/src/main/java/net/imglib2/RealPointSampleList.java
@@ -255,10 +255,4 @@ public class RealPointSampleList< T > implements IterableRealInterval< T >
 	{
 		return n;
 	}
-
-	@Override
-	public Iterator< T > iterator()
-	{
-		return cursor();
-	}
 }

--- a/src/main/java/net/imglib2/RealPointSampleList.java
+++ b/src/main/java/net/imglib2/RealPointSampleList.java
@@ -138,12 +138,6 @@ public class RealPointSampleList< T > implements IterableRealInterval< T >
 			fwd();
 			return sample;
 		}
-
-		@Override
-		public void remove()
-		{
-			/* Not yet implemented */
-		}
 	}
 
 	final protected int n;

--- a/src/main/java/net/imglib2/RealPointSampleList.java
+++ b/src/main/java/net/imglib2/RealPointSampleList.java
@@ -64,12 +64,6 @@ public class RealPointSampleList< T > implements IterableRealInterval< T >
 		}
 
 		@Override
-		final public RealCursor< T > copyCursor()
-		{
-			return copy();
-		}
-
-		@Override
 		public double getDoublePosition( final int d )
 		{
 			return position.getDoublePosition( d );

--- a/src/main/java/net/imglib2/RealPositionable.java
+++ b/src/main/java/net/imglib2/RealPositionable.java
@@ -49,7 +49,7 @@ public interface RealPositionable extends Positionable
 	 * @param distance
 	 * @param d
 	 */
-	public void move( float distance, int d );
+	void move( float distance, int d );
 
 	/**
 	 * Move the element in one dimension for some distance.
@@ -57,7 +57,7 @@ public interface RealPositionable extends Positionable
 	 * @param distance
 	 * @param d
 	 */
-	public void move( double distance, int d );
+	void move( double distance, int d );
 
 	/**
 	 * Move the element relative to its current location using a
@@ -67,7 +67,7 @@ public interface RealPositionable extends Positionable
 	 *            relative offset, {@link RealLocalizable#numDimensions()} must
 	 *            be &ge; {@link #numDimensions()}
 	 */
-	public void move( RealLocalizable distance );
+	void move( RealLocalizable distance );
 
 	/**
 	 * Move the element relative to its current location using a float[] as
@@ -76,7 +76,7 @@ public interface RealPositionable extends Positionable
 	 * @param distance,
 	 *            length must be &ge; {@link #numDimensions()}
 	 */
-	public void move( float[] distance );
+	void move( float[] distance );
 
 	/**
 	 * Move the element relative to its current location using a float[] as
@@ -85,7 +85,7 @@ public interface RealPositionable extends Positionable
 	 * @param distance,
 	 *            length must be &ge; {@link #numDimensions()}
 	 */
-	public void move( double[] distance );
+	void move( double[] distance );
 
 	/**
 	 * Place the element at the same location as a given {@link RealLocalizable}
@@ -94,7 +94,7 @@ public interface RealPositionable extends Positionable
 	 *            absolute position, {@link RealLocalizable#numDimensions()}
 	 *            must be &ge; {@link #numDimensions()}
 	 */
-	public void setPosition( RealLocalizable position );
+	void setPosition( RealLocalizable position );
 
 	/**
 	 * Set the position of the element.
@@ -103,7 +103,7 @@ public interface RealPositionable extends Positionable
 	 *            absolute position, length must be &ge;
 	 *            {@link #numDimensions()}
 	 */
-	public void setPosition( float position[] );
+	void setPosition( float position[] );
 
 	/**
 	 * Set the position of the element.
@@ -112,7 +112,7 @@ public interface RealPositionable extends Positionable
 	 *            absolute position, length must be &ge;
 	 *            {@link #numDimensions()}
 	 */
-	public void setPosition( double position[] );
+	void setPosition( double position[] );
 
 	/**
 	 * Set the position of the element for one dimension.
@@ -120,7 +120,7 @@ public interface RealPositionable extends Positionable
 	 * @param position
 	 * @param d
 	 */
-	public void setPosition( float position, int d );
+	void setPosition( float position, int d );
 
 	/**
 	 * Set the position of the element for one dimension.
@@ -128,5 +128,5 @@ public interface RealPositionable extends Positionable
 	 * @param position
 	 * @param d
 	 */
-	public void setPosition( double position, int d );
+	void setPosition( double position, int d );
 }

--- a/src/main/java/net/imglib2/RealRandomAccess.java
+++ b/src/main/java/net/imglib2/RealRandomAccess.java
@@ -49,13 +49,13 @@ public interface RealRandomAccess< T > extends RealLocalizable, RealPositionable
 	// http://bugs.sun.com/view_bug.do?bug_id=6656332
 	// The bug is fixed in JDK7.
 	@Deprecated
-	public default RealRandomAccess< T > copyRealRandomAccess()
+	default RealRandomAccess< T > copyRealRandomAccess()
 	{
 		return copy();
 	}
 
 	@Override
-	public RealRandomAccess< T > copy();
+	RealRandomAccess< T > copy();
 
 	/**
 	 * Convenience method that moves the {@link RealRandomAccess} to the given

--- a/src/main/java/net/imglib2/RealRandomAccessible.java
+++ b/src/main/java/net/imglib2/RealRandomAccessible.java
@@ -62,9 +62,9 @@ public interface RealRandomAccessible< T > extends EuclideanSpace
 	 *
 	 * @return random access sampler
 	 */
-	public RealRandomAccess< T > realRandomAccess();
+	RealRandomAccess< T > realRandomAccess();
 
-	public RealRandomAccess< T > realRandomAccess( RealInterval interval );
+	RealRandomAccess< T > realRandomAccess( RealInterval interval );
 
 	/**
 	 * Convenience method to query a {@link RealRandomAccessible} for the value at a

--- a/src/main/java/net/imglib2/Sampler.java
+++ b/src/main/java/net/imglib2/Sampler.java
@@ -59,7 +59,7 @@ public interface Sampler< T >
 	 * Access the actual <em>T</em> instance providing access to a pixel,
 	 * sub-pixel or integral region value the {@link Sampler} points at.
 	 */
-	public T get();
+	T get();
 
 	/**
 	 * @return - A new {@link Sampler} in the same state accessing the same
@@ -72,5 +72,5 @@ public interface Sampler< T >
 	 *         value, not necessarily the same instance (this is the case for an
 	 *         {@link ArrayCursor} for example)
 	 */
-	public Sampler< T > copy();
+	Sampler< T > copy();
 }

--- a/src/main/java/net/imglib2/concatenate/Concatenable.java
+++ b/src/main/java/net/imglib2/concatenate/Concatenable.java
@@ -55,7 +55,7 @@ public interface Concatenable< A >
 	 * equivalent to first applying <em>a</em> to <em>x</em> and then applying
 	 * <em>b</em> to the result.
 	 */
-	public Concatenable< A > concatenate( A a );
+	Concatenable< A > concatenate( A a );
 
-	public Class< A > getConcatenableClass();
+	Class< A > getConcatenableClass();
 }

--- a/src/main/java/net/imglib2/concatenate/PreConcatenable.java
+++ b/src/main/java/net/imglib2/concatenate/PreConcatenable.java
@@ -56,7 +56,7 @@ public interface PreConcatenable< A >
 	 * equivalent to first applying <em>a</em> to <em>x</em> and then applying
 	 * <em>b</em> to the result.
 	 */
-	public PreConcatenable< A > preConcatenate( A a );
+	PreConcatenable< A > preConcatenate( A a );
 
-	public Class< A > getPreConcatenableClass();
+	Class< A > getPreConcatenableClass();
 }

--- a/src/main/java/net/imglib2/converter/AbstractConvertedCursor.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedCursor.java
@@ -142,10 +142,4 @@ abstract public class AbstractConvertedCursor< A, B > implements Cursor< B >
 
 	@Override
 	abstract public AbstractConvertedCursor< A, B > copy();
-
-	@Override
-	public AbstractConvertedCursor< A, B > copyCursor()
-	{
-		return copy();
-	}
 }

--- a/src/main/java/net/imglib2/converter/AbstractConvertedCursor.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedCursor.java
@@ -128,13 +128,6 @@ abstract public class AbstractConvertedCursor< A, B > implements Cursor< B >
 	}
 
 	@Override
-	public B next()
-	{
-		fwd();
-		return get();
-	}
-
-	@Override
 	public void remove()
 	{
 		source.remove();

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableInterval.java
@@ -64,18 +64,6 @@ abstract public class AbstractConvertedIterableInterval< A, B > extends Abstract
 	}
 
 	@Override
-	public Iterator< B > iterator()
-	{
-		return cursor();
-	}
-
-	@Override
-	public B firstElement()
-	{
-		return cursor().next();
-	}
-
-	@Override
 	abstract public AbstractConvertedCursor< A, B > cursor();
 
 	@Override

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableRandomAccessibleInterval.java
@@ -58,7 +58,7 @@ abstract public class AbstractConvertedIterableRandomAccessibleInterval< A, B, S
 	abstract public AbstractConvertedRandomAccess< A, B > randomAccess();
 
 	@Override
-	abstract public AbstractConvertedRandomAccess< A, B > randomAccess( final Interval interval );
+	abstract public AbstractConvertedRandomAccess< A, B > randomAccess( Interval interval );
 
 	@Override
 	public long size()

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableRandomAccessibleInterval.java
@@ -73,18 +73,6 @@ abstract public class AbstractConvertedIterableRandomAccessibleInterval< A, B, S
 	}
 
 	@Override
-	public Iterator< B > iterator()
-	{
-		return cursor();
-	}
-
-	@Override
-	public B firstElement()
-	{
-		return cursor().next();
-	}
-
-	@Override
 	abstract public AbstractConvertedCursor< A, B > cursor();
 
 	@Override

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableRealInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableRealInterval.java
@@ -64,18 +64,6 @@ abstract public class AbstractConvertedIterableRealInterval< A, B > extends Abst
 	}
 
 	@Override
-	public Iterator< B > iterator()
-	{
-		return cursor();
-	}
-
-	@Override
-	public B firstElement()
-	{
-		return cursor().next();
-	}
-
-	@Override
 	abstract public AbstractConvertedRealCursor< A, B > cursor();
 
 	@Override

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessible.java
@@ -66,6 +66,6 @@ abstract public class AbstractConvertedRandomAccessible< A, B > implements Rando
 	abstract public AbstractConvertedRandomAccess< A, B > randomAccess();
 
 	@Override
-	abstract public AbstractConvertedRandomAccess< A, B > randomAccess( final Interval interval );
+	abstract public AbstractConvertedRandomAccess< A, B > randomAccess( Interval interval );
 	
 }

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessibleInterval.java
@@ -58,6 +58,6 @@ abstract public class AbstractConvertedRandomAccessibleInterval< A, B > extends 
 	abstract public AbstractConvertedRandomAccess< A, B > randomAccess();
 
 	@Override
-	abstract public AbstractConvertedRandomAccess< A, B > randomAccess( final Interval interval );
+	abstract public AbstractConvertedRandomAccess< A, B > randomAccess( Interval interval );
 
 }

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRealCursor.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRealCursor.java
@@ -104,13 +104,6 @@ abstract public class AbstractConvertedRealCursor< A, B > implements RealCursor<
 	}
 
 	@Override
-	public B next()
-	{
-		fwd();
-		return get();
-	}
-
-	@Override
 	public void remove()
 	{
 		source.remove();

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRealCursor.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRealCursor.java
@@ -118,10 +118,4 @@ abstract public class AbstractConvertedRealCursor< A, B > implements RealCursor<
 
 	@Override
 	abstract public AbstractConvertedRealCursor< A, B > copy();
-
-	@Override
-	public AbstractConvertedRealCursor< A, B > copyCursor()
-	{
-		return copy();
-	}
 }

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRealRandomAccessible.java
@@ -66,5 +66,5 @@ abstract public class AbstractConvertedRealRandomAccessible< A, B > implements R
 	abstract public AbstractConvertedRealRandomAccess< A, B > realRandomAccess();
 
 	@Override
-	abstract public AbstractConvertedRealRandomAccess< A, B > realRandomAccess( final RealInterval interval );
+	abstract public AbstractConvertedRealRandomAccess< A, B > realRandomAccess( RealInterval interval );
 }

--- a/src/main/java/net/imglib2/converter/BiConverter.java
+++ b/src/main/java/net/imglib2/converter/BiConverter.java
@@ -43,5 +43,5 @@ package net.imglib2.converter;
  */
 public interface BiConverter< A, B, C >
 {
-	public void convert( A inputA, B outputB, C output );
+	void convert( A inputA, B outputB, C output );
 }

--- a/src/main/java/net/imglib2/converter/ChannelARGBConverter.java
+++ b/src/main/java/net/imglib2/converter/ChannelARGBConverter.java
@@ -76,7 +76,7 @@ public final class ChannelARGBConverter implements Converter< UnsignedByteType, 
 		converterListRGBA.add( new ChannelARGBConverter( A ) );
 	}
 
-	public static enum Channel
+	public enum Channel
 	{
 		A( 24 ), R( 16 ), G( 8 ), B( 0 );
 

--- a/src/main/java/net/imglib2/converter/Converter.java
+++ b/src/main/java/net/imglib2/converter/Converter.java
@@ -46,5 +46,5 @@ import java.util.function.BiConsumer;
  */
 public interface Converter< A, B >
 {
-	public void convert( A input, B output );
+	void convert( A input, B output );
 }

--- a/src/main/java/net/imglib2/converter/readwrite/SamplerConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/SamplerConverter.java
@@ -42,5 +42,5 @@ import net.imglib2.Sampler;
  */
 public interface SamplerConverter< A, B >
 {
-	public B convert( Sampler< ? extends A > sampler );
+	B convert( Sampler< ? extends A > sampler );
 }

--- a/src/main/java/net/imglib2/display/AbstractArrayColorTable.java
+++ b/src/main/java/net/imglib2/display/AbstractArrayColorTable.java
@@ -97,22 +97,4 @@ public abstract class AbstractArrayColorTable< T > implements ArrayColorTable< T
 		return values.length;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 * <p>
-	 * Value is unsigned 8 bits.
-	 * </p>
-	 */
-	@Override
-	public abstract int get( int comp, int bin );
-
-	/**
-	 * {@inheritDoc}
-	 * <p>
-	 * Value is unsigned 8 bits.
-	 * </p>
-	 */
-	@Override
-	public abstract int getResampled( int comp, int bins, int bin );
-
 }

--- a/src/main/java/net/imglib2/display/AbstractArrayColorTable.java
+++ b/src/main/java/net/imglib2/display/AbstractArrayColorTable.java
@@ -104,7 +104,7 @@ public abstract class AbstractArrayColorTable< T > implements ArrayColorTable< T
 	 * </p>
 	 */
 	@Override
-	public abstract int get( final int comp, final int bin );
+	public abstract int get( int comp, int bin );
 
 	/**
 	 * {@inheritDoc}
@@ -113,6 +113,6 @@ public abstract class AbstractArrayColorTable< T > implements ArrayColorTable< T
 	 * </p>
 	 */
 	@Override
-	public abstract int getResampled( final int comp, final int bins, final int bin );
+	public abstract int getResampled( int comp, int bins, int bin );
 
 }

--- a/src/main/java/net/imglib2/display/ColorTable.java
+++ b/src/main/java/net/imglib2/display/ColorTable.java
@@ -40,13 +40,13 @@ package net.imglib2.display;
 public interface ColorTable
 {
 	// TODO ARG What about C,M,Y,K?
-	public static final int RED = 0;
+	int RED = 0;
 
-	public static final int GREEN = 1;
+	int GREEN = 1;
 
-	public static final int BLUE = 2;
+	int BLUE = 2;
 
-	public static final int ALPHA = 3;
+	int ALPHA = 3;
 
 	int lookupARGB( double min, double max, double value );
 

--- a/src/main/java/net/imglib2/display/ColorTable.java
+++ b/src/main/java/net/imglib2/display/ColorTable.java
@@ -48,18 +48,18 @@ public interface ColorTable
 
 	public static final int ALPHA = 3;
 
-	public int lookupARGB( double min, double max, double value );
+	int lookupARGB( double min, double max, double value );
 
 	/**
 	 * Gets the number of color components in the table (typically 3 for RGB or
 	 * 4 for RGBA).
 	 */
-	public int getComponentCount();
+	int getComponentCount();
 
 	/**
 	 * Gets the number of elements for each color component in the table.
 	 */
-	public int getLength();
+	int getLength();
 
 	/**
 	 * Gets an individual value from the color table.
@@ -70,7 +70,7 @@ public interface ColorTable
 	 *            The index into the color table.
 	 * @return The value of the table at the specified position.
 	 */
-	public int get( final int comp, final int bin );
+	int get( final int comp, final int bin );
 
 	/**
 	 * Gets an individual value from a color table with given number of bins.
@@ -83,5 +83,5 @@ public interface ColorTable
 	 *            The index into the color table.
 	 * @return The value of the table at the specified position.
 	 */
-	public int getResampled( final int comp, final int bins, final int bin );
+	int getResampled( final int comp, final int bins, final int bin );
 }

--- a/src/main/java/net/imglib2/display/ColorTable.java
+++ b/src/main/java/net/imglib2/display/ColorTable.java
@@ -70,7 +70,7 @@ public interface ColorTable
 	 *            The index into the color table.
 	 * @return The value of the table at the specified position.
 	 */
-	int get( final int comp, final int bin );
+	int get( int comp, int bin );
 
 	/**
 	 * Gets an individual value from a color table with given number of bins.
@@ -83,5 +83,5 @@ public interface ColorTable
 	 *            The index into the color table.
 	 * @return The value of the table at the specified position.
 	 */
-	int getResampled( final int comp, final int bins, final int bin );
+	int getResampled( int comp, int bins, int bin );
 }

--- a/src/main/java/net/imglib2/display/LinearRange.java
+++ b/src/main/java/net/imglib2/display/LinearRange.java
@@ -41,11 +41,11 @@ package net.imglib2.display;
  */
 public interface LinearRange
 {
-	public double getMin();
+	double getMin();
 
-	public double getMax();
+	double getMax();
 
-	public void setMin( double min );
+	void setMin( double min );
 
-	public void setMax( double max );
+	void setMax( double max );
 }

--- a/src/main/java/net/imglib2/display/projector/Projector.java
+++ b/src/main/java/net/imglib2/display/projector/Projector.java
@@ -41,5 +41,5 @@ package net.imglib2.display.projector;
  */
 public interface Projector
 {
-	public void map();
+	void map();
 }

--- a/src/main/java/net/imglib2/display/projector/sampler/IntervalSampler.java
+++ b/src/main/java/net/imglib2/display/projector/sampler/IntervalSampler.java
@@ -65,15 +65,6 @@ public class IntervalSampler< T > implements ProjectedSampler< T >
 	}
 
 	@Override
-	public void jumpFwd( final long steps )
-	{
-		for ( int i = 0; i < steps; i++ )
-		{
-			fwd();
-		}
-	}
-
-	@Override
 	public void fwd()
 	{
 		m_source.fwd( m_projectionDimension );

--- a/src/main/java/net/imglib2/display/screenimage/ScreenImage.java
+++ b/src/main/java/net/imglib2/display/screenimage/ScreenImage.java
@@ -45,5 +45,5 @@ package net.imglib2.display.screenimage;
  */
 public interface ScreenImage< T >
 {
-	public T image();
+	T image();
 }

--- a/src/main/java/net/imglib2/display/screenimage/awt/AWTScreenImage.java
+++ b/src/main/java/net/imglib2/display/screenimage/awt/AWTScreenImage.java
@@ -47,6 +47,6 @@ public interface AWTScreenImage extends ScreenImage< Image >
 {
 
 	@Override
-	public Image image();
+	Image image();
 
 }

--- a/src/main/java/net/imglib2/img/AbstractImg.java
+++ b/src/main/java/net/imglib2/img/AbstractImg.java
@@ -69,18 +69,6 @@ public abstract class AbstractImg< T > implements Img< T >
 			max[ i ] = size[ i ] - 1;
 	}
 
-	@Override
-	public Iterator< T > iterator()
-	{
-		return cursor();
-	}
-
-	@Override
-	public T firstElement()
-	{
-		return cursor().next();
-	}
-
 	public static long numElements( final long[] dim )
 	{
 		long numPixels = 1;

--- a/src/main/java/net/imglib2/img/Img.java
+++ b/src/main/java/net/imglib2/img/Img.java
@@ -60,11 +60,11 @@ public interface Img< T >
 	 * 
 	 * @return a factory for Imgs of the same kind as this one.
 	 */
-	public ImgFactory< T > factory();
+	ImgFactory< T > factory();
 
 	/**
 	 * @return - A copy of the current {@link Img} instance, all pixels are
 	 *         duplicated
 	 */
-	public Img< T > copy();
+	Img< T > copy();
 }

--- a/src/main/java/net/imglib2/img/ImgFactory.java
+++ b/src/main/java/net/imglib2/img/ImgFactory.java
@@ -66,7 +66,7 @@ public abstract class ImgFactory< T >
 	 *
 	 * @return new image with the specified {@code dimensions}.
 	 */
-	public abstract Img< T > create( final long... dimensions );
+	public abstract Img< T > create( long... dimensions );
 
 	/**
 	 * Create an {@code Img<T>} with the specified {@code dimensions}.
@@ -114,7 +114,7 @@ public abstract class ImgFactory< T >
 	 * @throws IncompatibleTypeException
 	 *             if type S is not compatible
 	 */
-	public abstract < S > ImgFactory< S > imgFactory( final S type ) throws IncompatibleTypeException;
+	public abstract < S > ImgFactory< S > imgFactory( S type ) throws IncompatibleTypeException;
 
 	/**
 	 * Creates the same {@link ImgFactory} for a different generic parameter if
@@ -156,7 +156,7 @@ public abstract class ImgFactory< T >
 	}
 
 	@Deprecated
-	public abstract Img< T > create( final long[] dim, final T type );
+	public abstract Img< T > create( long[] dim, T type );
 
 	@Deprecated
 	public Img< T > create( final Dimensions dim, final T type )

--- a/src/main/java/net/imglib2/img/NativeImg.java
+++ b/src/main/java/net/imglib2/img/NativeImg.java
@@ -51,9 +51,9 @@ public interface NativeImg< T extends Type< T >, A > extends Img< T >
 	 *            cursor
 	 * @return native array which is referred to by the updater
 	 */
-	A update( final Object updater );
+	A update( Object updater );
 
-	void setLinkedType( final T type );
+	void setLinkedType( T type );
 
 	T createLinkedType();
 }

--- a/src/main/java/net/imglib2/img/NativeImg.java
+++ b/src/main/java/net/imglib2/img/NativeImg.java
@@ -51,9 +51,9 @@ public interface NativeImg< T extends Type< T >, A > extends Img< T >
 	 *            cursor
 	 * @return native array which is referred to by the updater
 	 */
-	public A update( final Object updater );
+	A update( final Object updater );
 
-	public void setLinkedType( final T type );
+	void setLinkedType( final T type );
 
-	public T createLinkedType();
+	T createLinkedType();
 }

--- a/src/main/java/net/imglib2/img/NativeImgFactory.java
+++ b/src/main/java/net/imglib2/img/NativeImgFactory.java
@@ -58,7 +58,7 @@ public abstract class NativeImgFactory< T extends NativeType< T > > extends ImgF
 	 * @return new {@link NativeImg} with the specified {@code dimensions}.
 	 */
 	@Override
-	public abstract NativeImg< T, ? > create( final long... dimensions );
+	public abstract NativeImg< T, ? > create( long... dimensions );
 
 	/**
 	 * Create an {@code Img<T>} with the specified {@code dimensions}.
@@ -103,7 +103,7 @@ public abstract class NativeImgFactory< T extends NativeType< T > > extends ImgF
 
 	@Override
 	@Deprecated
-	public abstract NativeImg< T, ? > create( final long[] dimension, final T type );
+	public abstract NativeImg< T, ? > create( long[] dimension, T type );
 
 	@Deprecated
 	public NativeImgFactory( )

--- a/src/main/java/net/imglib2/img/array/ArrayCursor.java
+++ b/src/main/java/net/imglib2/img/array/ArrayCursor.java
@@ -63,10 +63,4 @@ public final class ArrayCursor< T extends NativeType< T > > extends AbstractArra
 	{
 		return new ArrayCursor< T >( this );
 	}
-
-	@Override
-	public ArrayCursor< T > copyCursor()
-	{
-		return copy();
-	}
 }

--- a/src/main/java/net/imglib2/img/array/ArrayLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/array/ArrayLocalizingCursor.java
@@ -76,10 +76,4 @@ public final class ArrayLocalizingCursor< T extends NativeType< T > > extends Ab
 	{
 		return new ArrayLocalizingCursor< T >( this );
 	}
-
-	@Override
-	public ArrayLocalizingCursor< T > copyCursor()
-	{
-		return copy();
-	}
 }

--- a/src/main/java/net/imglib2/img/array/ArrayLocalizingSubIntervalCursor.java
+++ b/src/main/java/net/imglib2/img/array/ArrayLocalizingSubIntervalCursor.java
@@ -77,11 +77,4 @@ public final class ArrayLocalizingSubIntervalCursor< T extends NativeType< T > >
 	{
 		return new ArrayLocalizingSubIntervalCursor< T >( this );
 	}
-
-	@Override
-	public ArrayLocalizingSubIntervalCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
 }

--- a/src/main/java/net/imglib2/img/array/ArraySubIntervalCursor.java
+++ b/src/main/java/net/imglib2/img/array/ArraySubIntervalCursor.java
@@ -78,10 +78,4 @@ public final class ArraySubIntervalCursor< T extends NativeType< T > > extends A
 	{
 		return new ArraySubIntervalCursor< T >( this );
 	}
-
-	@Override
-	public ArraySubIntervalCursor< T > copyCursor()
-	{
-		return copy();
-	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/BooleanAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/BooleanAccess.java
@@ -41,7 +41,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface BooleanAccess extends DataAccess
 {
-	boolean getValue( final int index );
+	boolean getValue( int index );
 
-	void setValue( final int index, final boolean value );
+	void setValue( int index, boolean value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/BooleanAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/BooleanAccess.java
@@ -41,7 +41,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface BooleanAccess extends DataAccess
 {
-	public boolean getValue( final int index );
+	boolean getValue( final int index );
 
-	public void setValue( final int index, final boolean value );
+	void setValue( final int index, final boolean value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/ByteAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/ByteAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface ByteAccess extends DataAccess
 {
-	public byte getValue( final int index );
+	byte getValue( final int index );
 
-	public void setValue( final int index, final byte value );
+	void setValue( final int index, final byte value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/ByteAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/ByteAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface ByteAccess extends DataAccess
 {
-	byte getValue( final int index );
+	byte getValue( int index );
 
-	void setValue( final int index, final byte value );
+	void setValue( int index, byte value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/CharAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/CharAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface CharAccess extends DataAccess
 {
-	char getValue( final int index );
+	char getValue( int index );
 
-	void setValue( final int index, final char value );
+	void setValue( int index, char value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/CharAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/CharAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface CharAccess extends DataAccess
 {
-	public char getValue( final int index );
+	char getValue( final int index );
 
-	public void setValue( final int index, final char value );
+	void setValue( final int index, final char value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/DataAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/DataAccess.java
@@ -66,7 +66,7 @@ public interface DataAccess
 	 * @see NativeImg#update(Object)
 	 * @see NativeType#updateContainer(Object)
 	 */
-	default DataAccess createView( final Object o )
+	default DataAccess createView( Object o )
 	{
 		return this;
 	}

--- a/src/main/java/net/imglib2/img/basictypeaccess/DataAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/DataAccess.java
@@ -66,7 +66,7 @@ public interface DataAccess
 	 * @see NativeImg#update(Object)
 	 * @see NativeType#updateContainer(Object)
 	 */
-	public default DataAccess createView( final Object o )
+	default DataAccess createView( final Object o )
 	{
 		return this;
 	}

--- a/src/main/java/net/imglib2/img/basictypeaccess/DoubleAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/DoubleAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface DoubleAccess extends DataAccess
 {
-	public double getValue( final int index );
+	double getValue( final int index );
 
-	public void setValue( final int index, final double value );
+	void setValue( final int index, final double value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/DoubleAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/DoubleAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface DoubleAccess extends DataAccess
 {
-	double getValue( final int index );
+	double getValue( int index );
 
-	void setValue( final int index, final double value );
+	void setValue( int index, double value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/FloatAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/FloatAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface FloatAccess extends DataAccess
 {
-	float getValue( final int index );
+	float getValue( int index );
 
-	void setValue( final int index, final float value );
+	void setValue( int index, float value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/FloatAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/FloatAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface FloatAccess extends DataAccess
 {
-	public float getValue( final int index );
+	float getValue( final int index );
 
-	public void setValue( final int index, final float value );
+	void setValue( final int index, final float value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/IntAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/IntAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface IntAccess extends DataAccess
 {
-	public int getValue( final int index );
+	int getValue( final int index );
 
-	public void setValue( final int index, final int value );
+	void setValue( final int index, final int value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/IntAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/IntAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface IntAccess extends DataAccess
 {
-	int getValue( final int index );
+	int getValue( int index );
 
-	void setValue( final int index, final int value );
+	void setValue( int index, int value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/LongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/LongAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface LongAccess extends DataAccess
 {
-	public long getValue( final int index );
+	long getValue( final int index );
 
-	public void setValue( final int index, final long value );
+	void setValue( final int index, final long value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/LongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/LongAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface LongAccess extends DataAccess
 {
-	long getValue( final int index );
+	long getValue( int index );
 
-	void setValue( final int index, final long value );
+	void setValue( int index, long value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/ShortAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/ShortAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface ShortAccess extends DataAccess
 {
-	public short getValue( final int index );
+	short getValue( final int index );
 
-	public void setValue( final int index, final short value );
+	void setValue( final int index, final short value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/ShortAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/ShortAccess.java
@@ -42,7 +42,7 @@ package net.imglib2.img.basictypeaccess;
  */
 public interface ShortAccess extends DataAccess
 {
-	short getValue( final int index );
+	short getValue( int index );
 
-	void setValue( final int index, final short value );
+	void setValue( int index, short value );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/AbstractBufferAccess.java
@@ -207,14 +207,6 @@ public abstract class AbstractBufferAccess< A extends AbstractBufferAccess< A, B
 	 */
 
 	/**
-	 * Get number of bytes for a specific primitive type.
-	 *
-	 * This usually retrieves a static field.
-	 */
-	@Override
-	public abstract int getNumBytesPerEntity();
-
-	/**
 	 * Create a new instance of this class given a Buffer of the same type.
 	 *
 	 * @param buffer

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
@@ -70,9 +70,10 @@ public interface BufferAccess< A > extends VolatileAccess, ArrayDataAccess< A >
 	boolean isReadOnly();
 
 	/**
-	 * Number of bytes for this type
+	 * Get number of bytes for one entity in this {@code BufferAccess}.
+	 * This usually retrieves a static field.
 	 *
-	 * @return
+	 * @return number of bytes
 	 */
 	int getNumBytesPerEntity();
 

--- a/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/nio/BufferAccess.java
@@ -59,7 +59,7 @@ public interface BufferAccess< A > extends VolatileAccess, ArrayDataAccess< A >
 	 * @return true if the Buffer is direct.
 	 * @see Buffer#isDirect()
 	 */
-	public boolean isDirect();
+	boolean isDirect();
 
 	/**
 	 * Determine if data can be read only and not written
@@ -67,14 +67,14 @@ public interface BufferAccess< A > extends VolatileAccess, ArrayDataAccess< A >
 	 * @return
 	 * @see Buffer#isReadOnly()
 	 */
-	public boolean isReadOnly();
+	boolean isReadOnly();
 
 	/**
 	 * Number of bytes for this type
 	 *
 	 * @return
 	 */
-	public int getNumBytesPerEntity();
+	int getNumBytesPerEntity();
 
 	/**
 	 * Create a new instance from a ByteBuffer
@@ -83,6 +83,6 @@ public interface BufferAccess< A > extends VolatileAccess, ArrayDataAccess< A >
 	 * @param isValid
 	 * @return
 	 */
-	public A newInstance( ByteBuffer buffer, boolean isValid );
+	A newInstance( ByteBuffer buffer, boolean isValid );
 
 }

--- a/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
+++ b/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
@@ -76,7 +76,7 @@ public abstract class AbstractCellImg<
 		/**
 		 * @return the cell the sampler is currently in.
 		 */
-		public C getCell();
+		C getCell();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/CellCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellCursor.java
@@ -73,7 +73,7 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 
 		this.type = cursor.type.duplicateTypeOnSameNativeImg();
 		i = type.index();
-		this.cursorOnCells = cursor.cursorOnCells.copyCursor();
+		this.cursorOnCells = cursor.cursorOnCells.copy();
 		isNotLastCell = cursor.isNotLastCell;
 		lastIndexInCell = cursor.lastIndexInCell;
 		typeIndex = cursor.typeIndex;
@@ -109,12 +109,6 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 	public CellCursor< T, C > copy()
 	{
 		return new CellCursor<>( this );
-	}
-
-	@Override
-	public CellCursor< T, C > copyCursor()
-	{
-		return copy();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/CellGrid.java
+++ b/src/main/java/net/imglib2/img/cell/CellGrid.java
@@ -448,21 +448,9 @@ public class CellGrid
 		}
 
 		@Override
-		public Interval firstElement()
-		{
-			return cursor().next();
-		}
-
-		@Override
 		public FlatIterationOrder iterationOrder()
 		{
 			return new FlatIterationOrder( this );
-		}
-
-		@Override
-		public Iterator< Interval > iterator()
-		{
-			return cursor();
 		}
 	}
 

--- a/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
@@ -77,7 +77,7 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 
 		this.type = cursor.type.duplicateTypeOnSameNativeImg();
 		typeIndex = type.index();
-		this.cursorOnCells = cursor.cursorOnCells.copyCursor();
+		this.cursorOnCells = cursor.cursorOnCells.copy();
 		this.currentCellMin = cursor.currentCellMin;
 		this.currentCellMax = cursor.currentCellMax;
 
@@ -120,12 +120,6 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 	public CellLocalizingCursor< T, C > copy()
 	{
 		return new CellLocalizingCursor<>( this );
-	}
-
-	@Override
-	public CellLocalizingCursor< T, C > copyCursor()
-	{
-		return copy();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/list/AbstractListImg.java
+++ b/src/main/java/net/imglib2/img/list/AbstractListImg.java
@@ -82,9 +82,9 @@ public abstract class AbstractListImg< T > extends AbstractImg< T >
 		IntervalIndexer.createAllocationSteps( this.dim, step );
 	}
 
-	protected abstract T get( final int index );
+	protected abstract T get( int index );
 
-	protected abstract void set( final int index, final T value );
+	protected abstract void set( int index, T value );
 
 	@Override
 	public ListCursor< T > cursor()

--- a/src/main/java/net/imglib2/img/list/AbstractLongListImg.java
+++ b/src/main/java/net/imglib2/img/list/AbstractLongListImg.java
@@ -396,9 +396,9 @@ public abstract class AbstractLongListImg< T > extends AbstractImg< T >
 		IntervalIndexer.createAllocationSteps( dimension, step );
 	}
 
-	protected abstract T get( final long index );
+	protected abstract T get( long index );
 
-	protected abstract void set( final long index, final T value );
+	protected abstract void set( long index, T value );
 
 	@Override
 	public LongListCursor cursor()

--- a/src/main/java/net/imglib2/img/list/AbstractLongListImg.java
+++ b/src/main/java/net/imglib2/img/list/AbstractLongListImg.java
@@ -110,12 +110,6 @@ public abstract class AbstractLongListImg< T > extends AbstractImg< T >
 		}
 
 		@Override
-		public LongListCursor copyCursor()
-		{
-			return copy();
-		}
-
-		@Override
 		public boolean hasNext()
 		{
 			return i < maxNumPixels;
@@ -238,12 +232,6 @@ public abstract class AbstractLongListImg< T > extends AbstractImg< T >
 		public LongListLocalizingCursor copy()
 		{
 			return new LongListLocalizingCursor( this );
-		}
-
-		@Override
-		public LongListLocalizingCursor copyCursor()
-		{
-			return copy();
 		}
 	}
 

--- a/src/main/java/net/imglib2/img/list/ListCursor.java
+++ b/src/main/java/net/imglib2/img/list/ListCursor.java
@@ -94,12 +94,6 @@ final public class ListCursor< T > extends AbstractCursorInt< T >
 	}
 
 	@Override
-	public ListCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
-	@Override
 	public boolean hasNext()
 	{
 		return i < maxNumPixels;

--- a/src/main/java/net/imglib2/img/list/ListLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/list/ListLocalizingCursor.java
@@ -139,10 +139,4 @@ final public class ListLocalizingCursor< T > extends AbstractLocalizingCursorInt
 	{
 		return new ListLocalizingCursor< T >( this );
 	}
-
-	@Override
-	public ListLocalizingCursor< T > copyCursor()
-	{
-		return copy();
-	}
 }

--- a/src/main/java/net/imglib2/img/planar/PlanarCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarCursor.java
@@ -113,12 +113,6 @@ public class PlanarCursor< T extends NativeType< T > > extends AbstractCursorInt
 		return new PlanarCursor< T >( this );
 	}
 
-	@Override
-	public PlanarCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
 	/**
 	 * Note: This test is fragile in a sense that it returns true for elements
 	 * after the last element as well.

--- a/src/main/java/net/imglib2/img/planar/PlanarImg.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImg.java
@@ -108,7 +108,7 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 		/**
 		 * @return the index of the slice the sampler is currently accessing.
 		 */
-		public int getCurrentSliceIndex();
+		int getCurrentSliceIndex();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
@@ -131,12 +131,6 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 		return new PlanarLocalizingCursor< T >( this );
 	}
 
-	@Override
-	public PlanarLocalizingCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
 	/**
 	 * Note: This test is fragile in a sense that it returns true for elements
 	 * after the last element as well.

--- a/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetCursor.java
@@ -155,15 +155,6 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 	 * {@inheritDoc}
 	 */
 	@Override
-	public PlanarPlaneSubsetCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
 	public final boolean hasNext()
 	{
 		return typeIndex.get() < lastPlaneIndex;

--- a/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetLocalizingCursor.java
@@ -166,15 +166,6 @@ public class PlanarPlaneSubsetLocalizingCursor< T extends NativeType< T > >
 	 * {@inheritDoc}
 	 */
 	@Override
-	public PlanarPlaneSubsetLocalizingCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
 	public final boolean hasNext()
 	{
 		return typeIndex.get() < lastIndexPlane;

--- a/src/main/java/net/imglib2/img/sparse/NtreeAccess.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeAccess.java
@@ -45,7 +45,7 @@ public interface NtreeAccess< L extends Comparable< L >, A extends NtreeAccess< 
 	A createInstance( long[] pos );
 
 	@Override
-	public default A createView( final Object updater )
+	default A createView( final Object updater )
 	{
 		return createInstance( ( ( PositionProvider ) updater ).getPosition() );
 	}

--- a/src/main/java/net/imglib2/img/sparse/NtreeCursor.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeCursor.java
@@ -101,12 +101,6 @@ public final class NtreeCursor< T extends NativeType< T >> extends
 	}
 
 	@Override
-	public NtreeCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
-	@Override
 	public long[] getPosition()
 	{
 		return position;

--- a/src/main/java/net/imglib2/img/sparse/NtreeCursor.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeCursor.java
@@ -91,10 +91,6 @@ public final class NtreeCursor< T extends NativeType< T >> extends
 	}
 
 	@Override
-	public void remove()
-	{}
-
-	@Override
 	public NtreeCursor< T > copy()
 	{
 		return new NtreeCursor<>( this );

--- a/src/main/java/net/imglib2/img/sparse/NtreeCursor.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeCursor.java
@@ -84,13 +84,6 @@ public final class NtreeCursor< T extends NativeType< T >> extends
 	}
 
 	@Override
-	public T next()
-	{
-		fwd();
-		return get();
-	}
-
-	@Override
 	public NtreeCursor< T > copy()
 	{
 		return new NtreeCursor<>( this );

--- a/src/main/java/net/imglib2/img/sparse/NtreeImg.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeImg.java
@@ -69,7 +69,7 @@ public final class NtreeImg< T extends NativeType< T >, A extends NtreeAccess< ?
 		this.data = img.data;
 	}
 
-	public static interface PositionProvider
+	public interface PositionProvider
 	{
 		long[] getPosition();
 	}

--- a/src/main/java/net/imglib2/interpolation/InterpolatorFactory.java
+++ b/src/main/java/net/imglib2/interpolation/InterpolatorFactory.java
@@ -48,7 +48,7 @@ import net.imglib2.RealRandomAccess;
  */
 public interface InterpolatorFactory< T, F >
 {
-	public RealRandomAccess< T > create( final F f );
+	RealRandomAccess< T > create( final F f );
 
-	public RealRandomAccess< T > create( final F f, final RealInterval interval );
+	RealRandomAccess< T > create( final F f, final RealInterval interval );
 }

--- a/src/main/java/net/imglib2/interpolation/InterpolatorFactory.java
+++ b/src/main/java/net/imglib2/interpolation/InterpolatorFactory.java
@@ -48,7 +48,7 @@ import net.imglib2.RealRandomAccess;
  */
 public interface InterpolatorFactory< T, F >
 {
-	RealRandomAccess< T > create( final F f );
+	RealRandomAccess< T > create( F f );
 
-	RealRandomAccess< T > create( final F f, final RealInterval interval );
+	RealRandomAccess< T > create( F f, RealInterval interval );
 }

--- a/src/main/java/net/imglib2/neighborsearch/KNearestNeighborSearch.java
+++ b/src/main/java/net/imglib2/neighborsearch/KNearestNeighborSearch.java
@@ -55,45 +55,45 @@ public interface KNearestNeighborSearch< T > extends NearestNeighborSearch< T >
 	 * @param reference
 	 */
 	@Override
-	public void search( final RealLocalizable reference );
+	void search( final RealLocalizable reference );
 
 	/**
 	 * Get the of k nearest neighbor points used in this search
 	 * 
 	 * @return the number of nearest neighbor points k used for this search
 	 */
-	public int getK();
+	int getK();
 
 	/**
 	 * Access the data of the <em>i</em><sup>th</sup> nearest neighbor, ordered
 	 * by square Euclidean distance. Data is accessed through a {@link Sampler}
 	 * that guarantees write access if the underlying data set is writable.
 	 */
-	public Sampler< T > getSampler( final int i );
+	Sampler< T > getSampler( final int i );
 
 	/**
 	 * Access the position of the <em>i</em><sup>th</sup> nearest neighbor,
 	 * ordered by square Euclidean distance.
 	 */
-	public RealLocalizable getPosition( final int i );
+	RealLocalizable getPosition( final int i );
 
 	/**
 	 * Access the square Euclidean distance between the reference location as
 	 * used for the last search and the <em>i</em><sup>th</sup> nearest
 	 * neighbor, ordered by square Euclidean distance.
 	 */
-	public double getSquareDistance( final int i );
+	double getSquareDistance( final int i );
 
 	/**
 	 * Access the Euclidean distance between the reference location as used for
 	 * the last search and the <em>i</em><sup>th</sup> nearest neighbor, ordered
 	 * by square Euclidean distance.
 	 */
-	public double getDistance( final int i );
+	double getDistance( final int i );
 
 	/**
 	 * Create a copy.
 	 */
 	@Override
-	public KNearestNeighborSearch< T > copy();
+	KNearestNeighborSearch< T > copy();
 }

--- a/src/main/java/net/imglib2/neighborsearch/KNearestNeighborSearch.java
+++ b/src/main/java/net/imglib2/neighborsearch/KNearestNeighborSearch.java
@@ -55,7 +55,7 @@ public interface KNearestNeighborSearch< T > extends NearestNeighborSearch< T >
 	 * @param reference
 	 */
 	@Override
-	void search( final RealLocalizable reference );
+	void search( RealLocalizable reference );
 
 	/**
 	 * Get the of k nearest neighbor points used in this search
@@ -69,27 +69,27 @@ public interface KNearestNeighborSearch< T > extends NearestNeighborSearch< T >
 	 * by square Euclidean distance. Data is accessed through a {@link Sampler}
 	 * that guarantees write access if the underlying data set is writable.
 	 */
-	Sampler< T > getSampler( final int i );
+	Sampler< T > getSampler( int i );
 
 	/**
 	 * Access the position of the <em>i</em><sup>th</sup> nearest neighbor,
 	 * ordered by square Euclidean distance.
 	 */
-	RealLocalizable getPosition( final int i );
+	RealLocalizable getPosition( int i );
 
 	/**
 	 * Access the square Euclidean distance between the reference location as
 	 * used for the last search and the <em>i</em><sup>th</sup> nearest
 	 * neighbor, ordered by square Euclidean distance.
 	 */
-	double getSquareDistance( final int i );
+	double getSquareDistance( int i );
 
 	/**
 	 * Access the Euclidean distance between the reference location as used for
 	 * the last search and the <em>i</em><sup>th</sup> nearest neighbor, ordered
 	 * by square Euclidean distance.
 	 */
-	double getDistance( final int i );
+	double getDistance( int i );
 
 	/**
 	 * Create a copy.

--- a/src/main/java/net/imglib2/neighborsearch/KNearestNeighborSearchOnIterableRealInterval.java
+++ b/src/main/java/net/imglib2/neighborsearch/KNearestNeighborSearchOnIterableRealInterval.java
@@ -112,7 +112,7 @@ public class KNearestNeighborSearchOnIterableRealInterval< T > implements KNeare
 			int i = k - 1;
 			if ( squareDistances[ i ] > squareDistance )
 			{
-				final RealCursor< T > candidate = cursor.copyCursor();
+				final RealCursor< T > candidate = cursor.copy();
 
 				for ( int j = i - 1; i > 0 && squareDistances[ j ] > squareDistance; --i, --j )
 				{

--- a/src/main/java/net/imglib2/neighborsearch/NearestNeighborSearch.java
+++ b/src/main/java/net/imglib2/neighborsearch/NearestNeighborSearch.java
@@ -54,37 +54,37 @@ public interface NearestNeighborSearch< T > extends EuclideanSpace
 	 * 
 	 * @param reference
 	 */
-	public void search( final RealLocalizable reference );
+	void search( final RealLocalizable reference );
 
 	/**
 	 * Access the data of the nearest neighbor. Data is accessed through a
 	 * {@link Sampler} that guarantees write access if the underlying data set
 	 * is writable.
 	 */
-	public Sampler< T > getSampler();
+	Sampler< T > getSampler();
 
 	/**
 	 * Access the position of the nearest neighbor, ordered by square Euclidean
 	 * distance.
 	 */
-	public RealLocalizable getPosition();
+	RealLocalizable getPosition();
 
 	/**
 	 * Access the square Euclidean distance between the reference location as
 	 * used for the last search and the nearest neighbor, ordered by square
 	 * Euclidean distance.
 	 */
-	public double getSquareDistance();
+	double getSquareDistance();
 
 	/**
 	 * Access the Euclidean distance between the reference location as used for
 	 * the last search and the nearest neighbor, ordered by square Euclidean
 	 * distance.
 	 */
-	public double getDistance();
+	double getDistance();
 
 	/**
 	 * Create a copy.
 	 */
-	public NearestNeighborSearch< T > copy();
+	NearestNeighborSearch< T > copy();
 }

--- a/src/main/java/net/imglib2/neighborsearch/NearestNeighborSearch.java
+++ b/src/main/java/net/imglib2/neighborsearch/NearestNeighborSearch.java
@@ -54,7 +54,7 @@ public interface NearestNeighborSearch< T > extends EuclideanSpace
 	 * 
 	 * @param reference
 	 */
-	void search( final RealLocalizable reference );
+	void search( RealLocalizable reference );
 
 	/**
 	 * Access the data of the nearest neighbor. Data is accessed through a

--- a/src/main/java/net/imglib2/neighborsearch/NearestNeighborSearchOnIterableRealInterval.java
+++ b/src/main/java/net/imglib2/neighborsearch/NearestNeighborSearchOnIterableRealInterval.java
@@ -101,7 +101,7 @@ public class NearestNeighborSearchOnIterableRealInterval< T > implements Nearest
 			if ( squareDistance > cursorSquareDistance )
 			{
 				squareDistance = cursorSquareDistance;
-				element = cursor.copyCursor();
+				element = cursor.copy();
 			}
 		}
 	}

--- a/src/main/java/net/imglib2/neighborsearch/RadiusNeighborSearch.java
+++ b/src/main/java/net/imglib2/neighborsearch/RadiusNeighborSearch.java
@@ -67,7 +67,7 @@ public interface RadiusNeighborSearch< T > extends EuclideanSpace
 	 *            whether the results should be ordered by ascending distances
 	 *            to reference.
 	 */
-	public void search( final RealLocalizable reference, final double radius, final boolean sortResults );
+	void search( final RealLocalizable reference, final double radius, final boolean sortResults );
 
 	/**
 	 * Get the number of points found within radius after a
@@ -76,7 +76,7 @@ public interface RadiusNeighborSearch< T > extends EuclideanSpace
 	 * @return the number of points found within radius after a
 	 *         {@link #search(RealLocalizable, double, boolean)}.
 	 */
-	public int numNeighbors();
+	int numNeighbors();
 
 	/**
 	 * Access the data of the <em>i</em><sup>th</sup> neighbor within radius. If
@@ -85,14 +85,14 @@ public interface RadiusNeighborSearch< T > extends EuclideanSpace
 	 * {@link Sampler} that guarantees write access if the underlying data set
 	 * is writable.
 	 */
-	public Sampler< T > getSampler( final int i );
+	Sampler< T > getSampler( final int i );
 
 	/**
 	 * Access the position of the <em>i</em><sup>th</sup> neighbor within
 	 * radius. If {@code sortResults} was set to true, neighbors are ordered by
 	 * square Euclidean distance to the reference.
 	 */
-	public RealLocalizable getPosition( final int i );
+	RealLocalizable getPosition( final int i );
 
 	/**
 	 * Access the square Euclidean distance between the reference location as
@@ -100,11 +100,11 @@ public interface RadiusNeighborSearch< T > extends EuclideanSpace
 	 * {@code sortResults} was set to true, neighbors are ordered by square
 	 * Euclidean distance to the reference.
 	 */
-	public double getSquareDistance( final int i );
+	double getSquareDistance( final int i );
 
 	/**
 	 * Access the Euclidean distance between the reference location as used for
 	 * the last search and the <em>i</em><sup>th</sup> neighbor.
 	 */
-	public double getDistance( final int i );
+	double getDistance( final int i );
 }

--- a/src/main/java/net/imglib2/neighborsearch/RadiusNeighborSearch.java
+++ b/src/main/java/net/imglib2/neighborsearch/RadiusNeighborSearch.java
@@ -67,7 +67,7 @@ public interface RadiusNeighborSearch< T > extends EuclideanSpace
 	 *            whether the results should be ordered by ascending distances
 	 *            to reference.
 	 */
-	void search( final RealLocalizable reference, final double radius, final boolean sortResults );
+	void search( RealLocalizable reference, double radius, boolean sortResults );
 
 	/**
 	 * Get the number of points found within radius after a
@@ -85,14 +85,14 @@ public interface RadiusNeighborSearch< T > extends EuclideanSpace
 	 * {@link Sampler} that guarantees write access if the underlying data set
 	 * is writable.
 	 */
-	Sampler< T > getSampler( final int i );
+	Sampler< T > getSampler( int i );
 
 	/**
 	 * Access the position of the <em>i</em><sup>th</sup> neighbor within
 	 * radius. If {@code sortResults} was set to true, neighbors are ordered by
 	 * square Euclidean distance to the reference.
 	 */
-	RealLocalizable getPosition( final int i );
+	RealLocalizable getPosition( int i );
 
 	/**
 	 * Access the square Euclidean distance between the reference location as
@@ -100,11 +100,11 @@ public interface RadiusNeighborSearch< T > extends EuclideanSpace
 	 * {@code sortResults} was set to true, neighbors are ordered by square
 	 * Euclidean distance to the reference.
 	 */
-	double getSquareDistance( final int i );
+	double getSquareDistance( int i );
 
 	/**
 	 * Access the Euclidean distance between the reference location as used for
 	 * the last search and the <em>i</em><sup>th</sup> neighbor.
 	 */
-	double getDistance( final int i );
+	double getDistance( int i );
 }

--- a/src/main/java/net/imglib2/outofbounds/Bounded.java
+++ b/src/main/java/net/imglib2/outofbounds/Bounded.java
@@ -50,5 +50,5 @@ import net.imglib2.Sampler;
 public interface Bounded
 {
 	/** True if located out of image bounds. */
-	public boolean isOutOfBounds();
+	boolean isOutOfBounds();
 }

--- a/src/main/java/net/imglib2/outofbounds/OutOfBounds.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBounds.java
@@ -44,5 +44,5 @@ import net.imglib2.RandomAccess;
 public interface OutOfBounds< T > extends RandomAccess< T >, Bounded
 {
 	@Override
-	public OutOfBounds< T > copy();
+	OutOfBounds< T > copy();
 }

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsFactory.java
@@ -43,5 +43,5 @@ package net.imglib2.outofbounds;
  */
 public interface OutOfBoundsFactory< T, F >
 {
-	public OutOfBounds< T > create( F f );
+	OutOfBounds< T > create( F f );
 }

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsMirrorFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsMirrorFactory.java
@@ -50,7 +50,7 @@ import net.imglib2.RandomAccessible;
  */
 public class OutOfBoundsMirrorFactory< T, F extends Interval & RandomAccessible< T > > implements OutOfBoundsFactory< T, F >
 {
-	static public enum Boundary
+	public enum Boundary
 	{
 		SINGLE, DOUBLE
 	}

--- a/src/main/java/net/imglib2/outofbounds/RealOutOfBounds.java
+++ b/src/main/java/net/imglib2/outofbounds/RealOutOfBounds.java
@@ -45,5 +45,5 @@ import net.imglib2.RealRandomAccess;
 public interface RealOutOfBounds< T > extends OutOfBounds< T >, RealRandomAccess< T >
 {
 	@Override
-	public RealOutOfBounds< T > copy();
+	RealOutOfBounds< T > copy();
 }

--- a/src/main/java/net/imglib2/outofbounds/RealOutOfBoundsFactory.java
+++ b/src/main/java/net/imglib2/outofbounds/RealOutOfBoundsFactory.java
@@ -43,5 +43,5 @@ package net.imglib2.outofbounds;
  */
 public interface RealOutOfBoundsFactory< T, F >
 {
-	public RealOutOfBounds< T > create( F f );
+	RealOutOfBounds< T > create( F f );
 }

--- a/src/main/java/net/imglib2/transform/InvertibleTransform.java
+++ b/src/main/java/net/imglib2/transform/InvertibleTransform.java
@@ -67,7 +67,7 @@ public interface InvertibleTransform extends Transform
 	 * @param target
 	 *            target coordinates.
 	 */
-	public void applyInverse( final long[] source, final long[] target );
+	void applyInverse( final long[] source, final long[] target );
 
 	/**
 	 * Apply the inverse transform to a target vector to obtain a source vector.
@@ -77,7 +77,7 @@ public interface InvertibleTransform extends Transform
 	 * @param target
 	 *            target coordinates.
 	 */
-	public void applyInverse( final int[] source, final int[] target );
+	void applyInverse( final int[] source, final int[] target );
 
 	/**
 	 * Apply the inverse transform to a target {@link Localizable} to obtain a
@@ -88,12 +88,12 @@ public interface InvertibleTransform extends Transform
 	 * @param target
 	 *            target coordinates.
 	 */
-	public void applyInverse( final Positionable source, final Localizable target );
+	void applyInverse( final Positionable source, final Localizable target );
 
 	/**
 	 * Get the inverse transform.
 	 * 
 	 * @return the inverse transform
 	 */
-	public InvertibleTransform inverse();
+	InvertibleTransform inverse();
 }

--- a/src/main/java/net/imglib2/transform/InvertibleTransform.java
+++ b/src/main/java/net/imglib2/transform/InvertibleTransform.java
@@ -67,7 +67,7 @@ public interface InvertibleTransform extends Transform
 	 * @param target
 	 *            target coordinates.
 	 */
-	void applyInverse( final long[] source, final long[] target );
+	void applyInverse( long[] source, long[] target );
 
 	/**
 	 * Apply the inverse transform to a target vector to obtain a source vector.
@@ -77,7 +77,7 @@ public interface InvertibleTransform extends Transform
 	 * @param target
 	 *            target coordinates.
 	 */
-	void applyInverse( final int[] source, final int[] target );
+	void applyInverse( int[] source, int[] target );
 
 	/**
 	 * Apply the inverse transform to a target {@link Localizable} to obtain a
@@ -88,7 +88,7 @@ public interface InvertibleTransform extends Transform
 	 * @param target
 	 *            target coordinates.
 	 */
-	void applyInverse( final Positionable source, final Localizable target );
+	void applyInverse( Positionable source, Localizable target );
 
 	/**
 	 * Get the inverse transform.

--- a/src/main/java/net/imglib2/transform/Transform.java
+++ b/src/main/java/net/imglib2/transform/Transform.java
@@ -73,7 +73,7 @@ public interface Transform
 	 * @param target
 	 *            set this to the target coordinates.
 	 */
-	void apply( final long[] source, final long[] target );
+	void apply( long[] source, long[] target );
 
 	/**
 	 * Apply the {@link Transform} to a source vector to obtain a target vector.
@@ -83,7 +83,7 @@ public interface Transform
 	 * @param target
 	 *            set this to the target coordinates.
 	 */
-	void apply( final int[] source, final int[] target );
+	void apply( int[] source, int[] target );
 
 	/**
 	 * Apply the {@link Transform} to a source {@link Localizable} to obtain a
@@ -94,5 +94,5 @@ public interface Transform
 	 * @param target
 	 *            set this to the target coordinates.
 	 */
-	void apply( final Localizable source, final Positionable target );
+	void apply( Localizable source, Positionable target );
 }

--- a/src/main/java/net/imglib2/transform/Transform.java
+++ b/src/main/java/net/imglib2/transform/Transform.java
@@ -56,14 +56,14 @@ public interface Transform
 	 * 
 	 * @return the dimension of the source vector.
 	 */
-	public int numSourceDimensions();
+	int numSourceDimensions();
 
 	/**
 	 * Returns <em>m</em>, the dimension of the target vector.
 	 * 
 	 * @return the dimension of the target vector.
 	 */
-	public int numTargetDimensions();
+	int numTargetDimensions();
 
 	/**
 	 * Apply the {@link Transform} to a source vector to obtain a target vector.
@@ -73,7 +73,7 @@ public interface Transform
 	 * @param target
 	 *            set this to the target coordinates.
 	 */
-	public void apply( final long[] source, final long[] target );
+	void apply( final long[] source, final long[] target );
 
 	/**
 	 * Apply the {@link Transform} to a source vector to obtain a target vector.
@@ -83,7 +83,7 @@ public interface Transform
 	 * @param target
 	 *            set this to the target coordinates.
 	 */
-	public void apply( final int[] source, final int[] target );
+	void apply( final int[] source, final int[] target );
 
 	/**
 	 * Apply the {@link Transform} to a source {@link Localizable} to obtain a
@@ -94,5 +94,5 @@ public interface Transform
 	 * @param target
 	 *            set this to the target coordinates.
 	 */
-	public void apply( final Localizable source, final Positionable target );
+	void apply( final Localizable source, final Positionable target );
 }

--- a/src/main/java/net/imglib2/transform/Transformable.java
+++ b/src/main/java/net/imglib2/transform/Transformable.java
@@ -56,6 +56,6 @@ public interface Transformable< O, T extends Transform >
 	 *            the destination space.
 	 * @return a copy built to operate similarly in the transformed space.
 	 */
-	O transform( final T t );
+	O transform( T t );
 
 }

--- a/src/main/java/net/imglib2/transform/Transformable.java
+++ b/src/main/java/net/imglib2/transform/Transformable.java
@@ -56,6 +56,6 @@ public interface Transformable< O, T extends Transform >
 	 *            the destination space.
 	 * @return a copy built to operate similarly in the transformed space.
 	 */
-	public O transform( final T t );
+	O transform( final T t );
 
 }

--- a/src/main/java/net/imglib2/transform/integer/BoundingBoxTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/BoundingBoxTransform.java
@@ -50,5 +50,5 @@ public interface BoundingBoxTransform
 	 * @param boundingBox
 	 * @return the transformed bounding box
 	 */
-	public BoundingBox transform( BoundingBox boundingBox );
+	BoundingBox transform( BoundingBox boundingBox );
 }

--- a/src/main/java/net/imglib2/transform/integer/Mixed.java
+++ b/src/main/java/net/imglib2/transform/integer/Mixed.java
@@ -65,7 +65,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *            array of size at least the target dimension to store the
 	 *            result.
 	 */
-	public void getTranslation( final long[] translation );
+	void getTranslation( final long[] translation );
 
 	/**
 	 * Get the d-th component of translation (see
@@ -73,7 +73,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *
 	 * @param d
 	 */
-	public long getTranslation( final int d );
+	long getTranslation( final int d );
 
 	/**
 	 * Get a boolean array indicating which target dimensions are _not_ taken
@@ -89,7 +89,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *            array of size at least the target dimension to store the
 	 *            result.
 	 */
-	public void getComponentZero( final boolean[] zero );
+	void getComponentZero( final boolean[] zero );
 
 	/**
 	 * Get the d-th component of zeroing vector (see {@link
@@ -97,7 +97,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *
 	 * @param d
 	 */
-	public boolean getComponentZero( final int d );
+	boolean getComponentZero( final int d );
 
 	/**
 	 * Get an array indicating for each target dimensions from which source
@@ -114,7 +114,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *            array of size at least the target dimension to store the
 	 *            result.
 	 */
-	public void getComponentMapping( final int[] component );
+	void getComponentMapping( final int[] component );
 
 	/**
 	 * Get the source dimension which is mapped to the d-th target dimension
@@ -122,7 +122,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *
 	 * @param d
 	 */
-	public int getComponentMapping( final int d );
+	int getComponentMapping( final int d );
 
 	/**
 	 * Get an array indicating for each target component, whether the source
@@ -137,7 +137,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *            array of size at least the target dimension to store the
 	 *            result.
 	 */
-	public void getComponentInversion( final boolean[] invert );
+	void getComponentInversion( final boolean[] invert );
 
 	/**
 	 * Get the d-th component of inversion vector (see {@link
@@ -145,11 +145,11 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *
 	 * @param d
 	 */
-	public boolean getComponentInversion( final int d );
+	boolean getComponentInversion( final int d );
 
 	/**
 	 * Get the matrix that transforms homogeneous source points to homogeneous
 	 * target points. For testing purposes.
 	 */
-	public double[][] getMatrix();
+	double[][] getMatrix();
 }

--- a/src/main/java/net/imglib2/transform/integer/Mixed.java
+++ b/src/main/java/net/imglib2/transform/integer/Mixed.java
@@ -65,7 +65,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *            array of size at least the target dimension to store the
 	 *            result.
 	 */
-	void getTranslation( final long[] translation );
+	void getTranslation( long[] translation );
 
 	/**
 	 * Get the d-th component of translation (see
@@ -73,7 +73,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *
 	 * @param d
 	 */
-	long getTranslation( final int d );
+	long getTranslation( int d );
 
 	/**
 	 * Get a boolean array indicating which target dimensions are _not_ taken
@@ -89,7 +89,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *            array of size at least the target dimension to store the
 	 *            result.
 	 */
-	void getComponentZero( final boolean[] zero );
+	void getComponentZero( boolean[] zero );
 
 	/**
 	 * Get the d-th component of zeroing vector (see {@link
@@ -97,7 +97,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *
 	 * @param d
 	 */
-	boolean getComponentZero( final int d );
+	boolean getComponentZero( int d );
 
 	/**
 	 * Get an array indicating for each target dimensions from which source
@@ -114,7 +114,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *            array of size at least the target dimension to store the
 	 *            result.
 	 */
-	void getComponentMapping( final int[] component );
+	void getComponentMapping( int[] component );
 
 	/**
 	 * Get the source dimension which is mapped to the d-th target dimension
@@ -122,7 +122,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *
 	 * @param d
 	 */
-	int getComponentMapping( final int d );
+	int getComponentMapping( int d );
 
 	/**
 	 * Get an array indicating for each target component, whether the source
@@ -137,7 +137,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *            array of size at least the target dimension to store the
 	 *            result.
 	 */
-	void getComponentInversion( final boolean[] invert );
+	void getComponentInversion( boolean[] invert );
 
 	/**
 	 * Get the d-th component of inversion vector (see {@link
@@ -145,7 +145,7 @@ public interface Mixed extends Transform, BoundingBoxTransform
 	 *
 	 * @param d
 	 */
-	boolean getComponentInversion( final int d );
+	boolean getComponentInversion( int d );
 
 	/**
 	 * Get the matrix that transforms homogeneous source points to homogeneous

--- a/src/main/java/net/imglib2/type/AbstractNativeType.java
+++ b/src/main/java/net/imglib2/type/AbstractNativeType.java
@@ -54,7 +54,4 @@ public abstract class AbstractNativeType< T extends AbstractNativeType< T >> imp
 	{
 		return i;
 	}
-
-	@Override
-	public abstract String toString();
 }

--- a/src/main/java/net/imglib2/type/BasePairType.java
+++ b/src/main/java/net/imglib2/type/BasePairType.java
@@ -44,7 +44,7 @@ import net.imglib2.type.label.BasePairBitType.Base;
  */
 public interface BasePairType< T extends BasePairType< T >> extends Type< T >, Comparable< T >
 {
-	void set( final Base base );
+	void set( Base base );
 
 	Base get();
 

--- a/src/main/java/net/imglib2/type/BasePairType.java
+++ b/src/main/java/net/imglib2/type/BasePairType.java
@@ -44,11 +44,11 @@ import net.imglib2.type.label.BasePairBitType.Base;
  */
 public interface BasePairType< T extends BasePairType< T >> extends Type< T >, Comparable< T >
 {
-	public void set( final Base base );
+	void set( final Base base );
 
-	public Base get();
+	Base get();
 
-	public void complement();
+	void complement();
 
 	byte baseToValue();
 }

--- a/src/main/java/net/imglib2/type/BooleanType.java
+++ b/src/main/java/net/imglib2/type/BooleanType.java
@@ -44,16 +44,16 @@ import net.imglib2.type.numeric.RealType;
  */
 public interface BooleanType< T extends BooleanType< T > > extends Type< T >, RealType< T >
 {
-	public boolean get();
+	boolean get();
 
-	public void set( boolean value );
+	void set( boolean value );
 
-	public void and( T c );
+	void and( T c );
 
-	public void or( T c );
+	void or( T c );
 
-	public void xor( T c );
+	void xor( T c );
 
-	public void not();
+	void not();
 
 }

--- a/src/main/java/net/imglib2/type/PrimitiveType.java
+++ b/src/main/java/net/imglib2/type/PrimitiveType.java
@@ -64,7 +64,7 @@ public enum PrimitiveType
 
 	private final int byteCount;
 
-	private PrimitiveType( final int byteCount )
+	PrimitiveType( final int byteCount )
 	{
 		this.byteCount = byteCount;
 	}

--- a/src/main/java/net/imglib2/type/Type.java
+++ b/src/main/java/net/imglib2/type/Type.java
@@ -56,7 +56,7 @@ public interface Type< T extends Type< T > > extends ValueEquals< T >
 	 * 
 	 * @return a new {@link Type} variable
 	 */
-	public T createVariable();
+	T createVariable();
 
 	/**
 	 * Creates a new {@link Type} variable that has the value of this
@@ -64,7 +64,7 @@ public interface Type< T extends Type< T > > extends ValueEquals< T >
 	 * 
 	 * @return a new {@link Type} variable
 	 */
-	public T copy();
+	T copy();
 
 	/**
 	 * Sets the value of another {@link Type}.
@@ -72,5 +72,5 @@ public interface Type< T extends Type< T > > extends ValueEquals< T >
 	 * @param c
 	 *            the new value
 	 */
-	public void set( T c );
+	void set( T c );
 }

--- a/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
@@ -50,13 +50,13 @@ abstract public class AbstractARGBDoubleType< T extends AbstractARGBDoubleType< 
 
 	abstract public double getB();
 
-	abstract public void setA( final double a );
+	abstract public void setA( double a );
 
-	abstract public void setR( final double r );
+	abstract public void setR( double r );
 
-	abstract public void setG( final double g );
+	abstract public void setG( double g );
 
-	abstract public void setB( final double b );
+	abstract public void setB( double b );
 
 	public void set( final double a, final double r, final double g, final double b )
 	{

--- a/src/main/java/net/imglib2/type/numeric/ComplexType.java
+++ b/src/main/java/net/imglib2/type/numeric/ComplexType.java
@@ -40,33 +40,33 @@ package net.imglib2.type.numeric;
  */
 public interface ComplexType< T extends ComplexType< T >> extends NumericType< T >
 {
-	public double getRealDouble();
+	double getRealDouble();
 
-	public float getRealFloat();
+	float getRealFloat();
 
-	public double getImaginaryDouble();
+	double getImaginaryDouble();
 
-	public float getImaginaryFloat();
+	float getImaginaryFloat();
 
-	public void setReal( float f );
+	void setReal( float f );
 
-	public void setReal( double f );
+	void setReal( double f );
 
-	public void setImaginary( float f );
+	void setImaginary( float f );
 
-	public void setImaginary( double f );
+	void setImaginary( double f );
 
-	public void setComplexNumber( float r, float i );
+	void setComplexNumber( float r, float i );
 
-	public void setComplexNumber( double r, double i );
+	void setComplexNumber( double r, double i );
 
-	public float getPowerFloat();
+	float getPowerFloat();
 
-	public double getPowerDouble();
+	double getPowerDouble();
 
-	public float getPhaseFloat();
+	float getPhaseFloat();
 
-	public double getPhaseDouble();
+	double getPhaseDouble();
 
-	public void complexConjugate();
+	void complexConjugate();
 }

--- a/src/main/java/net/imglib2/type/numeric/IntegerType.java
+++ b/src/main/java/net/imglib2/type/numeric/IntegerType.java
@@ -42,15 +42,15 @@ import java.math.BigInteger;
  */
 public interface IntegerType< T extends IntegerType< T >> extends RealType< T >
 {
-	public int getInteger();
+	int getInteger();
 
-	public long getIntegerLong();
+	long getIntegerLong();
 
-	public BigInteger getBigInteger();
+	BigInteger getBigInteger();
 
-	public void setInteger( int f );
+	void setInteger( int f );
 
-	public void setInteger( long f );
+	void setInteger( long f );
 
-	public void setBigInteger( BigInteger b );
+	void setBigInteger( BigInteger b );
 }

--- a/src/main/java/net/imglib2/type/numeric/RealType.java
+++ b/src/main/java/net/imglib2/type/numeric/RealType.java
@@ -42,15 +42,15 @@ package net.imglib2.type.numeric;
  */
 public interface RealType< T extends RealType< T >> extends ComplexType< T >, Comparable< T >
 {
-	public void inc();
+	void inc();
 
-	public void dec();
+	void dec();
 
-	public double getMaxValue();
+	double getMaxValue();
 
-	public double getMinValue();
+	double getMinValue();
 
-	public double getMinIncrement();
+	double getMinIncrement();
 
-	public int getBitsPerPixel();
+	int getBitsPerPixel();
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
@@ -67,7 +67,8 @@ public abstract class AbstractIntegerBitType< T extends AbstractIntegerBitType< 
 	}
 
 	public abstract long get();
-	public abstract void set( final long value );
+
+	public abstract void set( long value );
 
 	@Override
 	public int getBitsPerPixel() { return nBits; }

--- a/src/main/java/net/imglib2/type/operators/Add.java
+++ b/src/main/java/net/imglib2/type/operators/Add.java
@@ -40,5 +40,5 @@ package net.imglib2.type.operators;
  */
 public interface Add< T >
 {
-	public void add( T c );
+	void add( T c );
 }

--- a/src/main/java/net/imglib2/type/operators/Div.java
+++ b/src/main/java/net/imglib2/type/operators/Div.java
@@ -40,5 +40,5 @@ package net.imglib2.type.operators;
  */
 public interface Div< T >
 {
-	public void div( T c );
+	void div( T c );
 }

--- a/src/main/java/net/imglib2/type/operators/Mul.java
+++ b/src/main/java/net/imglib2/type/operators/Mul.java
@@ -40,5 +40,5 @@ package net.imglib2.type.operators;
  */
 public interface Mul< T >
 {
-	public void mul( T c );
+	void mul( T c );
 }

--- a/src/main/java/net/imglib2/type/operators/MulFloatingPoint.java
+++ b/src/main/java/net/imglib2/type/operators/MulFloatingPoint.java
@@ -38,6 +38,6 @@ package net.imglib2.type.operators;
  */
 public interface MulFloatingPoint
 {
-	public void mul( float c );
-	public void mul( double c );
+	void mul( float c );
+	void mul( double c );
 }

--- a/src/main/java/net/imglib2/type/operators/Pow.java
+++ b/src/main/java/net/imglib2/type/operators/Pow.java
@@ -40,5 +40,5 @@ package net.imglib2.type.operators;
  */
 public interface Pow< T >
 {
-	public void pow( T c );
+	void pow( T c );
 }

--- a/src/main/java/net/imglib2/type/operators/PowFloatingPoint.java
+++ b/src/main/java/net/imglib2/type/operators/PowFloatingPoint.java
@@ -38,5 +38,5 @@ package net.imglib2.type.operators;
  */
 public interface PowFloatingPoint
 {
-	public void pow( double d );
+	void pow( double d );
 }

--- a/src/main/java/net/imglib2/type/operators/SetOne.java
+++ b/src/main/java/net/imglib2/type/operators/SetOne.java
@@ -38,5 +38,5 @@ package net.imglib2.type.operators;
  */
 public interface SetOne
 {
-	public void setOne();
+	void setOne();
 }

--- a/src/main/java/net/imglib2/type/operators/SetZero.java
+++ b/src/main/java/net/imglib2/type/operators/SetZero.java
@@ -38,5 +38,5 @@ package net.imglib2.type.operators;
  */
 public interface SetZero
 {
-	public void setZero();
+	void setZero();
 }

--- a/src/main/java/net/imglib2/type/operators/Sub.java
+++ b/src/main/java/net/imglib2/type/operators/Sub.java
@@ -40,5 +40,5 @@ package net.imglib2.type.operators;
  */
 public interface Sub< T >
 {
-	public void sub( T c );
+	void sub( T c );
 }

--- a/src/main/java/net/imglib2/type/operators/ValueEquals.java
+++ b/src/main/java/net/imglib2/type/operators/ValueEquals.java
@@ -42,5 +42,5 @@ package net.imglib2.type.operators;
  */
 public interface ValueEquals< T >
 {
-	public boolean valueEquals( T t );
+	boolean valueEquals( T t );
 }

--- a/src/main/java/net/imglib2/util/Grid.java
+++ b/src/main/java/net/imglib2/util/Grid.java
@@ -546,21 +546,9 @@ public class Grid
 		}
 
 		@Override
-		public Interval firstElement()
-		{
-			return cursor().next();
-		}
-
-		@Override
 		public FlatIterationOrder iterationOrder()
 		{
 			return new FlatIterationOrder( this );
-		}
-
-		@Override
-		public Iterator< Interval > iterator()
-		{
-			return cursor();
 		}
 	}
 

--- a/src/main/java/net/imglib2/util/Localizables.java
+++ b/src/main/java/net/imglib2/util/Localizables.java
@@ -200,7 +200,7 @@ public class Localizables
 	}
 
 	/**
-	 * A RandomAccess that returns it's current position as value.
+	 * A RandomAccess that returns its current position as value.
 	 */
 	private static class LocationRandomAccess extends Point implements RandomAccess< Localizable >
 	{
@@ -248,7 +248,7 @@ public class Localizables
 	}
 
 	/**
-	 * A RandomAccess that returns it's current position as value.
+	 * A RandomAccess that returns its current position as value.
 	 */
 	private static class RealLocationRealRandomAccess extends RealPoint implements RealRandomAccess< RealLocalizable >
 	{

--- a/src/main/java/net/imglib2/util/Pair.java
+++ b/src/main/java/net/imglib2/util/Pair.java
@@ -36,7 +36,7 @@ package net.imglib2.util;
 
 public interface Pair< A, B >
 {
-	public A getA();
+	A getA();
 
-	public B getB();
+	B getB();
 }

--- a/src/main/java/net/imglib2/view/IterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/view/IterableRandomAccessibleInterval.java
@@ -78,23 +78,9 @@ public class IterableRandomAccessibleInterval< T > extends AbstractWrappedInterv
 	}
 
 	@Override
-	public T firstElement()
-	{
-		// we cannot simply create an randomaccessible on interval
-		// this does not ensure it will be placed at the first element
-		return cursor().next();
-	}
-
-	@Override
 	public FlatIterationOrder iterationOrder()
 	{
 		return new FlatIterationOrder( sourceInterval );
-	}
-
-	@Override
-	public Iterator< T > iterator()
-	{
-		return cursor();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/view/RandomAccessibleIntervalCursor.java
+++ b/src/main/java/net/imglib2/view/RandomAccessibleIntervalCursor.java
@@ -152,10 +152,6 @@ public final class RandomAccessibleIntervalCursor< T > extends AbstractInterval 
 	}
 
 	@Override
-	public void remove()
-	{}
-
-	@Override
 	public RandomAccessibleIntervalCursor< T > copy()
 	{
 		return new RandomAccessibleIntervalCursor< T >( this );

--- a/src/main/java/net/imglib2/view/RandomAccessibleIntervalCursor.java
+++ b/src/main/java/net/imglib2/view/RandomAccessibleIntervalCursor.java
@@ -162,12 +162,6 @@ public final class RandomAccessibleIntervalCursor< T > extends AbstractInterval 
 	}
 
 	@Override
-	public RandomAccessibleIntervalCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
-	@Override
 	public void localize( final float[] position )
 	{
 		randomAccess.localize( position );

--- a/src/main/java/net/imglib2/view/RandomAccessibleIntervalCursor.java
+++ b/src/main/java/net/imglib2/view/RandomAccessibleIntervalCursor.java
@@ -145,13 +145,6 @@ public final class RandomAccessibleIntervalCursor< T > extends AbstractInterval 
 	}
 
 	@Override
-	public T next()
-	{
-		fwd();
-		return get();
-	}
-
-	@Override
 	public RandomAccessibleIntervalCursor< T > copy()
 	{
 		return new RandomAccessibleIntervalCursor< T >( this );

--- a/src/main/java/net/imglib2/view/StackView.java
+++ b/src/main/java/net/imglib2/view/StackView.java
@@ -67,7 +67,7 @@ public class StackView< T > extends AbstractInterval implements RandomAccessible
 	 * {@link RandomAccess}es on all constituent hyper-slices of the
 	 * {@link StackView}.
 	 */
-	public static enum StackAccessMode
+	public enum StackAccessMode
 	{
 		/**
 		 * The default behavior is the following.

--- a/src/main/java/net/imglib2/view/TransformedRandomAccessible.java
+++ b/src/main/java/net/imglib2/view/TransformedRandomAccessible.java
@@ -54,7 +54,7 @@ public interface TransformedRandomAccessible< T > extends RandomAccessible< T >,
 	 * 
 	 * @return the source {@link RandomAccessible}.
 	 */
-	public RandomAccessible< T > getSource();
+	RandomAccessible< T > getSource();
 
 	/**
 	 * Get the transformation from view coordinates into {@link #getSource()
@@ -68,5 +68,5 @@ public interface TransformedRandomAccessible< T > extends RandomAccessible< T >,
 	 * @return transformation from view coordinates into {@link #getSource()
 	 *         source} coordinates.
 	 */
-	public Transform getTransformToSource();
+	Transform getTransformToSource();
 }

--- a/src/main/java/net/imglib2/view/composite/AbstractNumericComposite.java
+++ b/src/main/java/net/imglib2/view/composite/AbstractNumericComposite.java
@@ -69,12 +69,6 @@ abstract public class AbstractNumericComposite< T extends NumericType< T >, C ex
 			final T t = sourceAccess.get();
 			return t;
 		}
-
-		@Override
-		public void remove()
-		{
-			throw new UnsupportedOperationException();
-		}
 	};
 
 	public AbstractNumericComposite( final RandomAccess< T > sourceAccess, final int length )

--- a/src/main/java/net/imglib2/view/composite/Composite.java
+++ b/src/main/java/net/imglib2/view/composite/Composite.java
@@ -46,5 +46,5 @@ public interface Composite< T >
 	 * @param i
 	 * @return
 	 */
-	public T get( final long i );
+	T get( final long i );
 }

--- a/src/main/java/net/imglib2/view/composite/Composite.java
+++ b/src/main/java/net/imglib2/view/composite/Composite.java
@@ -46,5 +46,5 @@ public interface Composite< T >
 	 * @param i
 	 * @return
 	 */
-	T get( final long i );
+	T get( long i );
 }

--- a/src/main/java/net/imglib2/view/composite/CompositeFactory.java
+++ b/src/main/java/net/imglib2/view/composite/CompositeFactory.java
@@ -43,5 +43,5 @@ import net.imglib2.RandomAccess;
  */
 public interface CompositeFactory< T, C extends Composite< T > >
 {
-	C create( final RandomAccess< T > sourceAccess );
+	C create( RandomAccess< T > sourceAccess );
 }

--- a/src/main/java/net/imglib2/view/composite/CompositeFactory.java
+++ b/src/main/java/net/imglib2/view/composite/CompositeFactory.java
@@ -43,5 +43,5 @@ import net.imglib2.RandomAccess;
  */
 public interface CompositeFactory< T, C extends Composite< T > >
 {
-	public C create( final RandomAccess< T > sourceAccess );
+	C create( final RandomAccess< T > sourceAccess );
 }

--- a/src/main/java/net/imglib2/view/iteration/IterableTransformBuilder.java
+++ b/src/main/java/net/imglib2/view/iteration/IterableTransformBuilder.java
@@ -129,21 +129,9 @@ public class IterableTransformBuilder< T > extends TransformBuilder< T >
 		}
 
 		@Override
-		public T firstElement()
-		{
-			return cursor().next();
-		}
-
-		@Override
 		public Object iterationOrder()
 		{
 			return iterableSource.subIntervalIterationOrder( interval );
-		}
-
-		@Override
-		public Iterator< T > iterator()
-		{
-			return cursor();
 		}
 
 		@Override
@@ -191,21 +179,9 @@ public class IterableTransformBuilder< T > extends TransformBuilder< T >
 		}
 
 		@Override
-		public T firstElement()
-		{
-			return cursor().next();
-		}
-
-		@Override
 		public Object iterationOrder()
 		{
 			return hasFlatIterationOrder ? new FlatIterationOrder( interval ) : this;
-		}
-
-		@Override
-		public Iterator< T > iterator()
-		{
-			return cursor();
 		}
 
 		@Override

--- a/src/main/java/net/imglib2/view/iteration/SlicingCursor.java
+++ b/src/main/java/net/imglib2/view/iteration/SlicingCursor.java
@@ -210,15 +210,6 @@ public class SlicingCursor< T > extends AbstractEuclideanSpace implements Cursor
 	 * {@inheritDoc}
 	 */
 	@Override
-	public SlicingCursor< T > copyCursor()
-	{
-		return copy();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
 	public void jumpFwd( final long steps )
 	{
 		s.jumpFwd( steps );

--- a/src/main/java/net/imglib2/view/iteration/SlicingCursor.java
+++ b/src/main/java/net/imglib2/view/iteration/SlicingCursor.java
@@ -250,13 +250,4 @@ public class SlicingCursor< T > extends AbstractEuclideanSpace implements Cursor
 	{
 		return s.next();
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void remove()
-	{
-		return;
-	}
 }

--- a/src/main/java/net/imglib2/view/iteration/SubIntervalIterable.java
+++ b/src/main/java/net/imglib2/view/iteration/SubIntervalIterable.java
@@ -55,7 +55,7 @@ public interface SubIntervalIterable< T >
 	 * @return true if a {@link Cursor} can be optimized given the
 	 *         {@link Interval}
 	 */
-	public boolean supportsOptimizedCursor( Interval interval );
+	boolean supportsOptimizedCursor( Interval interval );
 
 	/**
 	 * Returns the iteration order given the interval.
@@ -65,7 +65,7 @@ public interface SubIntervalIterable< T >
 	 * 
 	 * @return the iteration order object @see {@link IterableRealInterval}
 	 */
-	public Object subIntervalIterationOrder( Interval interval );
+	Object subIntervalIterationOrder( Interval interval );
 
 	/**
 	 * Create a {@link Cursor} to iterate over the given {@link Interval}.
@@ -75,7 +75,7 @@ public interface SubIntervalIterable< T >
 	 * 
 	 * @return {@link Cursor}
 	 */
-	public Cursor< T > cursor( Interval interval );
+	Cursor< T > cursor( Interval interval );
 
 	/**
 	 * Create a {@link Cursor} to iterate over the given {@link Interval}.
@@ -85,5 +85,5 @@ public interface SubIntervalIterable< T >
 	 * 
 	 * @return {@link Cursor}
 	 */
-	public Cursor< T > localizingCursor( Interval interval );
+	Cursor< T > localizingCursor( Interval interval );
 }

--- a/src/test/java/net/imglib2/RealPointSampleListTest.java
+++ b/src/test/java/net/imglib2/RealPointSampleListTest.java
@@ -129,7 +129,7 @@ public class RealPointSampleListTest
 		while ( cursor.hasNext() )
 		{
 			cursor.fwd();
-			copies.add( cursor.copyCursor() );
+			copies.add( cursor.copy() );
 		}
 
 		cursor.reset();

--- a/src/test/java/net/imglib2/histogram/HistogramNdTest.java
+++ b/src/test/java/net/imglib2/histogram/HistogramNdTest.java
@@ -369,13 +369,6 @@ public class HistogramNdTest
 					tuple.get( 2 ).set( ( argbValue.get() >> 0 ) & 0xff );
 					return tuple;
 				}
-
-				@Override
-				public void remove()
-				{
-					// do nothing
-				}
-
 			};
 		}
 

--- a/src/test/java/net/imglib2/img/cell/ArrayRandomAccessBenchmark.java
+++ b/src/test/java/net/imglib2/img/cell/ArrayRandomAccessBenchmark.java
@@ -143,7 +143,7 @@ public class ArrayRandomAccessBenchmark
 
 	public interface Benchmark
 	{
-		public void run();
+		void run();
 	}
 
 	public static void benchmark( final Benchmark b )

--- a/src/test/java/net/imglib2/img/planar/PlanarRandomAccessBenchmark.java
+++ b/src/test/java/net/imglib2/img/planar/PlanarRandomAccessBenchmark.java
@@ -133,7 +133,7 @@ public class PlanarRandomAccessBenchmark
 
 	public interface Benchmark
 	{
-		public void run();
+		void run();
 	}
 
 	public static void benchmark( final Benchmark b )

--- a/src/test/java/tests/JUnitTestBase.java
+++ b/src/test/java/tests/JUnitTestBase.java
@@ -70,7 +70,7 @@ public class JUnitTestBase
 	 */
 	protected interface Function
 	{
-		public float calculate( long[] pos );
+		float calculate( long[] pos );
 	}
 
 	/**


### PR DESCRIPTION
* Default implement `Iterator.jumpFwd()`

* Default implement `RealCursor.next()`
A potential argument against this could be performance: Every call to the default `next()` goes to polymorphic `fwd()` and `get()` calls. However, I did a benchmark, and it doesn't matter. Probably because the method is so small it is inlined everywhere. Additionally, we had already implemented `next()` in `AbstractCursor`, `AbstractCursorInt`, etc, so we would have this problem already anyway.

* Default implement `IterableRealInterval.iterator()` and `IterableRealInterval.firstElement()`

* Remove implementations of `java.util.Iterator.remove()`. There is a default implementation in the `java.util.Iterator` interface now.

* Deprecate and default implement `RealCursor.copyCursor()`.
@axtimwalde already took care of `copyRandomAccess()` and `copyRealRandomAccess()` in 4ae96db3 and 054a716d, respectively.

* Remove abstract overrides of abstract methods to the exact same signature.

* Remove meaningless `final` modifiers from arguments of abstract methods.
`final` annotations of method arguments are relevant to the method implementation, but not to the caller. (It is even allowed to override methods with non-final arguments, if arguments are declared `final` in the super class.)

* Remove redundant modifiers:
In particular, remove `public` modifier from interface methods. Remove `public`, `static`, and `final` from interface fields. Remove `static` from inner enums. Remove `private` from enum constructors. These are all implicit in the respective context.
