### PR TITLE
Draft: modifying the imglib2 coding style demo

### DIFF
--- a/mastodon-coding-style.xml
+++ b/mastodon-coding-style.xml
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="22">
+    <profile kind="CodeFormatterProfile" name="imglib2" version="22">
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_before_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter\:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_logical_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_record_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_enum_constant" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_permitted_types" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_annotations" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assertion_message_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_bitwise_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_not_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_record_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_bitwise_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_tag_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_constructor" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_record_components" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_record_declaration" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter\:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_switch_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_arrow" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="200"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_constructor" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_selector_in_method_invocation_on_expression_first_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_switch_case_with_arrow_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_colon" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_after_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_shift_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_record_components" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_record_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_switch_case_with_arrow" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_constructor_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assertion_message" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_record_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_relational_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_statement_group_in_switch" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="preserve_positions"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_permitted_types" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="140"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+    </profile>
+</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -253,4 +253,18 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+    <build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>net.revelc.code.formatter</groupId>
+					<artifactId>formatter-maven-plugin</artifactId>
+					<version>${formatter-maven-plugin.version}</version>
+					<configuration>
+						<configFile>mastodon-coding-style.xml</configFile>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 </project>

--- a/src/main/java/net/imglib2/AbstractWrappedPositionableLocalizable.java
+++ b/src/main/java/net/imglib2/AbstractWrappedPositionableLocalizable.java
@@ -44,7 +44,8 @@ package net.imglib2;
  * @author Christian Dietz
  * @author Tobias Pietzsch
  */
-public abstract class AbstractWrappedPositionableLocalizable< P extends Positionable & Localizable > extends AbstractWrappedLocalizable< P > implements Positionable
+public abstract class AbstractWrappedPositionableLocalizable< P extends Positionable & Localizable > extends AbstractWrappedLocalizable< P >
+		implements Positionable
 {
 	protected AbstractWrappedPositionableLocalizable( final P source )
 	{

--- a/src/main/java/net/imglib2/AbstractWrappedRealInterval.java
+++ b/src/main/java/net/imglib2/AbstractWrappedRealInterval.java
@@ -90,7 +90,7 @@ public abstract class AbstractWrappedRealInterval< I extends RealInterval > impl
 	{
 		return sourceInterval.numDimensions();
 	}
-	
+
 	public I getSource()
 	{
 		return sourceInterval;

--- a/src/main/java/net/imglib2/FinalDimensions.java
+++ b/src/main/java/net/imglib2/FinalDimensions.java
@@ -129,7 +129,7 @@ public final class FinalDimensions implements Dimensions
 	public boolean equals( final Object obj )
 	{
 		return obj instanceof FinalDimensions &&
-				Intervals.equalDimensions( this, (FinalDimensions) obj );
+				Intervals.equalDimensions( this, ( FinalDimensions ) obj );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/KDTree.java
+++ b/src/main/java/net/imglib2/KDTree.java
@@ -93,7 +93,8 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 		 * @param right
 		 *            right child node
 		 */
-		public ValueNode( final T value, final RealLocalizable position, final int dimension, final ValueNode< T > left, final ValueNode< T > right )
+		public ValueNode( final T value, final RealLocalizable position, final int dimension, final ValueNode< T > left,
+				final ValueNode< T > right )
 		{
 			super( position, dimension, left, right );
 			this.value = value;
@@ -143,7 +144,8 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 		 * @param right
 		 *            right child node
 		 */
-		public SamplerNode( final Sampler< T > sampler, final RealLocalizable position, final int dimension, final SamplerNode< T > left, final SamplerNode< T > right )
+		public SamplerNode( final Sampler< T > sampler, final RealLocalizable position, final int dimension, final SamplerNode< T > left,
+				final SamplerNode< T > right )
 		{
 			super( position, dimension, left, right );
 			this.sampler = sampler;
@@ -318,7 +320,8 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 	 * @return a new node containing the subtree of the given sublist of
 	 *         positions.
 	 */
-	protected < L extends RealLocalizable > ValueNode< T > makeNode( final List< L > positions, final int i, final int j, final int d, final List< T > values, final int[] permutation )
+	protected < L extends RealLocalizable > ValueNode< T > makeNode( final List< L > positions, final int i, final int j, final int d,
+			final List< T > values, final int[] permutation )
 	{
 		if ( j > i )
 		{
@@ -326,7 +329,9 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 			KthElement.kthElement( i, j, k, positions, permutation, new DimComparator< L >( d ) );
 
 			final int dChild = ( d + 1 == n ) ? 0 : d + 1;
-			return new ValueNode< T >( values.get( permutation[ k ] ), positions.get( k ), d, makeNode( positions, i, k - 1, dChild, values, permutation ), makeNode( positions, k + 1, j, dChild, values, permutation ) );
+			return new ValueNode< T >( values.get( permutation[ k ] ), positions.get( k ), d,
+					makeNode( positions, i, k - 1, dChild, values, permutation ),
+					makeNode( positions, k + 1, j, dChild, values, permutation ) );
 		}
 		else if ( j == i )
 		{
@@ -359,7 +364,8 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 	 * @return a new node containing the subtree of the given sublist of
 	 *         positions.
 	 */
-	protected < L extends RealLocalizable > ValueNode< T > makeNode( final ListIterator< L > first, final ListIterator< L > last, final int d, final List< T > values, final int[] permutation )
+	protected < L extends RealLocalizable > ValueNode< T > makeNode( final ListIterator< L > first, final ListIterator< L > last,
+			final int d, final List< T > values, final int[] permutation )
 	{
 		final int i = first.nextIndex();
 		final int j = last.previousIndex();
@@ -419,7 +425,8 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 			KthElement.kthElement( i, j, k, elements, new DimComparator< L >( d ) );
 
 			final int dChild = ( d + 1 == n ) ? 0 : d + 1;
-			return new ValueNode< T >( ( T ) elements.get( k ), elements.get( k ), d, makeNode( elements, i, k - 1, dChild ), makeNode( elements, k + 1, j, dChild ) );
+			return new ValueNode< T >( ( T ) elements.get( k ), elements.get( k ), d, makeNode( elements, i, k - 1, dChild ),
+					makeNode( elements, k + 1, j, dChild ) );
 		}
 		else if ( j == i )
 		{
@@ -444,7 +451,8 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 	 *            dimension along which to split the sublist
 	 */
 	@SuppressWarnings( "unchecked" )
-	protected < L extends RealLocalizable > ValueNode< T > makeNode( final ListIterator< L > first, final ListIterator< L > last, final int d )
+	protected < L extends RealLocalizable > ValueNode< T > makeNode( final ListIterator< L > first, final ListIterator< L > last,
+			final int d )
 	{
 		final int i = first.nextIndex();
 		final int j = last.previousIndex();
@@ -510,7 +518,8 @@ public class KDTree< T > implements EuclideanSpace, IterableRealInterval< T >
 			KthElement.kthElement( i, j, k, elements, new DimComparator< RealCursor< T > >( d ) );
 
 			final int dChild = ( d + 1 == n ) ? 0 : d + 1;
-			return new SamplerNode< T >( elements.get( k ), elements.get( k ), d, makeSamplerNode( elements, i, k - 1, dChild ), makeSamplerNode( elements, k + 1, j, dChild ) );
+			return new SamplerNode< T >( elements.get( k ), elements.get( k ), d, makeSamplerNode( elements, i, k - 1, dChild ),
+					makeSamplerNode( elements, k + 1, j, dChild ) );
 		}
 		else if ( j == i )
 		{

--- a/src/main/java/net/imglib2/KDTreeNode.java
+++ b/src/main/java/net/imglib2/KDTreeNode.java
@@ -34,7 +34,6 @@
 
 package net.imglib2;
 
-
 /**
  * Abstract base class for nodes in a KDTree. A KDTreeNode has coordinates and a
  * value. It provides the coordinates via the {@link RealLocalizable} interface.

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -105,7 +105,7 @@ public interface Localizable extends RealLocalizable
 	 */
 	default int getIntPosition( final int d )
 	{
-		return (int) getLongPosition( d );
+		return ( int ) getLongPosition( d );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/concatenate/ConcatenateUtils.java
+++ b/src/main/java/net/imglib2/concatenate/ConcatenateUtils.java
@@ -91,7 +91,8 @@ public class ConcatenateUtils
 						iterator.set( c2 );
 						iterator.next();
 					}
-					else if ( PreConcatenable.class.isInstance( c2 ) && ( ( PreConcatenable ) c2 ).getPreConcatenableClass().isInstance( c1 ) )
+					else if ( PreConcatenable.class.isInstance( c2 )
+							&& ( ( PreConcatenable ) c2 ).getPreConcatenableClass().isInstance( c1 ) )
 					{
 						c2 = ( T ) ( ( PreConcatenable ) c2 ).preConcatenate( c1 );
 						iterator.previous();

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableInterval.java
@@ -44,7 +44,8 @@ import net.imglib2.View;
  * TODO
  * 
  */
-abstract public class AbstractConvertedIterableInterval< A, B > extends AbstractWrappedInterval< IterableInterval< A > > implements IterableInterval< B >, View
+abstract public class AbstractConvertedIterableInterval< A, B > extends AbstractWrappedInterval< IterableInterval< A > >
+		implements IterableInterval< B >, View
 {
 	public AbstractConvertedIterableInterval( final IterableInterval< A > source )
 	{

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableRandomAccessibleInterval.java
@@ -47,7 +47,8 @@ import net.imglib2.View;
  * TODO
  * 
  */
-abstract public class AbstractConvertedIterableRandomAccessibleInterval< A, B, S extends RandomAccessible< A > & IterableInterval< A > > extends AbstractWrappedInterval< S > implements IterableInterval< B >, RandomAccessibleInterval< B >, View
+abstract public class AbstractConvertedIterableRandomAccessibleInterval< A, B, S extends RandomAccessible< A > & IterableInterval< A > >
+		extends AbstractWrappedInterval< S > implements IterableInterval< B >, RandomAccessibleInterval< B >, View
 {
 	public AbstractConvertedIterableRandomAccessibleInterval( final S source )
 	{

--- a/src/main/java/net/imglib2/converter/AbstractConvertedIterableRealInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedIterableRealInterval.java
@@ -44,7 +44,8 @@ import net.imglib2.View;
  * TODO
  * 
  */
-abstract public class AbstractConvertedIterableRealInterval< A, B > extends AbstractWrappedRealInterval< IterableRealInterval< A > > implements IterableRealInterval< B >, View
+abstract public class AbstractConvertedIterableRealInterval< A, B > extends AbstractWrappedRealInterval< IterableRealInterval< A > >
+		implements IterableRealInterval< B >, View
 {
 	public AbstractConvertedIterableRealInterval( final IterableRealInterval< A > source )
 	{

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessible.java
@@ -67,5 +67,5 @@ abstract public class AbstractConvertedRandomAccessible< A, B > implements Rando
 
 	@Override
 	abstract public AbstractConvertedRandomAccess< A, B > randomAccess( Interval interval );
-	
+
 }

--- a/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/AbstractConvertedRandomAccessibleInterval.java
@@ -43,7 +43,8 @@ import net.imglib2.View;
  * @author Philipp Hanslovsky
  *
  */
-abstract public class AbstractConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >, View
+abstract public class AbstractConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedInterval< RandomAccessibleInterval< A > >
+		implements RandomAccessibleInterval< B >, View
 {
 
 	protected final RandomAccessibleInterval< A > source;

--- a/src/main/java/net/imglib2/converter/ColorChannelOrder.java
+++ b/src/main/java/net/imglib2/converter/ColorChannelOrder.java
@@ -45,7 +45,8 @@ public enum ColorChannelOrder
 		this.channelCount = channelCount;
 	}
 
-	public int channelCount() {
+	public int channelCount()
+	{
 		return channelCount;
 	}
 }

--- a/src/main/java/net/imglib2/converter/CompositeChannelConverter.java
+++ b/src/main/java/net/imglib2/converter/CompositeChannelConverter.java
@@ -48,12 +48,12 @@ import net.imglib2.view.composite.Composite;
 public class CompositeChannelConverter< T extends Type< T >, A extends Composite< T > > implements Converter< A, T >
 {
 	final protected long i;
-	
+
 	public CompositeChannelConverter( final long i )
 	{
 		this.i = i;
 	}
-	
+
 	@Override
 	public void convert( A input, T output )
 	{

--- a/src/main/java/net/imglib2/converter/Converters.java
+++ b/src/main/java/net/imglib2/converter/Converters.java
@@ -271,7 +271,6 @@ public class Converters
 		return new ConvertedRandomAccessibleInterval<>( source, converter, targetSupplier );
 	}
 
-
 	/**
 	 * Create a {@link RandomAccessibleInterval} whose {@link RandomAccess
 	 * RandomAccesses} {@link RandomAccess#get()} you a converted sample.
@@ -1073,7 +1072,8 @@ public class Converters
 	 *         into and from the corresponding channels of the original
 	 *         {@link ARGBType}.
 	 */
-	final static public RandomAccessibleInterval< UnsignedByteType > argbChannels( final RandomAccessibleInterval< ARGBType > source, final int... channels )
+	final static public RandomAccessibleInterval< UnsignedByteType > argbChannels( final RandomAccessibleInterval< ARGBType > source,
+			final int... channels )
 	{
 		final ArrayList< RandomAccessibleInterval< UnsignedByteType > > hyperSlices = new ArrayList<>();
 		for ( final int channel : channels )
@@ -1091,7 +1091,8 @@ public class Converters
 	 * @param channelOrder Order of the color channels.
 	 * @return Color view to the source image that can be used for reading and writing.
 	 */
-	final static public RandomAccessible< ARGBType > mergeARGB( final RandomAccessible< UnsignedByteType > source, final ColorChannelOrder channelOrder )
+	final static public RandomAccessible< ARGBType > mergeARGB( final RandomAccessible< UnsignedByteType > source,
+			final ColorChannelOrder channelOrder )
 	{
 		return Converters.convert( Views.collapse( source ), new CompositeARGBSamplerConverter( channelOrder ) );
 	}
@@ -1105,7 +1106,8 @@ public class Converters
 	 * @param channelOrder Order of the color channels.
 	 * @return Color view to the source image that can be used for reading and writing.
 	 */
-	final static public RandomAccessibleInterval< ARGBType > mergeARGB( final RandomAccessibleInterval< UnsignedByteType > source, final ColorChannelOrder channelOrder )
+	final static public RandomAccessibleInterval< ARGBType > mergeARGB( final RandomAccessibleInterval< UnsignedByteType > source,
+			final ColorChannelOrder channelOrder )
 	{
 		final int channelAxis = source.numDimensions() - 1;
 		if ( source.min( channelAxis ) > 0 || source.max( channelAxis ) < channelOrder.channelCount() - 1 )

--- a/src/main/java/net/imglib2/converter/RealLUTConverter.java
+++ b/src/main/java/net/imglib2/converter/RealLUTConverter.java
@@ -52,7 +52,7 @@ import net.imglib2.type.numeric.RealType;
  * @author Grant Harris
  * @author Curtis Rueden
  */
-public class RealLUTConverter< R extends RealType< R >> extends
+public class RealLUTConverter< R extends RealType< R > > extends
 		AbstractLinearRange implements Converter< R, ARGBType >
 {
 

--- a/src/main/java/net/imglib2/converter/RealTypeConverters.java
+++ b/src/main/java/net/imglib2/converter/RealTypeConverters.java
@@ -77,7 +77,7 @@ public final class RealTypeConverters
 		RealType< ? > s = Util.getTypeFromInterval( sourceInterval );
 		RealType< ? > d = Util.getTypeFromInterval( destination );
 		Converter< RealType< ? >, RealType< ? > > copy = getConverter( s, d );
-		boolean useMultiThreading = Intervals.numElements(destination) >= 20_000;
+		boolean useMultiThreading = Intervals.numElements( destination ) >= 20_000;
 		LoopBuilder.setImages( sourceInterval, destination ).multiThreaded( useMultiThreading ).forEachPixel( copy::convert );
 	}
 

--- a/src/main/java/net/imglib2/converter/VolatileRealTypeARGBConverter.java
+++ b/src/main/java/net/imglib2/converter/VolatileRealTypeARGBConverter.java
@@ -51,12 +51,12 @@ public class VolatileRealTypeARGBConverter extends RealARGBConverter< VolatileRe
 		super();
 		this.background = background;
 	}
-	
+
 	public VolatileRealTypeARGBConverter()
 	{
 		this( new ARGBType( 0xff000040 ) );
 	}
-	
+
 	public VolatileRealTypeARGBConverter( final double min, final double max, final ARGBType background )
 	{
 		super( min, max );

--- a/src/main/java/net/imglib2/converter/read/BiConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedIterableInterval.java
@@ -137,7 +137,6 @@ public class BiConvertedIterableInterval< A, B, C > extends AbstractConvertedIte
 		return convertedSupplier;
 	}
 
-
 	/**
 	 * Returns an instance of the {@link BiConverter}.  If the
 	 * {@link BiConvertedIterableInterval} was created with a {@link BiConverter}

--- a/src/main/java/net/imglib2/converter/read/BiConvertedIterableRealInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedIterableRealInterval.java
@@ -127,7 +127,6 @@ public class BiConvertedIterableRealInterval< A, B, C > extends AbstractConverte
 		return convertedSupplier;
 	}
 
-
 	/**
 	 * Returns an instance of the {@link BiConverter}.  If the
 	 * {@link BiConvertedIterableRealInterval} was created with a {@link BiConverter}

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccess.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccess.java
@@ -57,7 +57,6 @@ final public class BiConvertedRandomAccess< A, B, C > extends AbstractConvertedR
 
 	protected final C converted;
 
-
 	public BiConvertedRandomAccess(
 			final RandomAccess< A > sourceA,
 			final RandomAccess< B > sourceB,

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessible.java
@@ -84,7 +84,8 @@ public class BiConvertedRandomAccessible< A, B, C > extends AbstractConvertedRan
 	@Override
 	public BiConvertedRandomAccess< A, B, C > randomAccess( final Interval interval )
 	{
-		return new BiConvertedRandomAccess<>( source.randomAccess( interval ), sourceB.randomAccess( interval ), converterSupplier, convertedSupplier );
+		return new BiConvertedRandomAccess<>( source.randomAccess( interval ), sourceB.randomAccess( interval ), converterSupplier,
+				convertedSupplier );
 	}
 
 	/**
@@ -106,7 +107,6 @@ public class BiConvertedRandomAccessible< A, B, C > extends AbstractConvertedRan
 	{
 		return convertedSupplier;
 	}
-
 
 	/**
 	 * Returns an instance of the {@link BiConverter}.  If the

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRandomAccessibleInterval.java
@@ -47,7 +47,8 @@ import net.imglib2.type.Type;
  * TODO
  *
  */
-public class BiConvertedRandomAccessibleInterval< A, B, C > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< C >, View
+public class BiConvertedRandomAccessibleInterval< A, B, C > extends AbstractWrappedInterval< RandomAccessibleInterval< A > >
+		implements RandomAccessibleInterval< C >, View
 {
 	protected final RandomAccessibleInterval< B > sourceIntervalB;
 
@@ -115,7 +116,6 @@ public class BiConvertedRandomAccessibleInterval< A, B, C > extends AbstractWrap
 	{
 		return convertedSupplier;
 	}
-
 
 	/**
 	 * Returns an instance of the {@link BiConverter}.  If the

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessible.java
@@ -115,7 +115,6 @@ public class BiConvertedRealRandomAccessible< A, B, C > extends AbstractConverte
 		return convertedSupplier;
 	}
 
-
 	/**
 	 * Returns an instance of the {@link BiConverter}.  If the
 	 * {@link BiConvertedRealRandomAccessibleRealInterval} was created with a {@link BiConverter}

--- a/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/converter/read/BiConvertedRealRandomAccessibleRealInterval.java
@@ -47,7 +47,8 @@ import net.imglib2.type.Type;
  * TODO
  *
  */
-public class BiConvertedRealRandomAccessibleRealInterval< A, B, C > extends AbstractWrappedRealInterval< RealRandomAccessibleRealInterval< A > > implements RealRandomAccessibleRealInterval< C >, View
+public class BiConvertedRealRandomAccessibleRealInterval< A, B, C >
+		extends AbstractWrappedRealInterval< RealRandomAccessibleRealInterval< A > > implements RealRandomAccessibleRealInterval< C >, View
 {
 	protected final RealRandomAccessibleRealInterval< B > sourceIntervalB;
 
@@ -115,7 +116,6 @@ public class BiConvertedRealRandomAccessibleRealInterval< A, B, C > extends Abst
 	{
 		return convertedSupplier;
 	}
-
 
 	/**
 	 * Returns an instance of the {@link BiConverter}.  If the

--- a/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedIterableInterval.java
@@ -113,7 +113,6 @@ public class ConvertedIterableInterval< A, B > extends AbstractConvertedIterable
 		return convertedSupplier;
 	}
 
-
 	/**
 	 * Returns an instance of the {@link Converter}.  If the
 	 * {@link ConvertedIterableInterval} was created with a {@link Converter}

--- a/src/main/java/net/imglib2/converter/read/ConvertedIterableRealInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedIterableRealInterval.java
@@ -49,7 +49,7 @@ public class ConvertedIterableRealInterval< A, B > extends AbstractConvertedIter
 {
 	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
-	final protected Supplier< ? extends B> convertedSupplier;
+	final protected Supplier< ? extends B > convertedSupplier;
 
 	/**
 	 * Creates a copy of b for conversion.
@@ -60,7 +60,7 @@ public class ConvertedIterableRealInterval< A, B > extends AbstractConvertedIter
 	public ConvertedIterableRealInterval(
 			final IterableRealInterval< A > source,
 			final Supplier< Converter< ? super A, ? super B > > converterSupplier,
-			final Supplier< ? extends B> convertedSupplier )
+			final Supplier< ? extends B > convertedSupplier )
 	{
 		super( source );
 		this.converterSupplier = converterSupplier;
@@ -77,7 +77,7 @@ public class ConvertedIterableRealInterval< A, B > extends AbstractConvertedIter
 	public ConvertedIterableRealInterval(
 			final IterableRealInterval< A > source,
 			final Converter< ? super A, ? super B > converter,
-			final Supplier< ? extends B> convertedSupplier )
+			final Supplier< ? extends B > convertedSupplier )
 	{
 		this( source, () -> converter, convertedSupplier );
 	}
@@ -113,7 +113,6 @@ public class ConvertedIterableRealInterval< A, B > extends AbstractConvertedIter
 	{
 		return convertedSupplier;
 	}
-
 
 	/**
 	 * Returns an instance of the {@link Converter}.  If the

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessible.java
@@ -102,7 +102,6 @@ public class ConvertedRandomAccessible< A, B > extends AbstractConvertedRandomAc
 		return convertedSupplier;
 	}
 
-
 	/**
 	 * Returns an instance of the {@link Converter}.  If the
 	 * {@link ConvertedRandomAccessible} was created with a {@link Converter}

--- a/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRandomAccessibleInterval.java
@@ -47,7 +47,8 @@ import net.imglib2.type.Type;
  * TODO
  *
  */
-public class ConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >, View
+public class ConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedInterval< RandomAccessibleInterval< A > >
+		implements RandomAccessibleInterval< B >, View
 {
 	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
@@ -102,7 +103,6 @@ public class ConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedIn
 	{
 		return convertedSupplier;
 	}
-
 
 	/**
 	 * Returns an instance of the {@link Converter}.  If the

--- a/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccessible.java
@@ -102,7 +102,6 @@ public class ConvertedRealRandomAccessible< A, B > extends AbstractConvertedReal
 		return convertedSupplier;
 	}
 
-
 	/**
 	 * Returns an instance of the {@link Converter}.  If the
 	 * {@link ConvertedRealRandomAccessible} was created with a {@link Converter}

--- a/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/converter/read/ConvertedRealRandomAccessibleRealInterval.java
@@ -47,7 +47,8 @@ import net.imglib2.type.Type;
  * TODO
  *
  */
-public class ConvertedRealRandomAccessibleRealInterval< A, B > extends AbstractWrappedRealInterval< RealRandomAccessibleRealInterval< A > > implements RealRandomAccessibleRealInterval< B >, View
+public class ConvertedRealRandomAccessibleRealInterval< A, B > extends AbstractWrappedRealInterval< RealRandomAccessibleRealInterval< A > >
+		implements RealRandomAccessibleRealInterval< B >, View
 {
 	final protected Supplier< Converter< ? super A, ? super B > > converterSupplier;
 
@@ -102,7 +103,6 @@ public class ConvertedRealRandomAccessibleRealInterval< A, B > extends AbstractW
 	{
 		return convertedSupplier;
 	}
-
 
 	/**
 	 * Returns an instance of the {@link Converter}.  If the

--- a/src/main/java/net/imglib2/converter/readwrite/ARGBChannelSamplerConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/ARGBChannelSamplerConverter.java
@@ -45,14 +45,14 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
  */
 public final class ARGBChannelSamplerConverter implements SamplerConverter< ARGBType, UnsignedByteType >
 {
-	static final private int[] masks = new int[]{
+	static final private int[] masks = new int[] {
 			0x00ffffff,
 			0xff00ffff,
 			0xffff00ff,
 			0xffffff00
 	};
 
-	static final private int[] shifts = new int[]{
+	static final private int[] shifts = new int[] {
 			24,
 			16,
 			8,
@@ -88,7 +88,7 @@ public final class ARGBChannelSamplerConverter implements SamplerConverter< ARGB
 		@Override
 		public byte getValue( final int index )
 		{
-			return ( byte )( ( sampler.get().get() >> shift ) & 0xff );
+			return ( byte ) ( ( sampler.get().get() >> shift ) & 0xff );
 		}
 
 		/**

--- a/src/main/java/net/imglib2/converter/readwrite/CompositeARGBSamplerConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/CompositeARGBSamplerConverter.java
@@ -46,20 +46,23 @@ import java.util.function.Function;
 public class CompositeARGBSamplerConverter implements SamplerConverter< Composite< UnsignedByteType >, ARGBType >
 {
 
-	private final Function< Sampler< ? extends Composite< UnsignedByteType >>, ? extends IntAccess > factory;
+	private final Function< Sampler< ? extends Composite< UnsignedByteType > >, ? extends IntAccess > factory;
 
 	public CompositeARGBSamplerConverter( ColorChannelOrder order )
 	{
 		this.factory = getAccessFactory( order );
 	}
 
-	private Function<Sampler<? extends Composite<UnsignedByteType>>,? extends IntAccess> getAccessFactory( ColorChannelOrder order )
+	private Function< Sampler< ? extends Composite< UnsignedByteType > >, ? extends IntAccess > getAccessFactory( ColorChannelOrder order )
 	{
-		switch ( order ) {
-		case ARGB: return CompositeARGBAccess::new;
-		case RGB: return CompositeRGBAccess::new;
+		switch ( order )
+		{
+		case ARGB:
+			return CompositeARGBAccess::new;
+		case RGB:
+			return CompositeRGBAccess::new;
 		}
-		throw new IllegalArgumentException("Converter only supports ARGB and RGB channel order.");
+		throw new IllegalArgumentException( "Converter only supports ARGB and RGB channel order." );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/readwrite/WriteConvertedIterableRandomAccessibleInterval.java
@@ -45,7 +45,8 @@ import net.imglib2.converter.AbstractConvertedIterableRandomAccessibleInterval;
  * TODO
  *
  */
-public class WriteConvertedIterableRandomAccessibleInterval< A, B, S extends RandomAccessible< A > & IterableInterval< A > > extends AbstractConvertedIterableRandomAccessibleInterval< A, B, S >
+public class WriteConvertedIterableRandomAccessibleInterval< A, B, S extends RandomAccessible< A > & IterableInterval< A > >
+		extends AbstractConvertedIterableRandomAccessibleInterval< A, B, S >
 {
 	private final Supplier< SamplerConverter< ? super A, B > > converterSupplier;
 

--- a/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/converter/readwrite/WriteConvertedRandomAccessibleInterval.java
@@ -44,7 +44,8 @@ import net.imglib2.RandomAccessibleInterval;
  * TODO
  *
  */
-public class WriteConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedInterval< RandomAccessibleInterval< A > > implements RandomAccessibleInterval< B >
+public class WriteConvertedRandomAccessibleInterval< A, B > extends AbstractWrappedInterval< RandomAccessibleInterval< A > >
+		implements RandomAccessibleInterval< B >
 {
 	private final Supplier< SamplerConverter< ? super A, B > > converterSupplier;
 

--- a/src/main/java/net/imglib2/display/projector/IterableIntervalProjector2D.java
+++ b/src/main/java/net/imglib2/display/projector/IterableIntervalProjector2D.java
@@ -87,7 +87,8 @@ public class IterableIntervalProjector2D< A, B > extends AbstractProjector2D
 	 *            a converter that is applied to each point in the plain. This
 	 *            can e.g. be used for normalization, conversions, ...
 	 */
-	public IterableIntervalProjector2D( final int dimX, final int dimY, final RandomAccessible< A > source, final IterableInterval< B > target, final Converter< ? super A, B > converter )
+	public IterableIntervalProjector2D( final int dimX, final int dimY, final RandomAccessible< A > source,
+			final IterableInterval< B > target, final Converter< ? super A, B > converter )
 	{
 		super( source.numDimensions() );
 		this.dimX = dimX;
@@ -160,7 +161,7 @@ public class IterableIntervalProjector2D< A, B > extends AbstractProjector2D
 		else
 		{
 			final Cursor< B > targetCursor = target.localizingCursor();
-			
+
 			// use localizing cursor
 			final RandomAccess< A > sourceRandomAccess = source.randomAccess();
 			sourceRandomAccess.setPosition( position );

--- a/src/main/java/net/imglib2/display/projector/RandomAccessibleProjector2D.java
+++ b/src/main/java/net/imglib2/display/projector/RandomAccessibleProjector2D.java
@@ -94,7 +94,8 @@ public class RandomAccessibleProjector2D< A, B > extends AbstractProjector2D
 	 *            a converter that is applied to each point in the plain. This
 	 *            can e.g. be used for normalization, conversions, ...
 	 */
-	public RandomAccessibleProjector2D( final int dimX, final int dimY, final RandomAccessible< A > source, final RandomAccessibleInterval< B > target, final Converter< ? super A, B > converter )
+	public RandomAccessibleProjector2D( final int dimX, final int dimY, final RandomAccessible< A > source,
+			final RandomAccessibleInterval< B > target, final Converter< ? super A, B > converter )
 	{
 		super( source.numDimensions() );
 		this.dimX = dimX;

--- a/src/main/java/net/imglib2/display/projector/composite/CompositeXYProjector.java
+++ b/src/main/java/net/imglib2/display/projector/composite/CompositeXYProjector.java
@@ -63,7 +63,7 @@ import net.imglib2.type.numeric.ARGBType;
 public class CompositeXYProjector< A > extends AbstractProjector2D
 {
 
-	private final ArrayList< Converter< A, ARGBType >> converters;
+	private final ArrayList< Converter< A, ARGBType > > converters;
 
 	private final int dimIndex;
 
@@ -82,7 +82,8 @@ public class CompositeXYProjector< A > extends AbstractProjector2D
 	private final RandomAccessibleInterval< A > source;
 
 	@SuppressWarnings( "unchecked" )
-	public CompositeXYProjector( final RandomAccessibleInterval< A > source, final IterableInterval< ARGBType > target, final ArrayList< Converter< A, ARGBType >> converters, final int dimIndex )
+	public CompositeXYProjector( final RandomAccessibleInterval< A > source, final IterableInterval< ARGBType > target,
+			final ArrayList< Converter< A, ARGBType > > converters, final int dimIndex )
 	{
 		super( source.numDimensions() );
 		this.source = source;
@@ -94,7 +95,10 @@ public class CompositeXYProjector< A > extends AbstractProjector2D
 		positionCount = dimIndex < 0 ? 1 : source.dimension( dimIndex );
 		positionMin = dimIndex < 0 ? 0 : source.min( dimIndex );
 		final int converterCount = converters.size();
-		if ( positionCount != converterCount ) { throw new IllegalArgumentException( "Expected " + positionCount + " converters but got " + converterCount ); }
+		if ( positionCount != converterCount )
+		{
+			throw new IllegalArgumentException( "Expected " + positionCount + " converters but got " + converterCount );
+		}
 
 		composite = new boolean[ converterCount ];
 		composite[ 0 ] = true;

--- a/src/main/java/net/imglib2/display/projector/composite/CompositeXYRandomAccessibleProjector.java
+++ b/src/main/java/net/imglib2/display/projector/composite/CompositeXYRandomAccessibleProjector.java
@@ -81,7 +81,8 @@ public class CompositeXYRandomAccessibleProjector< A > extends AbstractProjector
 	protected final RandomAccessibleInterval< A > source;
 
 	@SuppressWarnings( "unchecked" )
-	public CompositeXYRandomAccessibleProjector( final RandomAccessibleInterval< A > source, final RandomAccessibleInterval< ARGBType > target, final ArrayList< Converter< A, ARGBType >> converters, final int dimIndex )
+	public CompositeXYRandomAccessibleProjector( final RandomAccessibleInterval< A > source,
+			final RandomAccessibleInterval< ARGBType > target, final ArrayList< Converter< A, ARGBType > > converters, final int dimIndex )
 	{
 		super( source.numDimensions() );
 		this.source = source;
@@ -93,7 +94,10 @@ public class CompositeXYRandomAccessibleProjector< A > extends AbstractProjector
 		positionCount = dimIndex < 0 ? 1 : source.dimension( dimIndex );
 		positionMin = dimIndex < 0 ? 0 : source.min( dimIndex );
 		final int converterCount = converters.size();
-		if ( positionCount != converterCount ) { throw new IllegalArgumentException( "Expected " + positionCount + " converters but got " + converterCount ); }
+		if ( positionCount != converterCount )
+		{
+			throw new IllegalArgumentException( "Expected " + positionCount + " converters but got " + converterCount );
+		}
 
 		min[ dimIndex ] = source.min( dimIndex );
 		max[ dimIndex ] = source.max( dimIndex );

--- a/src/main/java/net/imglib2/display/projector/sampler/SamplingProjector2D.java
+++ b/src/main/java/net/imglib2/display/projector/sampler/SamplingProjector2D.java
@@ -108,7 +108,8 @@ public class SamplingProjector2D< A, B > extends AbstractProjector2D
 	 *            selection of the third dimension
 	 * @param projectedPositions
 	 */
-	public SamplingProjector2D( final int dimX, final int dimY, final RandomAccessible< A > source, final IterableInterval< B > target, final Converter< ProjectedSampler< A >, B > converter, final int projectedDimension, final long[] projectedPositions )
+	public SamplingProjector2D( final int dimX, final int dimY, final RandomAccessible< A > source, final IterableInterval< B > target,
+			final Converter< ProjectedSampler< A >, B > converter, final int projectedDimension, final long[] projectedPositions )
 	{
 
 		super( source.numDimensions() );
@@ -138,7 +139,8 @@ public class SamplingProjector2D< A, B > extends AbstractProjector2D
 		projectionSampler = new SelectiveSampler< A >( projectedDimension, projectedPositions );
 	}
 
-	public SamplingProjector2D( final int dimX, final int dimY, final RandomAccessibleInterval< A > source, final IterableInterval< B > target, final Converter< ProjectedSampler< A >, B > converter, final int projectedDimension )
+	public SamplingProjector2D( final int dimX, final int dimY, final RandomAccessibleInterval< A > source,
+			final IterableInterval< B > target, final Converter< ProjectedSampler< A >, B > converter, final int projectedDimension )
 	{
 
 		super( source.numDimensions() );

--- a/src/main/java/net/imglib2/display/projector/specialized/ArrayImgXYByteProjector.java
+++ b/src/main/java/net/imglib2/display/projector/specialized/ArrayImgXYByteProjector.java
@@ -53,7 +53,7 @@ import net.imglib2.util.IntervalIndexer;
  * @param <A>
  *            source
  */
-public class ArrayImgXYByteProjector< A extends GenericByteType< A >> extends AbstractProjector2D
+public class ArrayImgXYByteProjector< A extends GenericByteType< A > > extends AbstractProjector2D
 {
 
 	private final byte[] sourceArray;
@@ -89,7 +89,8 @@ public class ArrayImgXYByteProjector< A extends GenericByteType< A >> extends Ab
 	 * @param normalizationFactor
 	 * @param min
 	 */
-	public ArrayImgXYByteProjector( final ArrayImg< A, ByteArray > source, final ArrayImg< UnsignedByteType, ByteArray > target, final double normalizationFactor, final double min )
+	public ArrayImgXYByteProjector( final ArrayImg< A, ByteArray > source, final ArrayImg< UnsignedByteType, ByteArray > target,
+			final double normalizationFactor, final double min )
 	{
 		super( source.numDimensions() );
 
@@ -149,7 +150,8 @@ public class ArrayImgXYByteProjector< A extends GenericByteType< A >> extends Ab
 				// | | calculate newValue: x
 				// | | unsigned_byte => int
 				// | | value - min * normalizationFactor
-				targetArray[ i ] = ( byte ) Math.min( 255, Math.max( 0, ( Math.round( ( ( targetArray[ i ] & 0xFF ) - minCopy ) * normalizationFactor ) ) ) );
+				targetArray[ i ] = ( byte ) Math.min( 255,
+						Math.max( 0, ( Math.round( ( ( targetArray[ i ] & 0xFF ) - minCopy ) * normalizationFactor ) ) ) );
 			}
 		}
 	}

--- a/src/main/java/net/imglib2/display/projector/specialized/ArrayImgXYShortProjector.java
+++ b/src/main/java/net/imglib2/display/projector/specialized/ArrayImgXYShortProjector.java
@@ -52,7 +52,7 @@ import net.imglib2.util.IntervalIndexer;
  * 
  * @param <A>
  */
-public class ArrayImgXYShortProjector< A extends GenericShortType< A >> extends AbstractProjector2D
+public class ArrayImgXYShortProjector< A extends GenericShortType< A > > extends AbstractProjector2D
 {
 
 	private final short[] sourceArray;
@@ -88,7 +88,8 @@ public class ArrayImgXYShortProjector< A extends GenericShortType< A >> extends 
 	 * @param normalizationFactor
 	 * @param min
 	 */
-	public ArrayImgXYShortProjector( final ArrayImg< A, ShortArray > source, final ArrayImg< UnsignedShortType, ShortArray > target, final double normalizationFactor, final double min )
+	public ArrayImgXYShortProjector( final ArrayImg< A, ShortArray > source, final ArrayImg< UnsignedShortType, ShortArray > target,
+			final double normalizationFactor, final double min )
 	{
 		super( source.numDimensions() );
 
@@ -137,7 +138,8 @@ public class ArrayImgXYShortProjector< A extends GenericShortType< A >> extends 
 			{
 				// normalizedValue = (oldValue - min) * normalizationFactor
 				// clamped to 0 .. 65535
-				targetArray[ i ] = ( short ) Math.min( 65535, Math.max( 0, ( Math.round( ( ( targetArray[ i ] & 0xFFFF ) - minCopy ) * normalizationFactor ) ) ) );
+				targetArray[ i ] = ( short ) Math.min( 65535,
+						Math.max( 0, ( Math.round( ( ( targetArray[ i ] & 0xFFFF ) - minCopy ) * normalizationFactor ) ) ) );
 			}
 		}
 	}

--- a/src/main/java/net/imglib2/display/projector/specialized/PlanarImgXYByteProjector.java
+++ b/src/main/java/net/imglib2/display/projector/specialized/PlanarImgXYByteProjector.java
@@ -53,7 +53,7 @@ import net.imglib2.util.IntervalIndexer;
  * 
  * @param <A>
  */
-public class PlanarImgXYByteProjector< A extends GenericByteType< A >> extends AbstractProjector2D
+public class PlanarImgXYByteProjector< A extends GenericByteType< A > > extends AbstractProjector2D
 {
 
 	private final PlanarImg< A, ByteArray > source;
@@ -89,7 +89,8 @@ public class PlanarImgXYByteProjector< A extends GenericByteType< A >> extends A
 	 * @param normalizationFactor
 	 * @param min
 	 */
-	public PlanarImgXYByteProjector( final PlanarImg< A, ByteArray > source, final ArrayImg< UnsignedByteType, ByteArray > target, final double normalizationFactor, final double min )
+	public PlanarImgXYByteProjector( final PlanarImg< A, ByteArray > source, final ArrayImg< UnsignedByteType, ByteArray > target,
+			final double normalizationFactor, final double min )
 	{
 		super( source.numDimensions() );
 
@@ -153,7 +154,8 @@ public class PlanarImgXYByteProjector< A extends GenericByteType< A >> extends A
 			{
 				// normalizedValue = (oldValue - min) * normalizationFactor
 				// clamped to 0 .. 255
-				targetArray[ i ] = ( byte ) Math.min( 255, Math.max( 0, ( Math.round( ( ( targetArray[ i ] & 0xFF ) - minCopy ) * normalizationFactor ) ) ) );
+				targetArray[ i ] = ( byte ) Math.min( 255,
+						Math.max( 0, ( Math.round( ( ( targetArray[ i ] & 0xFF ) - minCopy ) * normalizationFactor ) ) ) );
 			}
 		}
 	}

--- a/src/main/java/net/imglib2/display/projector/specialized/PlanarImgXYShortProjector.java
+++ b/src/main/java/net/imglib2/display/projector/specialized/PlanarImgXYShortProjector.java
@@ -53,7 +53,7 @@ import net.imglib2.util.IntervalIndexer;
  * 
  * @param <A>
  */
-public class PlanarImgXYShortProjector< A extends GenericShortType< A >> extends AbstractProjector2D
+public class PlanarImgXYShortProjector< A extends GenericShortType< A > > extends AbstractProjector2D
 {
 
 	private final PlanarImg< A, ShortArray > source;
@@ -89,7 +89,8 @@ public class PlanarImgXYShortProjector< A extends GenericShortType< A >> extends
 	 * @param normalizationFactor
 	 * @param min
 	 */
-	public PlanarImgXYShortProjector( final PlanarImg< A, ShortArray > source, final ArrayImg< UnsignedShortType, ShortArray > target, final double normalizationFactor, final double min )
+	public PlanarImgXYShortProjector( final PlanarImg< A, ShortArray > source, final ArrayImg< UnsignedShortType, ShortArray > target,
+			final double normalizationFactor, final double min )
 	{
 		super( source.numDimensions() );
 
@@ -154,7 +155,8 @@ public class PlanarImgXYShortProjector< A extends GenericShortType< A >> extends
 			{
 				// normalizedValue = (oldValue - min) * normalizationFactor
 				// clamped to 0 .. 65535
-				targetArray[ i ] = ( short ) Math.min( 65535, Math.max( 0, ( Math.round( ( ( targetArray[ i ] & 0xFFFF ) - minCopy ) * normalizationFactor ) ) ) );
+				targetArray[ i ] = ( short ) Math.min( 65535,
+						Math.max( 0, ( Math.round( ( ( targetArray[ i ] & 0xFFFF ) - minCopy ) * normalizationFactor ) ) ) );
 			}
 		}
 	}

--- a/src/main/java/net/imglib2/display/projector/volatiles/Volatile2DRandomAccessibleProjector.java
+++ b/src/main/java/net/imglib2/display/projector/volatiles/Volatile2DRandomAccessibleProjector.java
@@ -55,7 +55,8 @@ public class Volatile2DRandomAccessibleProjector< T, A extends Volatile< T >, B 
 {
 	protected boolean valid = false;
 
-	public Volatile2DRandomAccessibleProjector( final int dimX, final int dimY, final RandomAccessible< A > source, final RandomAccessibleInterval< B > target, final Converter< ? super A, B > converter )
+	public Volatile2DRandomAccessibleProjector( final int dimX, final int dimY, final RandomAccessible< A > source,
+			final RandomAccessibleInterval< B > target, final Converter< ? super A, B > converter )
 	{
 		super( dimX, dimY, source, Views.iterable( target ), converter );
 	}

--- a/src/main/java/net/imglib2/display/screenimage/awt/ARGBScreenImage.java
+++ b/src/main/java/net/imglib2/display/screenimage/awt/ARGBScreenImage.java
@@ -83,7 +83,7 @@ public class ARGBScreenImage extends ArrayImg< ARGBType, IntArray > implements A
 	 */
 	public ARGBScreenImage( final int width, final int height, final int[] data )
 	{
-		super( new IntArray( data ), new long[]{ width, height }, new Fraction() );
+		super( new IntArray( data ), new long[] { width, height }, new Fraction() );
 		setLinkedType( new ARGBType( this ) );
 		this.data = data;
 

--- a/src/main/java/net/imglib2/display/screenimage/awt/AWTScreenImageUtil.java
+++ b/src/main/java/net/imglib2/display/screenimage/awt/AWTScreenImageUtil.java
@@ -82,7 +82,7 @@ public class AWTScreenImageUtil
 	 * 
 	 */
 	@SuppressWarnings( { "unchecked", "rawtypes" } )
-	public static < T extends NativeType< T >> ArrayImgAWTScreenImage< T, ? > emptyScreenImage( final T type, final long[] dims )
+	public static < T extends NativeType< T > > ArrayImgAWTScreenImage< T, ? > emptyScreenImage( final T type, final long[] dims )
 	{
 
 		if ( ByteType.class.isAssignableFrom( type.getClass() ) )
@@ -96,7 +96,8 @@ public class AWTScreenImageUtil
 		if ( UnsignedByteType.class.isAssignableFrom( type.getClass() ) )
 		{
 			final ByteArray array = new ByteArray( numElements( dims ) );
-			final ArrayImgAWTScreenImage< UnsignedByteType, ByteArray > container = new UnsignedByteAWTScreenImage( new UnsignedByteType( array ), array, dims );
+			final ArrayImgAWTScreenImage< UnsignedByteType, ByteArray > container =
+					new UnsignedByteAWTScreenImage( new UnsignedByteType( array ), array, dims );
 			container.setLinkedType( new UnsignedByteType( container ) );
 			return ( ArrayImgAWTScreenImage ) container;
 		}
@@ -104,7 +105,8 @@ public class AWTScreenImageUtil
 		if ( ShortType.class.isAssignableFrom( type.getClass() ) )
 		{
 			final ShortArray array = new ShortArray( numElements( dims ) );
-			final ArrayImgAWTScreenImage< ShortType, ShortArray > container = new ShortAWTScreenImage( new ShortType( array ), array, dims );
+			final ArrayImgAWTScreenImage< ShortType, ShortArray > container =
+					new ShortAWTScreenImage( new ShortType( array ), array, dims );
 			container.setLinkedType( new ShortType( container ) );
 			return ( ArrayImgAWTScreenImage ) container;
 		}
@@ -112,7 +114,8 @@ public class AWTScreenImageUtil
 		if ( UnsignedShortType.class.isAssignableFrom( type.getClass() ) )
 		{
 			final ShortArray array = new ShortArray( numElements( dims ) );
-			final ArrayImgAWTScreenImage< UnsignedShortType, ShortArray > container = new UnsignedShortAWTScreenImage( new UnsignedShortType( array ), array, dims );
+			final ArrayImgAWTScreenImage< UnsignedShortType, ShortArray > container =
+					new UnsignedShortAWTScreenImage( new UnsignedShortType( array ), array, dims );
 			container.setLinkedType( new UnsignedShortType( container ) );
 			return ( ArrayImgAWTScreenImage ) container;
 		}
@@ -128,7 +131,8 @@ public class AWTScreenImageUtil
 		if ( UnsignedIntType.class.isAssignableFrom( type.getClass() ) )
 		{
 			final IntArray array = new IntArray( numElements( dims ) );
-			final ArrayImgAWTScreenImage< UnsignedIntType, IntArray > container = new UnsignedIntAWTScreenImage( new UnsignedIntType( array ), array, dims );
+			final ArrayImgAWTScreenImage< UnsignedIntType, IntArray > container =
+					new UnsignedIntAWTScreenImage( new UnsignedIntType( array ), array, dims );
 			container.setLinkedType( new UnsignedIntType( container ) );
 			return ( ArrayImgAWTScreenImage ) container;
 		}
@@ -136,7 +140,8 @@ public class AWTScreenImageUtil
 		if ( FloatType.class.isAssignableFrom( type.getClass() ) )
 		{
 			final FloatArray array = new FloatArray( numElements( dims ) );
-			final ArrayImgAWTScreenImage< FloatType, FloatArray > container = new FloatAWTScreenImage( new FloatType( array ), array, dims );
+			final ArrayImgAWTScreenImage< FloatType, FloatArray > container =
+					new FloatAWTScreenImage( new FloatType( array ), array, dims );
 			container.setLinkedType( new FloatType( container ) );
 			return ( ArrayImgAWTScreenImage ) container;
 		}
@@ -144,7 +149,8 @@ public class AWTScreenImageUtil
 		if ( DoubleType.class.isAssignableFrom( type.getClass() ) )
 		{
 			final DoubleArray array = new DoubleArray( numElements( dims ) );
-			final ArrayImgAWTScreenImage< DoubleType, DoubleArray > container = new DoubleAWTScreenImage( new DoubleType( array ), array, dims );
+			final ArrayImgAWTScreenImage< DoubleType, DoubleArray > container =
+					new DoubleAWTScreenImage( new DoubleType( array ), array, dims );
 			container.setLinkedType( new DoubleType( container ) );
 			return ( ArrayImgAWTScreenImage ) container;
 		}

--- a/src/main/java/net/imglib2/display/screenimage/awt/ArrayImgAWTScreenImage.java
+++ b/src/main/java/net/imglib2/display/screenimage/awt/ArrayImgAWTScreenImage.java
@@ -56,7 +56,8 @@ import net.imglib2.type.numeric.RealType;
  * 
  * @author Curtis Rueden
  */
-public abstract class ArrayImgAWTScreenImage< T extends NativeType< T >, A extends DataAccess > extends ArrayImg< T, A > implements AWTScreenImage
+public abstract class ArrayImgAWTScreenImage< T extends NativeType< T >, A extends DataAccess > extends ArrayImg< T, A >
+		implements AWTScreenImage
 {
 
 	private final BufferedImage bufferedImage;
@@ -80,7 +81,10 @@ public abstract class ArrayImgAWTScreenImage< T extends NativeType< T >, A exten
 
 	protected int getBitsPerPixel( final T type )
 	{
-		if ( type instanceof RealType ) { return ( ( RealType< ? > ) type ).getBitsPerPixel(); }
+		if ( type instanceof RealType )
+		{
+			return ( ( RealType< ? > ) type ).getBitsPerPixel();
+		}
 		throw new IllegalStateException( "Unknown bits per pixel: " + type );
 	}
 

--- a/src/main/java/net/imglib2/histogram/DiscreteFrequencyDistribution.java
+++ b/src/main/java/net/imglib2/histogram/DiscreteFrequencyDistribution.java
@@ -76,7 +76,10 @@ public class DiscreteFrequencyDistribution implements Img< LongType >
 
 		for ( int i = 0; i < binCounts.length; i++ )
 		{
-			if ( binCounts[ i ] <= 0 ) { throw new IllegalArgumentException( "invalid bin count (<= 0)" ); }
+			if ( binCounts[ i ] <= 0 )
+			{
+				throw new IllegalArgumentException( "invalid bin count (<= 0)" );
+			}
 		}
 
 		// then build object
@@ -131,7 +134,10 @@ public class DiscreteFrequencyDistribution implements Img< LongType >
 	 */
 	public void setFrequency( final long[] binPos, final long value )
 	{
-		if ( value < 0 ) { throw new IllegalArgumentException( "frequency count must be >= 0" ); }
+		if ( value < 0 )
+		{
+			throw new IllegalArgumentException( "frequency count must be >= 0" );
+		}
 		accessor.setPosition( binPos );
 		final long currentValue = accessor.get().get();
 		totalValues += ( value - currentValue );

--- a/src/main/java/net/imglib2/histogram/Histogram1d.java
+++ b/src/main/java/net/imglib2/histogram/Histogram1d.java
@@ -735,7 +735,7 @@ public class Histogram1d< T > implements Img< LongType >
 		reset();
 
 		// record the first element
-		final Iterator<T> iter = data.iterator();
+		final Iterator< T > iter = data.iterator();
 		if ( iter.hasNext() )
 		{
 			firstValue = iter.next();
@@ -745,7 +745,7 @@ public class Histogram1d< T > implements Img< LongType >
 		// record the rest of the elements
 		while ( iter.hasNext() )
 		{
-			increment ( iter.next() );
+			increment( iter.next() );
 		}
 	}
 

--- a/src/main/java/net/imglib2/histogram/HistogramNd.java
+++ b/src/main/java/net/imglib2/histogram/HistogramNd.java
@@ -66,7 +66,7 @@ public class HistogramNd< T > implements Img< LongType >
 
 	// -- instance variables --
 
-	private List< BinMapper1d< T >> mappers;
+	private List< BinMapper1d< T > > mappers;
 
 	private DiscreteFrequencyDistribution distrib;
 
@@ -89,7 +89,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param mappers
 	 *            The algorithms used to map values to bins
 	 */
-	public HistogramNd( final List< BinMapper1d< T >> mappers )
+	public HistogramNd( final List< BinMapper1d< T > > mappers )
 	{
 		this.mappers = mappers;
 		final long[] dims = new long[ mappers.size() ];
@@ -111,7 +111,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 */
 	public HistogramNd( final HistogramNd< T > other )
 	{
-		final List< BinMapper1d< T >> mappersCopy = new ArrayList< BinMapper1d< T >>();
+		final List< BinMapper1d< T > > mappersCopy = new ArrayList< BinMapper1d< T > >();
 		for ( final BinMapper1d< T > m : mappers )
 		{
 			mappersCopy.add( m.copy() );
@@ -132,7 +132,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param mappers
 	 *            The algorithms used to map values to bins
 	 */
-	public HistogramNd( final Iterable< List< T >> data, final List< BinMapper1d< T >> mappers )
+	public HistogramNd( final Iterable< List< T > > data, final List< BinMapper1d< T > > mappers )
 	{
 		this( mappers );
 		init( data );
@@ -148,7 +148,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param mappers
 	 *            The algorithms used to map values to bins
 	 */
-	public HistogramNd( final List< Iterable< T >> data, final List< BinMapper1d< T >> mappers )
+	public HistogramNd( final List< Iterable< T > > data, final List< BinMapper1d< T > > mappers )
 	{
 		this( mappers );
 		init( data );
@@ -601,7 +601,10 @@ public class HistogramNd< T > implements Img< LongType >
 	{
 		for ( int i = 0; i < mappers.size(); i++ )
 		{
-			if ( isInLowerTail( i, values.get( i ) ) ) { return true; }
+			if ( isInLowerTail( i, values.get( i ) ) )
+			{
+				return true;
+			}
 		}
 		return false;
 	}
@@ -620,7 +623,10 @@ public class HistogramNd< T > implements Img< LongType >
 		if ( hasTails( dim ) )
 		{
 			final long binPos = mappers.get( dim ).map( value );
-			if ( binPos == 0 ) { return true; }
+			if ( binPos == 0 )
+			{
+				return true;
+			}
 		}
 		return false;
 	}
@@ -636,7 +642,10 @@ public class HistogramNd< T > implements Img< LongType >
 	{
 		for ( int i = 0; i < mappers.size(); i++ )
 		{
-			if ( isInUpperTail( i, values.get( i ) ) ) { return true; }
+			if ( isInUpperTail( i, values.get( i ) ) )
+			{
+				return true;
+			}
 		}
 		return false;
 	}
@@ -655,7 +664,10 @@ public class HistogramNd< T > implements Img< LongType >
 		if ( hasTails( dim ) )
 		{
 			final long binPos = mappers.get( dim ).map( value );
-			if ( binPos == mappers.get( dim ).getBinCount() - 1 ) { return true; }
+			if ( binPos == mappers.get( dim ).getBinCount() - 1 )
+			{
+				return true;
+			}
 		}
 		return false;
 	}
@@ -671,7 +683,10 @@ public class HistogramNd< T > implements Img< LongType >
 	{
 		for ( int i = 0; i < mappers.size(); i++ )
 		{
-			if ( !isInMiddle( i, values.get( i ) ) ) { return false; }
+			if ( !isInMiddle( i, values.get( i ) ) )
+			{
+				return false;
+			}
 		}
 		return true;
 	}
@@ -690,7 +705,10 @@ public class HistogramNd< T > implements Img< LongType >
 		if ( hasTails( dim ) )
 		{
 			final long binPos = mappers.get( dim ).map( value );
-			if ( ( binPos == 0 ) || ( binPos == mappers.get( dim ).getBinCount() - 1 ) ) { return false; }
+			if ( ( binPos == 0 ) || ( binPos == mappers.get( dim ).getBinCount() - 1 ) )
+			{
+				return false;
+			}
 		}
 		return true;
 	}
@@ -705,7 +723,10 @@ public class HistogramNd< T > implements Img< LongType >
 	{
 		for ( int i = 0; i < mappers.size(); i++ )
 		{
-			if ( isOutside( i, values.get( i ) ) ) { return true; }
+			if ( isOutside( i, values.get( i ) ) )
+			{
+				return true;
+			}
 		}
 		return false;
 	}
@@ -720,7 +741,10 @@ public class HistogramNd< T > implements Img< LongType >
 	public boolean isOutside( final int dim, final T value )
 	{
 		final long binPos = mappers.get( dim ).map( value );
-		if ( ( binPos == Long.MIN_VALUE ) || ( binPos == Long.MAX_VALUE ) ) { return true; }
+		if ( ( binPos == Long.MIN_VALUE ) || ( binPos == Long.MAX_VALUE ) )
+		{
+			return true;
+		}
 		return false;
 	}
 
@@ -739,7 +763,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param data
 	 *            The total data to count
 	 */
-	public void countData( final Iterable< List< T >> data )
+	public void countData( final Iterable< List< T > > data )
 	{
 		init( data );
 	}
@@ -751,7 +775,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param data
 	 *            The total data to count
 	 */
-	public void countData( final List< Iterable< T >> data )
+	public void countData( final List< Iterable< T > > data )
 	{
 		init( data );
 	}
@@ -763,7 +787,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param data
 	 *            The new data to count
 	 */
-	public void addData( final Iterable< List< T >> data )
+	public void addData( final Iterable< List< T > > data )
 	{
 		add( data );
 	}
@@ -775,7 +799,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param data
 	 *            The new data to count
 	 */
-	public void addData( final List< Iterable< T >> data )
+	public void addData( final List< Iterable< T > > data )
 	{
 		add( data );
 	}
@@ -787,7 +811,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param data
 	 *            The old data to uncount
 	 */
-	public void subtractData( final Iterable< List< T >> data )
+	public void subtractData( final Iterable< List< T > > data )
 	{
 		subtract( data );
 	}
@@ -799,7 +823,7 @@ public class HistogramNd< T > implements Img< LongType >
 	 * @param data
 	 *            The old data to uncount
 	 */
-	public void subtractData( final List< Iterable< T >> data )
+	public void subtractData( final List< Iterable< T > > data )
 	{
 		subtract( data );
 	}
@@ -1028,51 +1052,51 @@ public class HistogramNd< T > implements Img< LongType >
 		ignoredCount = 0;
 	}
 
-	private void init( final Iterable< List< T >> data )
+	private void init( final Iterable< List< T > > data )
 	{
 		reset();
 		add( data );
 	}
 
-	private void init( final List< Iterable< T >> data )
+	private void init( final List< Iterable< T > > data )
 	{
 		reset();
 		add( data );
 	}
 
-	private void add( final Iterable< List< T >> data )
+	private void add( final Iterable< List< T > > data )
 	{
 		modifyCounts( data, incrementer );
 	}
 
-	private void add( final List< Iterable< T >> data )
+	private void add( final List< Iterable< T > > data )
 	{
 		modifyCounts( data, incrementer );
 	}
 
-	private void subtract( final Iterable< List< T >> data )
+	private void subtract( final Iterable< List< T > > data )
 	{
 		modifyCounts( data, decrementer );
 	}
 
-	private void subtract( final List< Iterable< T >> data )
+	private void subtract( final List< Iterable< T > > data )
 	{
 		modifyCounts( data, decrementer );
 	}
 
-	private void modifyCounts( final Iterable< List< T >> data, final Counter counter )
+	private void modifyCounts( final Iterable< List< T > > data, final Counter counter )
 	{
-		final Iterator< List< T >> iter = data.iterator();
+		final Iterator< List< T > > iter = data.iterator();
 		while ( iter.hasNext() )
 		{
 			count( iter.next(), counter );
 		}
 	}
 
-	private void modifyCounts( final List< Iterable< T >> data, final Counter counter )
+	private void modifyCounts( final List< Iterable< T > > data, final Counter counter )
 	{
 		final List< T > vals = new ArrayList< T >( mappers.size() );
-		final List< Iterator< T >> iters = new ArrayList< Iterator< T >>();
+		final List< Iterator< T > > iters = new ArrayList< Iterator< T > >();
 		for ( int i = 0; i < data.size(); i++ )
 		{
 			iters.add( data.get( i ).iterator() );

--- a/src/main/java/net/imglib2/histogram/Integer1dBinMapper.java
+++ b/src/main/java/net/imglib2/histogram/Integer1dBinMapper.java
@@ -44,7 +44,7 @@ import net.imglib2.type.numeric.IntegerType;
  * 
  * @author Barry DeZonia
  */
-public class Integer1dBinMapper< T extends IntegerType< T >> implements
+public class Integer1dBinMapper< T extends IntegerType< T > > implements
 		BinMapper1d< T >
 {
 
@@ -85,8 +85,11 @@ public class Integer1dBinMapper< T extends IntegerType< T >> implements
 		{
 			this.maxVal = minVal + numBins - 1;
 		}
-		if ( ( bins <= 0 ) || ( tailBins && bins <= 2 ) ) { throw new IllegalArgumentException(
-				"invalid Integer1dBinMapper: no data bins specified" ); }
+		if ( ( bins <= 0 ) || ( tailBins && bins <= 2 ) )
+		{
+			throw new IllegalArgumentException(
+					"invalid Integer1dBinMapper: no data bins specified" );
+		}
 	}
 
 	// -- BinMapper methods --
@@ -214,13 +217,16 @@ public class Integer1dBinMapper< T extends IntegerType< T >> implements
 	 *            Flags per dimension for whether to include tail bins
 	 * @return An unpopulated HistogramNd
 	 */
-	public static < K extends IntegerType< K >> HistogramNd< K > histogramNd(
+	public static < K extends IntegerType< K > > HistogramNd< K > histogramNd(
 			final long[] minVals, final long[] numBins, final boolean[] tailBins )
 	{
 		if ( ( minVals.length != numBins.length ) ||
-				( minVals.length != tailBins.length ) ) { throw new IllegalArgumentException(
-				"multiDimMapper: differing input array sizes" ); }
-		final List< BinMapper1d< K >> binMappers = new ArrayList< BinMapper1d< K >>();
+				( minVals.length != tailBins.length ) )
+		{
+			throw new IllegalArgumentException(
+					"multiDimMapper: differing input array sizes" );
+		}
+		final List< BinMapper1d< K > > binMappers = new ArrayList< BinMapper1d< K > >();
 		for ( int i = 0; i < minVals.length; i++ )
 		{
 			final Integer1dBinMapper< K > mapper =

--- a/src/main/java/net/imglib2/histogram/Real1dBinMapper.java
+++ b/src/main/java/net/imglib2/histogram/Real1dBinMapper.java
@@ -46,7 +46,7 @@ import net.imglib2.type.numeric.RealType;
  * 
  * @author Barry DeZonia
  */
-public class Real1dBinMapper< T extends RealType< T >> implements BinMapper1d< T >
+public class Real1dBinMapper< T extends RealType< T > > implements BinMapper1d< T >
 {
 
 	// -- instance variables --
@@ -86,10 +86,16 @@ public class Real1dBinMapper< T extends RealType< T >> implements BinMapper1d< T
 		this.minVal = minVal;
 		this.maxVal = maxVal;
 		this.tailBins = tailBins;
-		if ( numBins <= 0 || ( tailBins && numBins <= 2 ) ) { throw new IllegalArgumentException(
-				"invalid Real1dBinMapper: no data bins specified" ); }
-		if ( minVal > maxVal ) { throw new IllegalArgumentException(
-				"invalid Real1dBinMapper: invalid data range specified (min > max)" ); }
+		if ( numBins <= 0 || ( tailBins && numBins <= 2 ) )
+		{
+			throw new IllegalArgumentException(
+					"invalid Real1dBinMapper: no data bins specified" );
+		}
+		if ( minVal > maxVal )
+		{
+			throw new IllegalArgumentException(
+					"invalid Real1dBinMapper: invalid data range specified (min > max)" );
+		}
 		if ( tailBins )
 		{
 			this.interiorBins = bins - 2;
@@ -214,13 +220,16 @@ public class Real1dBinMapper< T extends RealType< T >> implements BinMapper1d< T
 	 *            Flags per dimension for whether to include tail bins
 	 * @return An unpopulated HistogramNd
 	 */
-	public static < K extends RealType< K >> HistogramNd< K > histogramNd(
+	public static < K extends RealType< K > > HistogramNd< K > histogramNd(
 			final double[] minVals, final double[] maxVals, final long[] numBins, final boolean[] tailBins )
 	{
 		if ( ( minVals.length != numBins.length ) ||
-				( minVals.length != tailBins.length ) ) { throw new IllegalArgumentException(
-				"multiDimMappers: differing input array sizes" ); }
-		final List< BinMapper1d< K >> binMappers = new ArrayList< BinMapper1d< K >>();
+				( minVals.length != tailBins.length ) )
+		{
+			throw new IllegalArgumentException(
+					"multiDimMappers: differing input array sizes" );
+		}
+		final List< BinMapper1d< K > > binMappers = new ArrayList< BinMapper1d< K > >();
 		for ( int i = 0; i < minVals.length; i++ )
 		{
 			final Real1dBinMapper< K > mapper =
@@ -234,7 +243,10 @@ public class Real1dBinMapper< T extends RealType< T >> implements BinMapper1d< T
 
 	private double min( final long pos )
 	{
-		if ( pos < 0 || pos > bins - 1 ) { throw new IllegalArgumentException( "invalid bin position specified" ); }
+		if ( pos < 0 || pos > bins - 1 )
+		{
+			throw new IllegalArgumentException( "invalid bin position specified" );
+		}
 		if ( tailBins )
 		{
 			if ( pos == 0 )
@@ -248,7 +260,10 @@ public class Real1dBinMapper< T extends RealType< T >> implements BinMapper1d< T
 
 	private double max( final long pos )
 	{
-		if ( pos < 0 || pos > bins - 1 ) { throw new IllegalArgumentException( "invalid bin position specified" ); }
+		if ( pos < 0 || pos > bins - 1 )
+		{
+			throw new IllegalArgumentException( "invalid bin position specified" );
+		}
 		if ( tailBins )
 		{
 			if ( pos == 0 )

--- a/src/main/java/net/imglib2/img/AbstractImg.java
+++ b/src/main/java/net/imglib2/img/AbstractImg.java
@@ -211,9 +211,9 @@ public abstract class AbstractImg< T > implements Img< T >
 		return randomAccess();
 	}
 
-//	@Override
-//	public OrthoSliceIterator< T > createOrthoSliceIterator( final Image< T > image, final int x, final int y, final int[] position )
-//	{
-//		return new OrthoSliceIterator< T >( image, x, y, position );
-//	}
+	//	@Override
+	//	public OrthoSliceIterator< T > createOrthoSliceIterator( final Image< T > image, final int x, final int y, final int[] position )
+	//	{
+	//		return new OrthoSliceIterator< T >( image, x, y, position );
+	//	}
 }

--- a/src/main/java/net/imglib2/img/AbstractNativeImg.java
+++ b/src/main/java/net/imglib2/img/AbstractNativeImg.java
@@ -48,6 +48,7 @@ public abstract class AbstractNativeImg< T extends NativeType< T >, A >
 		implements NativeImg< T, A >
 {
 	final protected Fraction entitiesPerPixel;
+
 	protected long numEntities;
 
 	protected T linkedType;

--- a/src/main/java/net/imglib2/img/ImgFactory.java
+++ b/src/main/java/net/imglib2/img/ImgFactory.java
@@ -138,7 +138,6 @@ public abstract class ImgFactory< T >
 		return imgFactory( typeSupplier.get() );
 	}
 
-
 	/*
 	 * -----------------------------------------------------------------------
 	 *
@@ -151,7 +150,8 @@ public abstract class ImgFactory< T >
 	 */
 
 	@Deprecated
-	public ImgFactory() {
+	public ImgFactory()
+	{
 		type = null;
 	}
 

--- a/src/main/java/net/imglib2/img/NativeImgFactory.java
+++ b/src/main/java/net/imglib2/img/NativeImgFactory.java
@@ -89,7 +89,6 @@ public abstract class NativeImgFactory< T extends NativeType< T > > extends ImgF
 		return create( Util.int2long( dimensions ) );
 	}
 
-
 	/*
 	 * -----------------------------------------------------------------------
 	 *
@@ -106,7 +105,7 @@ public abstract class NativeImgFactory< T extends NativeType< T > > extends ImgF
 	public abstract NativeImg< T, ? > create( long[] dimension, T type );
 
 	@Deprecated
-	public NativeImgFactory( )
+	public NativeImgFactory()
 	{
 		super();
 	}

--- a/src/main/java/net/imglib2/img/array/AbstractArrayLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/array/AbstractArrayLocalizingCursor.java
@@ -168,11 +168,11 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 	{
 		typeIndex.inc();
 
-//		 for ( int d = 0; d < n; ++d )
-//		 {
-//		 if ( ++position[ d ] > max[ d ] ) position[ d ] = 0;
-//		 else break;
-//		 }
+		//		 for ( int d = 0; d < n; ++d )
+		//		 {
+		//		 if ( ++position[ d ] > max[ d ] ) position[ d ] = 0;
+		//		 else break;
+		//		 }
 
 		/*
 		 * Benchmarks @ 2014-04-01 demonstrate that the less readable code below

--- a/src/main/java/net/imglib2/img/array/ArrayImg.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImg.java
@@ -59,7 +59,8 @@ import net.imglib2.view.iteration.SubIntervalIterable;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends AbstractNativeImg< T, A > implements SubIntervalIterable< T >
+public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends AbstractNativeImg< T, A >
+		implements SubIntervalIterable< T >
 {
 	final int[] steps, dim;
 

--- a/src/main/java/net/imglib2/img/array/ArrayImgFactory.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImgFactory.java
@@ -101,7 +101,8 @@ public class ArrayImgFactory< T extends NativeType< T > > extends NativeImgFacto
 		final long numEntities = entitiesPerPixel.mulCeil( AbstractImg.numElements( dimensions ) );
 
 		if ( numEntities > Integer.MAX_VALUE )
-			throw new RuntimeException( "Number of elements in ArrayImg too big, use for example CellImg instead: " + numEntities + " > " + Integer.MAX_VALUE );
+			throw new RuntimeException(
+					"Number of elements in ArrayImg too big, use for example CellImg instead: " + numEntities + " > " + Integer.MAX_VALUE );
 
 		return ( int ) numEntities;
 	}
@@ -111,10 +112,9 @@ public class ArrayImgFactory< T extends NativeType< T > > extends NativeImgFacto
 	public < S > ImgFactory< S > imgFactory( final S type ) throws IncompatibleTypeException
 	{
 		if ( type instanceof NativeType )
-			return new ArrayImgFactory( (NativeType) type );
+			return new ArrayImgFactory( ( NativeType ) type );
 		throw new IncompatibleTypeException( this, type.getClass().getCanonicalName() + " does not implement NativeType." );
 	}
-
 
 	/*
 	 * -----------------------------------------------------------------------

--- a/src/main/java/net/imglib2/img/array/ArrayImgs.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImgs.java
@@ -499,16 +499,19 @@ final public class ArrayImgs
 	 * Create an {@link ArrayImg}&lt;{@link UnsignedVariableBitLengthType}, {@link LongArray}&gt;.
 	 */
 	@SuppressWarnings( "unchecked" )
-	final static public ArrayImg< UnsignedVariableBitLengthType, LongArray > unsignedVariableBitLengths( final int nbits, final long... dim )
+	final static public ArrayImg< UnsignedVariableBitLengthType, LongArray > unsignedVariableBitLengths( final int nbits,
+			final long... dim )
 	{
-		return ( ArrayImg< UnsignedVariableBitLengthType, LongArray > ) new ArrayImgFactory<>( new UnsignedVariableBitLengthType( nbits ) ).create( dim );
+		return ( ArrayImg< UnsignedVariableBitLengthType, LongArray > ) new ArrayImgFactory<>( new UnsignedVariableBitLengthType( nbits ) )
+				.create( dim );
 	}
 
 	/**
 	 * Creates an {@link ArrayImg}&lt;{@link UnsignedVariableBitLengthType}, {@link LongAccess}&gt;
 	 * using a {@link LongAccess} passed as argument.
 	 */
-	final static public < A extends LongAccess > ArrayImg< UnsignedVariableBitLengthType, A > unsignedVariableBitLengths( final A access, final int nbits, final long... dim )
+	final static public < A extends LongAccess > ArrayImg< UnsignedVariableBitLengthType, A > unsignedVariableBitLengths( final A access,
+			final int nbits, final long... dim )
 	{
 		final ArrayImg< UnsignedVariableBitLengthType, A > img = new ArrayImg<>( access, dim, new Fraction( nbits, 64 ) );
 		final UnsignedVariableBitLengthType t = new UnsignedVariableBitLengthType( img, nbits );

--- a/src/main/java/net/imglib2/img/basictypeaccess/AccessFlags.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/AccessFlags.java
@@ -73,7 +73,7 @@ public enum AccessFlags
 	{
 		return f1 == DIRTY
 				? ( f2 == DIRTY ? flags_DIRTY : flags_DIRTY_VOLATILE )
-				: ( f2 == DIRTY ? flags_DIRTY_VOLATILE : flags_VOLATILE);
+				: ( f2 == DIRTY ? flags_DIRTY_VOLATILE : flags_VOLATILE );
 	}
 
 	public static Set< AccessFlags > setOf( final AccessFlags... flags )
@@ -98,7 +98,10 @@ public enum AccessFlags
 	}
 
 	private final static Set< AccessFlags > flags_DIRTY_VOLATILE = Collections.unmodifiableSet( EnumSet.of( DIRTY, VOLATILE ) );
+
 	private final static Set< AccessFlags > flags_DIRTY = Collections.unmodifiableSet( EnumSet.of( DIRTY ) );
+
 	private final static Set< AccessFlags > flags_VOLATILE = Collections.unmodifiableSet( EnumSet.of( VOLATILE ) );
+
 	private final static Set< AccessFlags > flags_NONE = Collections.unmodifiableSet( EnumSet.noneOf( AccessFlags.class ) );
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractBooleanArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractBooleanArray.java
@@ -73,7 +73,8 @@ public abstract class AbstractBooleanArray< A extends AbstractBooleanArray< A > 
 	}
 
 	@Override
-	public int getArrayLength() {
+	public int getArrayLength()
+	{
 		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractByteArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractByteArray.java
@@ -74,7 +74,8 @@ abstract public class AbstractByteArray< A extends AbstractByteArray< A > > impl
 	}
 
 	@Override
-	public int getArrayLength() {
+	public int getArrayLength()
+	{
 		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractCharArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractCharArray.java
@@ -74,7 +74,8 @@ abstract public class AbstractCharArray< A extends AbstractCharArray< A > > impl
 	}
 
 	@Override
-	public int getArrayLength() {
+	public int getArrayLength()
+	{
 		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractDoubleArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractDoubleArray.java
@@ -74,7 +74,8 @@ abstract public class AbstractDoubleArray< A extends AbstractDoubleArray< A > > 
 	}
 
 	@Override
-	public int getArrayLength() {
+	public int getArrayLength()
+	{
 		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractFloatArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractFloatArray.java
@@ -74,7 +74,8 @@ abstract public class AbstractFloatArray< A extends AbstractFloatArray< A > > im
 	}
 
 	@Override
-	public int getArrayLength() {
+	public int getArrayLength()
+	{
 		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractIntArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractIntArray.java
@@ -74,7 +74,8 @@ abstract public class AbstractIntArray< A extends AbstractIntArray< A > > implem
 	}
 
 	@Override
-	public int getArrayLength() {
+	public int getArrayLength()
+	{
 		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractLongArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractLongArray.java
@@ -74,7 +74,8 @@ abstract public class AbstractLongArray< A extends AbstractLongArray< A > > impl
 	}
 
 	@Override
-	public int getArrayLength() {
+	public int getArrayLength()
+	{
 		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractShortArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/AbstractShortArray.java
@@ -74,7 +74,8 @@ abstract public class AbstractShortArray< A extends AbstractShortArray< A > > im
 	}
 
 	@Override
-	public int getArrayLength() {
+	public int getArrayLength()
+	{
 		return data.length;
 	}
 }

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileBooleanAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileBooleanAccess.java
@@ -35,7 +35,6 @@ package net.imglib2.img.basictypeaccess.volatiles;
 
 import net.imglib2.img.basictypeaccess.BooleanAccess;
 
-
 /**
  * @author Curtis Rueden
  */

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileByteAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileByteAccess.java
@@ -35,7 +35,6 @@ package net.imglib2.img.basictypeaccess.volatiles;
 
 import net.imglib2.img.basictypeaccess.ByteAccess;
 
-
 /**
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileCharAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileCharAccess.java
@@ -35,7 +35,6 @@ package net.imglib2.img.basictypeaccess.volatiles;
 
 import net.imglib2.img.basictypeaccess.CharAccess;
 
-
 /**
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileDoubleAccess.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/VolatileDoubleAccess.java
@@ -35,7 +35,6 @@ package net.imglib2.img.basictypeaccess.volatiles;
 
 import net.imglib2.img.basictypeaccess.DoubleAccess;
 
-
 /**
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch

--- a/src/main/java/net/imglib2/img/basictypeaccess/volatiles/array/DirtyVolatileBooleanArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/volatiles/array/DirtyVolatileBooleanArray.java
@@ -43,7 +43,8 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
  *
  * @author Curtis Rueden
  */
-public class DirtyVolatileBooleanArray extends AbstractVolatileBooleanArray< DirtyVolatileBooleanArray > implements VolatileBooleanAccess, Dirty
+public class DirtyVolatileBooleanArray extends AbstractVolatileBooleanArray< DirtyVolatileBooleanArray >
+		implements VolatileBooleanAccess, Dirty
 {
 	protected boolean dirty = false;
 

--- a/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
+++ b/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
@@ -50,10 +50,10 @@ import net.imglib2.util.Fraction;
  * @author Tobias Pietzsch
  */
 public abstract class AbstractCellImg<
-				T extends NativeType< T >,
-				A extends DataAccess,
-				C extends Cell< A >,
-				I extends RandomAccessible< C > & IterableInterval< C > >
+		T extends NativeType< T >,
+		A extends DataAccess,
+		C extends Cell< A >,
+		I extends RandomAccessible< C > & IterableInterval< C > >
 		extends AbstractNativeImg< T, A >
 {
 	protected final CellGrid grid;

--- a/src/main/java/net/imglib2/img/cell/CellImg.java
+++ b/src/main/java/net/imglib2/img/cell/CellImg.java
@@ -43,7 +43,8 @@ public class CellImg< T extends NativeType< T >, A extends DataAccess > extends 
 {
 	private final CellImgFactory< T > factory;
 
-	public CellImg( final CellImgFactory< T > factory, final CellGrid grid, final ListImg< Cell< A > > imgOfCells, final Fraction entitiesPerPixel )
+	public CellImg( final CellImgFactory< T > factory, final CellGrid grid, final ListImg< Cell< A > > imgOfCells,
+			final Fraction entitiesPerPixel )
 	{
 		super( grid, imgOfCells, entitiesPerPixel );
 		this.factory = factory;

--- a/src/main/java/net/imglib2/img/cell/CellImgFactory.java
+++ b/src/main/java/net/imglib2/img/cell/CellImgFactory.java
@@ -82,7 +82,8 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 	 * @return
 	 * @throws IllegalArgumentException
 	 */
-	public static int[] getCellDimensions( final int[] defaultCellDimensions, final int n, final Fraction entitiesPerPixel ) throws IllegalArgumentException
+	public static int[] getCellDimensions( final int[] defaultCellDimensions, final int n, final Fraction entitiesPerPixel )
+			throws IllegalArgumentException
 	{
 		final int[] cellDimensions = new int[ n ];
 		final int max = defaultCellDimensions.length - 1;
@@ -143,7 +144,8 @@ public class CellImgFactory< T extends NativeType< T > > extends NativeImgFactor
 			cellCursor.fwd();
 			cellCursor.localize( cellGridPosition );
 			grid.getCellDimensions( cellGridPosition, cellMin, cellDims );
-			final A data = ArrayDataAccessFactory.get( typeFactory ).createArray( ( int ) entitiesPerPixel.mulCeil( Intervals.numElements( cellDims ) ) );
+			final A data = ArrayDataAccessFactory.get( typeFactory )
+					.createArray( ( int ) entitiesPerPixel.mulCeil( Intervals.numElements( cellDims ) ) );
 			cellCursor.set( new Cell<>( cellDims, cellMin, data ) );
 		}
 

--- a/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
@@ -45,8 +45,8 @@ import net.imglib2.type.NativeType;
  * @author Tobias Pietzsch
  */
 public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? > >
-	extends AbstractLocalizingCursor< T >
-	implements AbstractCellImg.CellImgSampler< C >
+		extends AbstractLocalizingCursor< T >
+		implements AbstractCellImg.CellImgSampler< C >
 {
 	protected final T type;
 

--- a/src/main/java/net/imglib2/img/list/ListImg.java
+++ b/src/main/java/net/imglib2/img/list/ListImg.java
@@ -86,9 +86,9 @@ public class ListImg< T > extends AbstractListImg< T >
 	public ListImg( final Collection< T > collection, final long... dim )
 	{
 		super( dim );
-		
-		assert numPixels == collection.size() : "Dimensions do not match number of pixels.";
-		
+
+		assert numPixels == collection.size(): "Dimensions do not match number of pixels.";
+
 		pixels = new ArrayList< T >( ( int ) numPixels );
 		pixels.addAll( collection );
 	}

--- a/src/main/java/net/imglib2/img/list/ListImgFactory.java
+++ b/src/main/java/net/imglib2/img/list/ListImgFactory.java
@@ -89,7 +89,6 @@ public class ListImgFactory< T > extends ImgFactory< T >
 		return new ListImgFactory<>( type );
 	}
 
-
 	/*
 	 * -----------------------------------------------------------------------
 	 *

--- a/src/main/java/net/imglib2/img/planar/PlanarImg.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImg.java
@@ -63,7 +63,8 @@ import java.util.List;
  * @author Johannes Schindelin
  * @author Tobias Pietzsch
  */
-public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A > > extends AbstractNativeImg< T, A > implements PlanarAccess< A >, SubIntervalIterable< T >
+public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A > > extends AbstractNativeImg< T, A >
+		implements PlanarAccess< A >, SubIntervalIterable< T >
 {
 	final protected int numSlices;
 
@@ -82,7 +83,7 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 		this.dimensions = longToIntArray( dim );
 		this.sliceSteps = computeSliceSteps( dim );
 		this.numSlices = numberOfSlices( dim );
-		if(slices.size() != numSlices)
+		if ( slices.size() != numSlices )
 			throw new IllegalArgumentException();
 		this.mirror = slices;
 	}
@@ -111,7 +112,7 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 		int getCurrentSliceIndex();
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings( "unchecked" )
 	@Override
 	public A update( final Object c )
 	{
@@ -381,11 +382,12 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 		return mirror;
 	}
 
-	private static < A extends ArrayDataAccess< A > > List< A > createSlices( final A creator, final long[] dim, final Fraction entitiesPerPixel )
+	private static < A extends ArrayDataAccess< A > > List< A > createSlices( final A creator, final long[] dim,
+			final Fraction entitiesPerPixel )
 	{
 		final int numSlices = numberOfSlices( dim );
 		final List< A > mirror = new ArrayList<>( numSlices );
-		final int pixelsPerPlane = (int) (( ( dim.length > 1 ) ? dim[ 1 ] : 1 ) * dim[ 0 ]);
+		final int pixelsPerPlane = ( int ) ( ( ( dim.length > 1 ) ? dim[ 1 ] : 1 ) * dim[ 0 ] );
 		final int numEntitiesPerSlice = ( int ) entitiesPerPixel.mulCeil( pixelsPerPlane );
 		for ( int i = 0; i < numSlices; ++i )
 			mirror.add( creator.createArray( numEntitiesPerSlice ) );

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
@@ -46,7 +46,8 @@ import net.imglib2.type.NativeType;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public class PlanarLocalizingCursor< T extends NativeType< T > > extends AbstractLocalizingCursorInt< T > implements PlanarImg.PlanarContainerSampler
+public class PlanarLocalizingCursor< T extends NativeType< T > > extends AbstractLocalizingCursorInt< T >
+		implements PlanarImg.PlanarContainerSampler
 {
 	protected final T type;
 

--- a/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarPlaneSubsetCursor.java
@@ -47,7 +47,7 @@ import net.imglib2.type.NativeType;
  * @author Christian Dietz
  * @author Jonathan Hale
  */
-public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
+public class PlanarPlaneSubsetCursor< T extends NativeType< T > > extends
 		AbstractCursorInt< T > implements PlanarImg.PlanarContainerSampler
 {
 
@@ -216,11 +216,12 @@ public class PlanarPlaneSubsetCursor< T extends NativeType< T >> extends
 		return container.indexToGlobalPosition( sliceIndex, typeIndex.get(), dim );
 	}
 
-	private long offset(final Interval interval) {
+	private long offset( final Interval interval )
+	{
 		final int maxDim = numDimensions() - 1;
-		long i = interval.min(maxDim);
-		for (int d = maxDim - 1; d >= 0; --d)
-			i = i * container.dimension(d) + interval.min(d);
+		long i = interval.min( maxDim );
+		for ( int d = maxDim - 1; d >= 0; --d )
+			i = i * container.dimension( d ) + interval.min( d );
 
 		return i;
 	}

--- a/src/main/java/net/imglib2/img/planar/PlanarRandomAccess.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarRandomAccess.java
@@ -49,7 +49,8 @@ import net.imglib2.type.NativeType;
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch
  */
-public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLocalizableInt implements RandomAccess< T >, PlanarImg.PlanarContainerSampler
+public class PlanarRandomAccess< T extends NativeType< T > > extends AbstractLocalizableInt
+		implements RandomAccess< T >, PlanarImg.PlanarContainerSampler
 {
 	final protected int[] sliceSteps;
 

--- a/src/main/java/net/imglib2/img/sparse/Ntree.java
+++ b/src/main/java/net/imglib2/img/sparse/Ntree.java
@@ -39,7 +39,7 @@ package net.imglib2.img.sparse;
  * 
  * @author Tobias Pietzsch
  */
-public final class Ntree< T extends Comparable< T >>
+public final class Ntree< T extends Comparable< T > >
 {
 
 	public static final class NtreeNode< T >

--- a/src/main/java/net/imglib2/img/sparse/NtreeCursor.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeCursor.java
@@ -43,7 +43,7 @@ import net.imglib2.type.NativeType;
  * @author Tobias Pietzsch
  * 
  */
-public final class NtreeCursor< T extends NativeType< T >> extends
+public final class NtreeCursor< T extends NativeType< T > > extends
 		LocalizingIntervalIterator implements Cursor< T >, PositionProvider
 {
 	private final NtreeImg< T, ? > img;

--- a/src/main/java/net/imglib2/img/sparse/NtreeImg.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeImg.java
@@ -46,7 +46,8 @@ import net.imglib2.util.Fraction;
  * @author Tobias Pietzsch
  * 
  */
-public final class NtreeImg< T extends NativeType< T >, A extends NtreeAccess< ?, A > > extends AbstractNativeImg< T, A > implements Serializable
+public final class NtreeImg< T extends NativeType< T >, A extends NtreeAccess< ?, A > > extends AbstractNativeImg< T, A >
+		implements Serializable
 {
 	/**
 	 * TODO: remove with proper serialization

--- a/src/main/java/net/imglib2/img/sparse/NtreeImgFactory.java
+++ b/src/main/java/net/imglib2/img/sparse/NtreeImgFactory.java
@@ -127,7 +127,6 @@ public class NtreeImgFactory< T extends NativeType< T > > extends NativeImgFacto
 		throw new IncompatibleTypeException( this, type.getClass().getCanonicalName() + " does not implement NativeType." );
 	}
 
-
 	/*
 	 * -----------------------------------------------------------------------
 	 *

--- a/src/main/java/net/imglib2/interpolation/neighborsearch/InverseDistanceWeightingInterpolatorFactory.java
+++ b/src/main/java/net/imglib2/interpolation/neighborsearch/InverseDistanceWeightingInterpolatorFactory.java
@@ -48,7 +48,8 @@ import net.imglib2.type.numeric.RealType;
  * @author Tobias Pietzsch
  * @author Stephan Preibisch
  */
-public class InverseDistanceWeightingInterpolatorFactory< T extends RealType< T > > implements InterpolatorFactory< T, KNearestNeighborSearch< T > >
+public class InverseDistanceWeightingInterpolatorFactory< T extends RealType< T > >
+		implements InterpolatorFactory< T, KNearestNeighborSearch< T > >
 {
 	final double p;
 

--- a/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorFactory.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorFactory.java
@@ -70,7 +70,8 @@ public class ClampingNLinearInterpolatorFactory< T extends NumericType< T > > im
 		}
 		else if ( VolatileARGBType.class.isInstance( type ) )
 		{
-			return ( RealRandomAccess ) new ClampingNLinearInterpolatorVolatileARGB< VolatileARGBType >( ( RandomAccessible ) randomAccessible );
+			return ( RealRandomAccess ) new ClampingNLinearInterpolatorVolatileARGB< VolatileARGBType >(
+					( RandomAccessible ) randomAccessible );
 		}
 		else
 			// fall back to (non-clamping) NLinearInterpolator

--- a/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorRealType.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorRealType.java
@@ -48,7 +48,9 @@ import net.imglib2.type.numeric.RealType;
 public class ClampingNLinearInterpolatorRealType< T extends RealType< T > > extends NLinearInterpolator< T >
 {
 	protected double acc;
+
 	protected final double clampMin;
+
 	protected final double clampMax;
 
 	protected ClampingNLinearInterpolatorRealType( final ClampingNLinearInterpolatorRealType< T > interpolator )

--- a/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorVolatileARGB.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorVolatileARGB.java
@@ -47,9 +47,11 @@ import net.imglib2.util.Util;
  * @author Stephan Saalfeld &lt;saalfeld@mpi-cbg.de&gt;
  * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
  */
-public class ClampingNLinearInterpolatorVolatileARGB< T extends AbstractVolatileNumericType< ARGBType, T > > extends NLinearInterpolator< T >
+public class ClampingNLinearInterpolatorVolatileARGB< T extends AbstractVolatileNumericType< ARGBType, T > >
+		extends NLinearInterpolator< T >
 {
 	protected double accA, accR, accG, accB;
+
 	protected boolean valid;
 
 	protected ClampingNLinearInterpolatorVolatileARGB( final ClampingNLinearInterpolatorVolatileARGB< T > interpolator )

--- a/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorVolatileRealType.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorVolatileRealType.java
@@ -46,11 +46,15 @@ import net.imglib2.type.volatiles.AbstractVolatileRealType;
  *
  * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
  */
-public class ClampingNLinearInterpolatorVolatileRealType< R extends RealType< R >, T extends AbstractVolatileRealType< R, T > > extends NLinearInterpolator< T >
+public class ClampingNLinearInterpolatorVolatileRealType< R extends RealType< R >, T extends AbstractVolatileRealType< R, T > >
+		extends NLinearInterpolator< T >
 {
 	protected double acc;
+
 	protected boolean valid;
+
 	protected final double clampMin;
+
 	protected final double clampMax;
 
 	protected ClampingNLinearInterpolatorVolatileRealType( final ClampingNLinearInterpolatorVolatileRealType< R, T > interpolator )

--- a/src/main/java/net/imglib2/interpolation/randomaccess/LanczosInterpolator.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/LanczosInterpolator.java
@@ -87,7 +87,8 @@ public class LanczosInterpolator< T extends RealType< T > > extends FloorOffset<
 	 * @param max
 	 *            - range for clipping (ignored if min==max)
 	 */
-	public LanczosInterpolator( final RandomAccessible< T > randomAccessible, final int alpha, final boolean clip, final double min, final double max )
+	public LanczosInterpolator( final RandomAccessible< T > randomAccessible, final int alpha, final boolean clip, final double min,
+			final double max )
 	{
 		super( randomAccessible.randomAccess(), createOffset( alpha, randomAccessible.numDimensions() ) );
 

--- a/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator.java
@@ -175,8 +175,8 @@ public class NLinearInterpolator< T extends NumericType< T > > extends Floor< Ra
 				baseIndex += baseIndexIncrement;
 			}
 		}
-//		printWeights();
-//		System.out.println();
+		//		printWeights();
+		//		System.out.println();
 	}
 
 	/**
@@ -258,10 +258,10 @@ public class NLinearInterpolator< T extends NumericType< T > > extends Floor< Ra
 		tmp.set( target.get() );
 		tmp.mul( weights[ code ] );
 		accumulator.add( tmp );
-//		System.out.print( "accumulating value at " + target );
-//		System.out.print( "with weights [" );
-//		printCode();
-//		System.out.printf( "] = %f" + "\n", weights[ code ] );
+		//		System.out.print( "accumulating value at " + target );
+		//		System.out.print( "with weights [" );
+		//		printCode();
+		//		System.out.printf( "] = %f" + "\n", weights[ code ] );
 	}
 
 	@SuppressWarnings( "unused" )

--- a/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolatorARGB.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolatorARGB.java
@@ -152,10 +152,10 @@ public class NLinearInterpolatorARGB extends NLinearInterpolator< ARGBType >
 		accG += ( ( argb >> 8 ) & 0xff ) * weights[ code ];
 		accB += ( argb & 0xff ) * weights[ code ];
 
-//		System.out.print( "accumulating value at " + target );
-//		System.out.print( "with weights [" );
-//		printCode();
-//		System.out.printf( "] = %f" + "\n", weights[ code ] );
+		//		System.out.print( "accumulating value at " + target );
+		//		System.out.print( "with weights [" );
+		//		printCode();
+		//		System.out.printf( "] = %f" + "\n", weights[ code ] );
 	}
 
 	@SuppressWarnings( "unused" )

--- a/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolatorFactory.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolatorFactory.java
@@ -57,8 +57,8 @@ public class NLinearInterpolatorFactory< T extends NumericType< T > > implements
 			return new NLinearInterpolator1D< T >( randomAccessible );
 		case 2:
 			return new NLinearInterpolator2D< T >( randomAccessible );
-//		case 3:
-//			return new NLinearInterpolator3D< T >( randomAccessible );
+		//		case 3:
+		//			return new NLinearInterpolator3D< T >( randomAccessible );
 		default:
 			return new NLinearInterpolator< T >( randomAccessible );
 		}

--- a/src/main/java/net/imglib2/interpolation/stack/LinearRealRandomAccessibleStackInterpolator.java
+++ b/src/main/java/net/imglib2/interpolation/stack/LinearRealRandomAccessibleStackInterpolator.java
@@ -60,7 +60,8 @@ import net.imglib2.util.Cast;
  * @param <T>
  *            the pixel type
  */
-public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType< T > > extends NearestNeighborRealRandomAccessibleStackInterpolator< T >
+public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType< T > >
+		extends NearestNeighborRealRandomAccessibleStackInterpolator< T >
 {
 	protected RealRandomAccess< T > sliceAccess2;
 
@@ -78,7 +79,6 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 	protected double w = 1;
 
 	protected double w1 = 0;
-
 
 	public LinearRealRandomAccessibleStackInterpolator(
 			final RealRandomAccessible< T >[] slices )
@@ -104,7 +104,7 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 	{
 		this(
 				slices.toArray(
-						Cast.<RealRandomAccessible< T >[]>unchecked(
+						Cast.< RealRandomAccessible< T >[] >unchecked(
 								Array.newInstance( RealRandomAccessible.class, slices.size() ) ) ) );
 
 	}
@@ -127,7 +127,7 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 	@Override
 	protected int getSliceIndex( @SuppressWarnings( "hiding" ) final double position )
 	{
-		return Math.max( 0, Math.min( lastSliceIndex, ( int )Math.floor( position ) ) );
+		return Math.max( 0, Math.min( lastSliceIndex, ( int ) Math.floor( position ) ) );
 	}
 
 	@Override
@@ -160,7 +160,8 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 			sliceAccess2 = sliceAccess;
 	}
 
-	protected void updateW() {
+	protected void updateW()
+	{
 
 		w1 = position[ sd ];
 		w1 -= Math.floor( w1 );
@@ -171,7 +172,8 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 	public void fwd( final int d )
 	{
 		position[ d ] += 1;
-		if ( d < sd ) {
+		if ( d < sd )
+		{
 			sliceAccess.fwd( d );
 			if ( sliceAccess2 != sliceAccess )
 				sliceAccess2.fwd( d );
@@ -184,7 +186,8 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 	public void bck( final int d )
 	{
 		position[ d ] += 1;
-		if ( d < sd ) {
+		if ( d < sd )
+		{
 			sliceAccess.bck( d );
 			if ( sliceAccess2 != sliceAccess )
 				sliceAccess2.bck( d );
@@ -197,7 +200,8 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 	public void move( final double distance, final int d )
 	{
 		position[ d ] += distance;
-		if ( d < sd ) {
+		if ( d < sd )
+		{
 			sliceAccess.move( distance, d );
 			if ( sliceAccess2 != sliceAccess )
 				sliceAccess2.move( distance, d );
@@ -518,19 +522,19 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 	@Override
 	public void setPosition( final int pos, final int d )
 	{
-		setPosition( ( double )pos, d );
+		setPosition( ( double ) pos, d );
 	}
 
 	@Override
 	public void setPosition( final long pos, final int d )
 	{
-		setPosition( ( double )pos, d );
+		setPosition( ( double ) pos, d );
 	}
 
 	@Override
 	public void setPosition( final float pos, final int d )
 	{
-		setPosition( ( double )pos, d );
+		setPosition( ( double ) pos, d );
 	}
 
 	@Override
@@ -549,7 +553,6 @@ public class LinearRealRandomAccessibleStackInterpolator< T extends NumericType<
 			updateW();
 		}
 	}
-
 
 	@Override
 	public T get()

--- a/src/main/java/net/imglib2/interpolation/stack/LinearRealRandomAccessibleStackInterpolatorFactory.java
+++ b/src/main/java/net/imglib2/interpolation/stack/LinearRealRandomAccessibleStackInterpolatorFactory.java
@@ -43,7 +43,8 @@ import net.imglib2.type.numeric.NumericType;
 /**
  *
  */
-public class LinearRealRandomAccessibleStackInterpolatorFactory< T extends NumericType< T >, F extends List< RealRandomAccessible< T > > > implements InterpolatorFactory< T, F >
+public class LinearRealRandomAccessibleStackInterpolatorFactory< T extends NumericType< T >, F extends List< RealRandomAccessible< T > > >
+		implements InterpolatorFactory< T, F >
 {
 	@Override
 	public LinearRealRandomAccessibleStackInterpolator< T > create( final F stack )

--- a/src/main/java/net/imglib2/interpolation/stack/NearestNeighborRealRandomAccessibleStackInterpolator.java
+++ b/src/main/java/net/imglib2/interpolation/stack/NearestNeighborRealRandomAccessibleStackInterpolator.java
@@ -99,7 +99,7 @@ public class NearestNeighborRealRandomAccessibleStackInterpolator< T > extends A
 	{
 		this(
 				slices.toArray(
-						Cast.<RealRandomAccessible< T >[]>unchecked(
+						Cast.< RealRandomAccessible< T >[] >unchecked(
 								Array.newInstance( RealRandomAccessible.class, slices.size() ) ) ) );
 
 	}
@@ -124,13 +124,14 @@ public class NearestNeighborRealRandomAccessibleStackInterpolator< T > extends A
 
 	protected int getSliceIndex( final double position )
 	{
-		return Math.max( 0, Math.min( lastSliceIndex, ( int )Math.round( position ) ) );
+		return Math.max( 0, Math.min( lastSliceIndex, ( int ) Math.round( position ) ) );
 	}
 
 	protected RealRandomAccess< T > getOrCreateAccess( final int i )
 	{
 		final RealRandomAccess< T > access = sliceAccesses[ i ];
-		if ( access == null ) {
+		if ( access == null )
+		{
 			return sliceAccesses[ i ] = slices[ i ].realRandomAccess();
 		}
 		return access;
@@ -157,7 +158,7 @@ public class NearestNeighborRealRandomAccessibleStackInterpolator< T > extends A
 	public void localize( final float[] position )
 	{
 		for ( int d = 0; d < n; ++d )
-			position[ d ] = ( float )this.position[ d ];
+			position[ d ] = ( float ) this.position[ d ];
 	}
 
 	@Override
@@ -170,7 +171,7 @@ public class NearestNeighborRealRandomAccessibleStackInterpolator< T > extends A
 	@Override
 	public float getFloatPosition( final int d )
 	{
-		return ( float )position[ d ];
+		return ( float ) position[ d ];
 	}
 
 	@Override
@@ -202,19 +203,19 @@ public class NearestNeighborRealRandomAccessibleStackInterpolator< T > extends A
 	@Override
 	public void move( final int distance, final int d )
 	{
-		move( ( double )distance, d );
+		move( ( double ) distance, d );
 	}
 
 	@Override
 	public void move( final long distance, final int d )
 	{
-		move( ( double )distance, d );
+		move( ( double ) distance, d );
 	}
 
 	@Override
 	public void move( final float distance, final int d )
 	{
-		move( ( double )distance, d );
+		move( ( double ) distance, d );
 	}
 
 	@Override
@@ -458,19 +459,19 @@ public class NearestNeighborRealRandomAccessibleStackInterpolator< T > extends A
 	@Override
 	public void setPosition( final int pos, final int d )
 	{
-		setPosition( ( double )pos, d );
+		setPosition( ( double ) pos, d );
 	}
 
 	@Override
 	public void setPosition( final long pos, final int d )
 	{
-		setPosition( ( double )pos, d );
+		setPosition( ( double ) pos, d );
 	}
 
 	@Override
 	public void setPosition( final float pos, final int d )
 	{
-		setPosition( ( double )pos, d );
+		setPosition( ( double ) pos, d );
 	}
 
 	@Override
@@ -482,7 +483,6 @@ public class NearestNeighborRealRandomAccessibleStackInterpolator< T > extends A
 		else
 			setSlice( getSliceIndex( pos ) );
 	}
-
 
 	@Override
 	public T get()

--- a/src/main/java/net/imglib2/interpolation/stack/NearestNeighborRealRandomAccessibleStackInterpolatorFactory.java
+++ b/src/main/java/net/imglib2/interpolation/stack/NearestNeighborRealRandomAccessibleStackInterpolatorFactory.java
@@ -42,7 +42,8 @@ import net.imglib2.interpolation.InterpolatorFactory;
 /**
  *
  */
-public class NearestNeighborRealRandomAccessibleStackInterpolatorFactory< T, F extends List< RealRandomAccessible< T > > > implements InterpolatorFactory< T, F >
+public class NearestNeighborRealRandomAccessibleStackInterpolatorFactory< T, F extends List< RealRandomAccessible< T > > >
+		implements InterpolatorFactory< T, F >
 {
 	@Override
 	public NearestNeighborRealRandomAccessibleStackInterpolator< T > create( final F stack )

--- a/src/main/java/net/imglib2/iterator/LocalizingRealIntervalIterator.java
+++ b/src/main/java/net/imglib2/iterator/LocalizingRealIntervalIterator.java
@@ -97,8 +97,8 @@ public class LocalizingRealIntervalIterator extends AbstractRealInterval impleme
 	@Override
 	public boolean hasNext()
 	{
-		for( int d = 0; d < numDimensions(); d++ )
-			if( (location[ d ] + step[ d ]) <= realMax( d ))
+		for ( int d = 0; d < numDimensions(); d++ )
+			if ( ( location[ d ] + step[ d ] ) <= realMax( d ) )
 			{
 				return true;
 			}
@@ -113,44 +113,44 @@ public class LocalizingRealIntervalIterator extends AbstractRealInterval impleme
 	}
 
 	@Override
-	public void localize(float[] position)
+	public void localize( float[] position )
 	{
-		for( int d = 0; d < position.length; d++ )
-			position[ d ] = (float)location[ d ];
+		for ( int d = 0; d < position.length; d++ )
+			position[ d ] = ( float ) location[ d ];
 	}
 
 	@Override
-	public void localize(double[] position)
+	public void localize( double[] position )
 	{
 		System.arraycopy( location, 0, position, 0, position.length );
 	}
 
 	@Override
-	public float getFloatPosition(int d)
+	public float getFloatPosition( int d )
 	{
-		return (float) location[ d ];
+		return ( float ) location[ d ];
 	}
 
 	@Override
-	public double getDoublePosition(int d)
+	public double getDoublePosition( int d )
 	{
 		return location[ d ];
 	}
 
 	@Override
-	public void jumpFwd(long steps)
+	public void jumpFwd( long steps )
 	{
-		for( int i = 0; i < steps; i++ )
+		for ( int i = 0; i < steps; i++ )
 			fwd();
 	}
 
 	@Override
 	public void fwd()
 	{
-		for( int d = 0; d < numDimensions(); d++ )
+		for ( int d = 0; d < numDimensions(); d++ )
 		{
 			fwdDim( d );
-			if( location[ d ] <= realMax(d))
+			if ( location[ d ] <= realMax( d ) )
 				break;
 			else
 				location[ d ] = realMin( d );

--- a/src/main/java/net/imglib2/loops/BindActionToSamplers.java
+++ b/src/main/java/net/imglib2/loops/BindActionToSamplers.java
@@ -53,7 +53,7 @@ final class BindActionToSamplers
 			new ClassCopyProvider<>( TriConsumerRunnable.class, Runnable.class ),
 			new ClassCopyProvider<>( FourConsumerRunnable.class, Runnable.class ),
 			new ClassCopyProvider<>( FiveConsumerRunnable.class, Runnable.class ),
-			new ClassCopyProvider<>( SixConsumerRunnable.class, Runnable.class ));
+			new ClassCopyProvider<>( SixConsumerRunnable.class, Runnable.class ) );
 
 	/**
 	 * For example.: Given a BiConsumer and two Samplers:
@@ -156,7 +156,8 @@ final class BindActionToSamplers
 
 		private final Sampler< C > samplerC;
 
-		public TriConsumerRunnable( final LoopBuilder.TriConsumer< A, B, C > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC )
+		public TriConsumerRunnable( final LoopBuilder.TriConsumer< A, B, C > action, final Sampler< A > samplerA,
+				final Sampler< B > samplerB, final Sampler< C > samplerC )
 		{
 			this.action = action;
 			this.samplerA = samplerA;
@@ -184,7 +185,8 @@ final class BindActionToSamplers
 
 		private final Sampler< D > samplerD;
 
-		public FourConsumerRunnable( final LoopBuilder.FourConsumer< A, B, C, D > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD )
+		public FourConsumerRunnable( final LoopBuilder.FourConsumer< A, B, C, D > action, final Sampler< A > samplerA,
+				final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD )
 		{
 			this.action = action;
 			this.samplerA = samplerA;
@@ -215,7 +217,8 @@ final class BindActionToSamplers
 
 		private final Sampler< E > samplerE;
 
-		public FiveConsumerRunnable( final LoopBuilder.FiveConsumer< A, B, C, D, E > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, Sampler< E > samplerE )
+		public FiveConsumerRunnable( final LoopBuilder.FiveConsumer< A, B, C, D, E > action, final Sampler< A > samplerA,
+				final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, Sampler< E > samplerE )
 		{
 			this.action = action;
 			this.samplerA = samplerA;
@@ -249,7 +252,9 @@ final class BindActionToSamplers
 
 		private final Sampler< F > samplerF;
 
-		public SixConsumerRunnable( final LoopBuilder.SixConsumer< A, B, C, D, E, F > action, final Sampler< A > samplerA, final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, final Sampler< E > samplerE, final Sampler< F > samplerF )
+		public SixConsumerRunnable( final LoopBuilder.SixConsumer< A, B, C, D, E, F > action, final Sampler< A > samplerA,
+				final Sampler< B > samplerB, final Sampler< C > samplerC, final Sampler< D > samplerD, final Sampler< E > samplerE,
+				final Sampler< F > samplerF )
 		{
 			this.action = action;
 			this.samplerA = samplerA;

--- a/src/main/java/net/imglib2/loops/ClassCopier.java
+++ b/src/main/java/net/imglib2/loops/ClassCopier.java
@@ -67,7 +67,8 @@ class ClassCopier< T >
 	public Class< ? extends T > copy()
 	{
 		@SuppressWarnings( "unchecked" )
-		final Class< ? extends T > copy = ( Class< ? extends T > ) new ClassCopyLoader( original.getClassLoader() ).bytesToClass( original.getName(), bytes );
+		final Class< ? extends T > copy =
+				( Class< ? extends T > ) new ClassCopyLoader( original.getClassLoader() ).bytesToClass( original.getName(), bytes );
 		return copy;
 	}
 

--- a/src/main/java/net/imglib2/loops/ClassCopyProvider.java
+++ b/src/main/java/net/imglib2/loops/ClassCopyProvider.java
@@ -64,10 +64,12 @@ public class ClassCopyProvider< T >
 	 * @param constructorSignature Constructor signature to be used
 	 *                             when creating a new instance with {@link #newInstanceForKey}
 	 */
-	public ClassCopyProvider( final Class< ? extends T > clazz, final Class< T > interfaceOfClazz, final Class< ? >... constructorSignature )
+	public ClassCopyProvider( final Class< ? extends T > clazz, final Class< T > interfaceOfClazz,
+			final Class< ? >... constructorSignature )
 	{
 		this.copier = new ClassCopier<>( clazz, interfaceOfClazz );
-		this.signature = ( constructorSignature == null || constructorSignature.length == 0 ) ? assumeConstructorSignature( clazz ) : constructorSignature;
+		this.signature = ( constructorSignature == null || constructorSignature.length == 0 ) ? assumeConstructorSignature( clazz )
+				: constructorSignature;
 	}
 
 	private static Class< ? >[] assumeConstructorSignature( final Class< ? > clazz )
@@ -78,7 +80,8 @@ public class ClassCopyProvider< T >
 		if ( constructors.length == 1 )
 			return constructors[ 0 ].getParameterTypes();
 		if ( constructors.length == 0 )
-			throw new IllegalArgumentException( "ClassCopyProvider: Class and it's constructor need to be public (" + clazz.getName() + ")." );
+			throw new IllegalArgumentException(
+					"ClassCopyProvider: Class and it's constructor need to be public (" + clazz.getName() + ")." );
 		throw new IllegalArgumentException( "ClassCopyProvider: Please specify constructor signature." );
 	}
 

--- a/src/main/java/net/imglib2/loops/FastCursorLoops.java
+++ b/src/main/java/net/imglib2/loops/FastCursorLoops.java
@@ -162,7 +162,8 @@ public final class FastCursorLoops
 
 		private final Cursor< C > cursorC;
 
-		public ThreeCursorLoop( final TriConsumer< A, B, C > action, final Cursor< A > cursorA, final Cursor< B > cursorB, final Cursor< C > cursorC )
+		public ThreeCursorLoop( final TriConsumer< A, B, C > action, final Cursor< A > cursorA, final Cursor< B > cursorB,
+				final Cursor< C > cursorC )
 		{
 			this.action = action;
 			this.cursorA = cursorA;
@@ -191,7 +192,8 @@ public final class FastCursorLoops
 
 		private final Cursor< D > cursorD;
 
-		public FourCursorLoop( final FourConsumer< A, B, C, D > action, final Cursor< A > cursorA, final Cursor< B > cursorB, final Cursor< C > cursorC, final Cursor< D > cursorD )
+		public FourCursorLoop( final FourConsumer< A, B, C, D > action, final Cursor< A > cursorA, final Cursor< B > cursorB,
+				final Cursor< C > cursorC, final Cursor< D > cursorD )
 		{
 			this.action = action;
 			this.cursorA = cursorA;
@@ -223,7 +225,8 @@ public final class FastCursorLoops
 
 		private final Cursor< E > cursorE;
 
-		public FiveCursorLoop( final FiveConsumer< A, B, C, D, E > action, final Cursor< A > cursorA, final Cursor< B > cursorB, final Cursor< C > cursorC, final Cursor< D > cursorD, Cursor< E > cursorE )
+		public FiveCursorLoop( final FiveConsumer< A, B, C, D, E > action, final Cursor< A > cursorA, final Cursor< B > cursorB,
+				final Cursor< C > cursorC, final Cursor< D > cursorD, Cursor< E > cursorE )
 		{
 			this.action = action;
 			this.cursorA = cursorA;
@@ -258,7 +261,8 @@ public final class FastCursorLoops
 
 		private final Cursor< F > cursorF;
 
-		public SixCursorLoop( final SixConsumer< A, B, C, D, E, F > action, final Cursor< A > cursorA, final Cursor< B > cursorB, final Cursor< C > cursorC, final Cursor< D > cursorD, final Cursor< E > cursorE, final Cursor< F > cursorF )
+		public SixCursorLoop( final SixConsumer< A, B, C, D, E, F > action, final Cursor< A > cursorA, final Cursor< B > cursorB,
+				final Cursor< C > cursorC, final Cursor< D > cursorD, final Cursor< E > cursorE, final Cursor< F > cursorF )
 		{
 			this.action = action;
 			this.cursorA = cursorA;

--- a/src/main/java/net/imglib2/loops/FastCursorRandomAccessLoops.java
+++ b/src/main/java/net/imglib2/loops/FastCursorRandomAccessLoops.java
@@ -89,7 +89,8 @@ final class FastCursorRandomAccessLoops
 			new ClassCopyProvider<>( TwoCursorLoop.class, LongConsumer.class ),
 			new ClassCopyProvider<>( ThreeCursorLoop.class, LongConsumer.class ) );
 
-	private static LongConsumer createLoop( final Object action, final Cursor< ? > cursor, final List< ? extends RandomAccess< ? > > randomAccesses )
+	private static LongConsumer createLoop( final Object action, final Cursor< ? > cursor,
+			final List< ? extends RandomAccess< ? > > randomAccesses )
 	{
 		final Object[] arguments = Stream.concat( Stream.of( action, cursor ), randomAccesses.stream() ).toArray();
 		ClassCopyProvider< LongConsumer > factory = factories.get( randomAccesses.size() );
@@ -157,7 +158,8 @@ final class FastCursorRandomAccessLoops
 
 		private final RandomAccess< C > randomAccessC;
 
-		public ThreeCursorLoop( final LoopBuilder.TriConsumer< A, B, C > action, final Cursor< A > cursorA, final RandomAccess< B > randomAccessB, final RandomAccess< C > randomAccessC )
+		public ThreeCursorLoop( final LoopBuilder.TriConsumer< A, B, C > action, final Cursor< A > cursorA,
+				final RandomAccess< B > randomAccessB, final RandomAccess< C > randomAccessC )
 		{
 			this.action = action;
 			this.cursorA = cursorA;

--- a/src/main/java/net/imglib2/loops/IntervalChunks.java
+++ b/src/main/java/net/imglib2/loops/IntervalChunks.java
@@ -87,7 +87,7 @@ public class IntervalChunks
 		long[] totalMax = Intervals.maxAsLongArray( interval );
 		long[] dimensions = Intervals.dimensionsAsLongArray( interval );
 		long[] cellNumbers = new long[ dimensions.length ];
-		Arrays.setAll(cellNumbers, d -> divideAndRoundUp( dimensions[ d ], cellDimensions[ d ] ) );
+		Arrays.setAll( cellNumbers, d -> divideAndRoundUp( dimensions[ d ], cellDimensions[ d ] ) );
 		long elements = Intervals.numElements( cellNumbers );
 		long[] cellIndicies = new long[ n ];
 		long[] min = new long[ n ];

--- a/src/main/java/net/imglib2/loops/IterableLoopBuilder.java
+++ b/src/main/java/net/imglib2/loops/IterableLoopBuilder.java
@@ -87,7 +87,7 @@ public class IterableLoopBuilder< T >
 
 	private final List< RandomAccessible< ? > > otherImages;
 
-	private IterableLoopBuilder( IterableInterval< ? > firstImage, RandomAccessible< ? > ... otherImages )
+	private IterableLoopBuilder( IterableInterval< ? > firstImage, RandomAccessible< ? >... otherImages )
 	{
 		this.firstImage = firstImage;
 		this.otherImages = Arrays.asList( otherImages );
@@ -112,7 +112,8 @@ public class IterableLoopBuilder< T >
 	/**
 	 * Sets the images to loop over.
 	 */
-	public static < A, B, C > IterableLoopBuilder< LoopBuilder.TriConsumer< A, B, C > > setImages( IterableInterval< A > a, RandomAccessible< B > b, RandomAccessible< C > c )
+	public static < A, B, C > IterableLoopBuilder< LoopBuilder.TriConsumer< A, B, C > > setImages( IterableInterval< A > a,
+			RandomAccessible< B > b, RandomAccessible< C > c )
 	{
 		return new IterableLoopBuilder<>( a, b, c );
 	}
@@ -133,7 +134,8 @@ public class IterableLoopBuilder< T >
 	 */
 	public < R > List< R > forEachChunk( Function< LoopBuilder.Chunk< T >, R > chunkAction )
 	{
-		List< Interval > intervals = IntervalChunks.chunkInterval( new FinalInterval( firstImage.size() ), taskExecutor.suggestNumberOfTasks() );
+		List< Interval > intervals =
+				IntervalChunks.chunkInterval( new FinalInterval( firstImage.size() ), taskExecutor.suggestNumberOfTasks() );
 		List< Chunk< T > > chunks = ListUtils.map( interval -> new Chunk< T >( firstImage, otherImages, interval ), intervals );
 		return taskExecutor.forEachApply( chunks, chunkAction );
 	}
@@ -157,7 +159,8 @@ public class IterableLoopBuilder< T >
 		return this;
 	}
 
-	private static class Chunk< T > implements LoopBuilder.Chunk< T > {
+	private static class Chunk< T > implements LoopBuilder.Chunk< T >
+	{
 
 		private final IterableInterval< ? > firstImage;
 
@@ -176,7 +179,8 @@ public class IterableLoopBuilder< T >
 		public void forEachPixel( T action )
 		{
 			Cursor< ? > cursor = firstImage.localizingCursor();
-			List< RandomAccess< ? > > randomAccesses = otherImages.stream().map( RandomAccessible::randomAccess ).collect( Collectors.toList());
+			List< RandomAccess< ? > > randomAccesses =
+					otherImages.stream().map( RandomAccessible::randomAccess ).collect( Collectors.toList() );
 			cursor.jumpFwd( interval.min( 0 ) );
 			long size = interval.dimension( 0 );
 			FastCursorRandomAccessLoops.loop( action, size, cursor, randomAccesses );

--- a/src/main/java/net/imglib2/loops/ListUtils.java
+++ b/src/main/java/net/imglib2/loops/ListUtils.java
@@ -43,46 +43,48 @@ public class ListUtils
 	static Object[] concatAsArray( Object action, List< ? > samplers )
 	{
 		Object[] result = new Object[ samplers.size() + 1 ];
-		result[0] = action;
+		result[ 0 ] = action;
 		for ( int i = 0; i < samplers.size(); i++ )
 			result[ i + 1 ] = samplers.get( i );
 		return result;
 	}
 
-	public static <T, R> List<R> map( final Function< T, R > function, final List< T > list ) {
-		List<R> result = new ArrayList<>( list.size() );
+	public static < T, R > List< R > map( final Function< T, R > function, final List< T > list )
+	{
+		List< R > result = new ArrayList<>( list.size() );
 		for ( T entry : list )
 			result.add( function.apply( entry ) );
 		return result;
 	}
 
-	public static <T> boolean allMatch( Predicate<T> predicate, List<T> list )
+	public static < T > boolean allMatch( Predicate< T > predicate, List< T > list )
 	{
 		for ( T entry : list )
-			if( !predicate.test( entry ) )
+			if ( !predicate.test( entry ) )
 				return false;
 		return true;
 	}
 
-	public static <T, R> List<R> map( final Function< T, R > function, final T[] list ) {
-		List<R> result = new ArrayList<>( list.length );
+	public static < T, R > List< R > map( final Function< T, R > function, final T[] list )
+	{
+		List< R > result = new ArrayList<>( list.length );
 		for ( T entry : list )
 			result.add( function.apply( entry ) );
 		return result;
 	}
 
-	public static <T> boolean allMatch( Predicate<T> predicate, T[] list )
+	public static < T > boolean allMatch( Predicate< T > predicate, T[] list )
 	{
 		for ( T entry : list )
-			if( !predicate.test( entry ) )
+			if ( !predicate.test( entry ) )
 				return false;
 		return true;
 	}
 
-	public static <T> boolean anyMatch( Predicate<T> predicate, T[] list )
+	public static < T > boolean anyMatch( Predicate< T > predicate, T[] list )
 	{
 		for ( T entry : list )
-			if( predicate.test( entry ) )
+			if ( predicate.test( entry ) )
 				return true;
 		return false;
 	}

--- a/src/main/java/net/imglib2/loops/LoopBuilder.java
+++ b/src/main/java/net/imglib2/loops/LoopBuilder.java
@@ -112,7 +112,8 @@ public class LoopBuilder< T >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B > LoopBuilder< BiConsumer< A, B > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b )
+	public static < A, B > LoopBuilder< BiConsumer< A, B > > setImages( final RandomAccessibleInterval< A > a,
+			final RandomAccessibleInterval< B > b )
 	{
 		return new LoopBuilder<>( a, b );
 	}
@@ -120,7 +121,8 @@ public class LoopBuilder< T >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C > LoopBuilder< TriConsumer< A, B, C > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c )
+	public static < A, B, C > LoopBuilder< TriConsumer< A, B, C > > setImages( final RandomAccessibleInterval< A > a,
+			final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c )
 	{
 		return new LoopBuilder<>( a, b, c );
 	}
@@ -128,7 +130,8 @@ public class LoopBuilder< T >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D > LoopBuilder< FourConsumer< A, B, C, D > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d )
+	public static < A, B, C, D > LoopBuilder< FourConsumer< A, B, C, D > > setImages( final RandomAccessibleInterval< A > a,
+			final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d )
 	{
 		return new LoopBuilder<>( a, b, c, d );
 	}
@@ -136,7 +139,9 @@ public class LoopBuilder< T >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D, E > LoopBuilder< FiveConsumer< A, B, C, D, E > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e )
+	public static < A, B, C, D, E > LoopBuilder< FiveConsumer< A, B, C, D, E > > setImages( final RandomAccessibleInterval< A > a,
+			final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d,
+			final RandomAccessibleInterval< E > e )
 	{
 		return new LoopBuilder<>( a, b, c, d, e );
 	}
@@ -144,7 +149,9 @@ public class LoopBuilder< T >
 	/**
 	 * @see LoopBuilder
 	 */
-	public static < A, B, C, D, E, F > LoopBuilder< SixConsumer< A, B, C, D, E, F > > setImages( final RandomAccessibleInterval< A > a, final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d, final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f )
+	public static < A, B, C, D, E, F > LoopBuilder< SixConsumer< A, B, C, D, E, F > > setImages( final RandomAccessibleInterval< A > a,
+			final RandomAccessibleInterval< B > b, final RandomAccessibleInterval< C > c, final RandomAccessibleInterval< D > d,
+			final RandomAccessibleInterval< E > e, final RandomAccessibleInterval< F > f )
 	{
 		return new LoopBuilder<>( a, b, c, d, e, f );
 	}
@@ -356,7 +363,8 @@ public class LoopBuilder< T >
 		return taskExecutor.forEachApply( chunks, chunk -> runOnChunkUsingRandomAccesses( images, chunkAction, chunk ) );
 	}
 
-	static < T, R > R runOnChunkUsingRandomAccesses( RandomAccessibleInterval[] images, Function< Chunk< T >, R > chunkAction, Interval subInterval )
+	static < T, R > R runOnChunkUsingRandomAccesses( RandomAccessibleInterval[] images, Function< Chunk< T >, R > chunkAction,
+			Interval subInterval )
 	{
 		final List< RandomAccess< ? > > samplers = ListUtils.map( LoopBuilder::initRandomAccess, images );
 		final Positionable synced = SyncedPositionables.create( samplers );
@@ -377,9 +385,7 @@ public class LoopBuilder< T >
 
 	private List< IterableInterval< ? > > imagesAsIterableIntervals()
 	{
-		return useFlatIterationOrder ?
-				flatIterableIntervals() :
-				equalIterationOrderIterableIntervals();
+		return useFlatIterationOrder ? flatIterableIntervals() : equalIterationOrderIterableIntervals();
 	}
 
 	private < R > List< R > runUsingCursors( List< IterableInterval< ? > > iterableIntervals, Function< Chunk< T >, R > chunkAction )
@@ -387,11 +393,12 @@ public class LoopBuilder< T >
 		int nTasks = taskExecutor.suggestNumberOfTasks();
 		final FinalInterval indices = new FinalInterval( Intervals.numElements( images[ 0 ] ) );
 		List< Interval > chunks = IntervalChunks.chunkInterval( indices, nTasks );
-		return taskExecutor.forEachApply( chunks, chunk ->
-				LoopBuilder.runOnChunkUsingCursors( iterableIntervals, chunkAction, chunk.min( 0 ), chunk.dimension( 0 ) ) );
+		return taskExecutor.forEachApply( chunks,
+				chunk -> LoopBuilder.runOnChunkUsingCursors( iterableIntervals, chunkAction, chunk.min( 0 ), chunk.dimension( 0 ) ) );
 	}
 
-	static < T, R > R runOnChunkUsingCursors( List< IterableInterval< ? > > iterableIntervals, Function< Chunk< T >, R > chunkAction, long offset, long numElements )
+	static < T, R > R runOnChunkUsingCursors( List< IterableInterval< ? > > iterableIntervals, Function< Chunk< T >, R > chunkAction,
+			long offset, long numElements )
 	{
 		final List< Cursor< ? > > cursors = ListUtils.map( IterableInterval::cursor, iterableIntervals );
 		if ( offset != 0 )

--- a/src/main/java/net/imglib2/loops/SyncedPositionables.java
+++ b/src/main/java/net/imglib2/loops/SyncedPositionables.java
@@ -93,7 +93,8 @@ public final class SyncedPositionables
 		return create( Arrays.asList( positionables ) );
 	}
 
-	static class Private {
+	static class Private
+	{
 
 		public interface Forwarder extends Positionable
 		{

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsMirrorExpWindowing.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsMirrorExpWindowing.java
@@ -73,7 +73,8 @@ public class OutOfBoundsMirrorExpWindowing< T extends NumericType< T > > extends
 		weights = outOfBounds.weights.clone();
 	}
 
-	public < F extends Interval & RandomAccessible< T > > OutOfBoundsMirrorExpWindowing( final F f, final int[] fadeOutDistance, final float exponent )
+	public < F extends Interval & RandomAccessible< T > > OutOfBoundsMirrorExpWindowing( final F f, final int[] fadeOutDistance,
+			final float exponent )
 	{
 		super( f );
 

--- a/src/main/java/net/imglib2/outofbounds/OutOfBoundsRandomValue.java
+++ b/src/main/java/net/imglib2/outofbounds/OutOfBoundsRandomValue.java
@@ -67,7 +67,8 @@ public class OutOfBoundsRandomValue< T extends RealType< T > > extends AbstractO
 		this.rnd = new Random();
 	}
 
-	public < F extends Interval & RandomAccessible< T > > OutOfBoundsRandomValue( final F f, final T value, final Random rnd, final double min, final double max )
+	public < F extends Interval & RandomAccessible< T > > OutOfBoundsRandomValue( final F f, final T value, final Random rnd,
+			final double min, final double max )
 	{
 		super( f );
 

--- a/src/main/java/net/imglib2/parallel/ForkJoinExecutorService.java
+++ b/src/main/java/net/imglib2/parallel/ForkJoinExecutorService.java
@@ -76,8 +76,7 @@ public class ForkJoinExecutorService extends AbstractExecutorService
 
 	@Override
 	public void shutdown()
-	{
-	}
+	{}
 
 	@Override
 	public List< Runnable > shutdownNow()
@@ -98,8 +97,7 @@ public class ForkJoinExecutorService extends AbstractExecutorService
 	}
 
 	@Override
-	public boolean awaitTermination( long l, TimeUnit timeUnit ) throws
-			InterruptedException
+	public boolean awaitTermination( long l, TimeUnit timeUnit ) throws InterruptedException
 	{
 		// NB: it's possible to implement this method. One might use a set of weak references to collect all tasks submitted.
 		// And this method call ForkJoinTask.get( long, timeUnit), to get the timing correct.
@@ -110,8 +108,7 @@ public class ForkJoinExecutorService extends AbstractExecutorService
 	}
 
 	@Override
-	public < T > List< Future< T > > invokeAll( Collection< ? extends Callable< T > > collection ) throws
-			InterruptedException
+	public < T > List< Future< T > > invokeAll( Collection< ? extends Callable< T > > collection ) throws InterruptedException
 	{
 		// TODO: Revisit if we ever drop support for Java 8.
 		//  For Java 11, the code below could be replaced by
@@ -128,8 +125,8 @@ public class ForkJoinExecutorService extends AbstractExecutorService
 	}
 
 	@Override
-	public < T > List< Future< T > > invokeAll( Collection< ? extends Callable< T > > collection, long l, TimeUnit timeUnit ) throws
-			InterruptedException
+	public < T > List< Future< T > > invokeAll( Collection< ? extends Callable< T > > collection, long l, TimeUnit timeUnit )
+			throws InterruptedException
 	{
 		throw new UnsupportedOperationException( "ForkJoinExecutorService, invokeAll with timeout is not implemented." );
 	}

--- a/src/main/java/net/imglib2/parallel/SequentialExecutorService.java
+++ b/src/main/java/net/imglib2/parallel/SequentialExecutorService.java
@@ -74,8 +74,7 @@ public class SequentialExecutorService extends AbstractExecutorService
 	}
 
 	@Override
-	public boolean awaitTermination( long l, TimeUnit timeUnit ) throws
-			InterruptedException
+	public boolean awaitTermination( long l, TimeUnit timeUnit ) throws InterruptedException
 	{
 		return true;
 	}

--- a/src/main/java/net/imglib2/parallel/SequentialTaskExecutor.java
+++ b/src/main/java/net/imglib2/parallel/SequentialTaskExecutor.java
@@ -86,7 +86,7 @@ class SequentialTaskExecutor implements TaskExecutor
 	@Override
 	public < T > void forEach( List< ? extends T > parameters, Consumer< ? super T > task )
 	{
-		for( T value : parameters )
+		for ( T value : parameters )
 			task.accept( value );
 	}
 

--- a/src/main/java/net/imglib2/parallel/TaskExecutors.java
+++ b/src/main/java/net/imglib2/parallel/TaskExecutors.java
@@ -162,7 +162,8 @@ public final class TaskExecutors
 	 * to the thread. The threads created, are using the given thread factory,
 	 * and the {@link TaskExecutors} are create using the given supplier.
 	 */
-	public static ThreadFactory applyTaskExecutorToThreadFactory( Supplier< TaskExecutor > taskExecutorFactory, ThreadFactory threadFactory )
+	public static ThreadFactory applyTaskExecutorToThreadFactory( Supplier< TaskExecutor > taskExecutorFactory,
+			ThreadFactory threadFactory )
 	{
 		return runnable -> threadFactory.newThread( () -> {
 			try (TaskExecutor taskExecutor = taskExecutorFactory.get())

--- a/src/main/java/net/imglib2/position/AbstractFunctionEuclideanSpace.java
+++ b/src/main/java/net/imglib2/position/AbstractFunctionEuclideanSpace.java
@@ -48,7 +48,9 @@ import net.imglib2.EuclideanSpace;
 public abstract class AbstractFunctionEuclideanSpace< P, T > implements EuclideanSpace
 {
 	protected final int n;
+
 	protected final Supplier< BiConsumer< P, ? super T > > functionSupplier;
+
 	protected final Supplier< T > typeSupplier;
 
 	/**
@@ -81,7 +83,7 @@ public abstract class AbstractFunctionEuclideanSpace< P, T > implements Euclidea
 			final BiConsumer< P, ? super T > function,
 			final Supplier< T > typeSupplier )
 	{
-		this(n, () -> function, typeSupplier);
+		this( n, () -> function, typeSupplier );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/position/FunctionRandomAccessible.java
+++ b/src/main/java/net/imglib2/position/FunctionRandomAccessible.java
@@ -57,7 +57,7 @@ public class FunctionRandomAccessible< T > extends AbstractFunctionEuclideanSpac
 			final BiConsumer< Localizable, ? super T > function,
 			final Supplier< T > typeSupplier )
 	{
-		super(n, function, typeSupplier);
+		super( n, function, typeSupplier );
 	}
 
 	public FunctionRandomAccessible(
@@ -65,12 +65,13 @@ public class FunctionRandomAccessible< T > extends AbstractFunctionEuclideanSpac
 			final Supplier< BiConsumer< Localizable, ? super T > > functionSupplier,
 			final Supplier< T > typeSupplier )
 	{
-		super(n, functionSupplier, typeSupplier);
+		super( n, functionSupplier, typeSupplier );
 	}
 
 	public class FunctionRandomAccess extends Point implements RandomAccess< T >
 	{
 		private final T t = typeSupplier.get();
+
 		private final BiConsumer< Localizable, ? super T > function = functionSupplier.get();
 
 		public FunctionRandomAccess()

--- a/src/main/java/net/imglib2/position/FunctionRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/position/FunctionRealRandomAccessible.java
@@ -49,7 +49,8 @@ import net.imglib2.RealRandomAccessible;
  *
  * @author Stephan Saalfeld
  */
-public class FunctionRealRandomAccessible< T > extends AbstractFunctionEuclideanSpace< RealLocalizable, T > implements RealRandomAccessible< T >
+public class FunctionRealRandomAccessible< T > extends AbstractFunctionEuclideanSpace< RealLocalizable, T >
+		implements RealRandomAccessible< T >
 {
 	public FunctionRealRandomAccessible(
 			final int n,
@@ -70,6 +71,7 @@ public class FunctionRealRandomAccessible< T > extends AbstractFunctionEuclidean
 	public class RealFunctionRealRandomAccess extends RealPoint implements RealRandomAccess< T >
 	{
 		private final T t = typeSupplier.get();
+
 		private final BiConsumer< RealLocalizable, ? super T > function = functionSupplier.get();
 
 		public RealFunctionRealRandomAccess()

--- a/src/main/java/net/imglib2/position/PositionRandomAccessible.java
+++ b/src/main/java/net/imglib2/position/PositionRandomAccessible.java
@@ -54,6 +54,7 @@ import net.imglib2.type.numeric.integer.LongType;
 public class PositionRandomAccessible implements RandomAccessible< LongType >
 {
 	private final int n;
+
 	private final int d;
 
 	public PositionRandomAccessible( final int numDimensions, final int d )

--- a/src/main/java/net/imglib2/position/RealPositionRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/position/RealPositionRealRandomAccessible.java
@@ -54,6 +54,7 @@ import net.imglib2.type.numeric.real.DoubleType;
 public class RealPositionRealRandomAccessible implements RealRandomAccessible< DoubleType >
 {
 	private final int n;
+
 	private final int d;
 
 	public RealPositionRealRandomAccessible( final int numDimensions, final int d )

--- a/src/main/java/net/imglib2/position/transform/AbstractPositionableTransform.java
+++ b/src/main/java/net/imglib2/position/transform/AbstractPositionableTransform.java
@@ -46,7 +46,8 @@ import net.imglib2.RealPositionable;
  *
  * @author Stephan Saalfeld
  */
-public abstract class AbstractPositionableTransform< LocalizablePositionable extends Localizable & Positionable > extends AbstractEuclideanSpace implements RealPositionable, RealLocalizable
+public abstract class AbstractPositionableTransform< LocalizablePositionable extends Localizable & Positionable >
+		extends AbstractEuclideanSpace implements RealPositionable, RealLocalizable
 {
 	final protected LocalizablePositionable target;
 

--- a/src/main/java/net/imglib2/position/transform/Floor.java
+++ b/src/main/java/net/imglib2/position/transform/Floor.java
@@ -48,7 +48,8 @@ import net.imglib2.RealPositionable;
  *
  * @author Stephan Saalfeld
  */
-public class Floor< LocalizablePositionable extends Localizable & Positionable > extends AbstractPositionableTransform< LocalizablePositionable >
+public class Floor< LocalizablePositionable extends Localizable & Positionable >
+		extends AbstractPositionableTransform< LocalizablePositionable >
 {
 	public Floor( final LocalizablePositionable target )
 	{

--- a/src/main/java/net/imglib2/position/transform/FloorOffset.java
+++ b/src/main/java/net/imglib2/position/transform/FloorOffset.java
@@ -48,7 +48,8 @@ import net.imglib2.RealPositionable;
  *
  * @author Stephan Saalfeld
  */
-public class FloorOffset< LocalizablePositionable extends Localizable & Positionable > extends AbstractPositionableTransform< LocalizablePositionable >
+public class FloorOffset< LocalizablePositionable extends Localizable & Positionable >
+		extends AbstractPositionableTransform< LocalizablePositionable >
 {
 	final protected long[] offset;
 

--- a/src/main/java/net/imglib2/position/transform/Round.java
+++ b/src/main/java/net/imglib2/position/transform/Round.java
@@ -47,7 +47,8 @@ import net.imglib2.RealPositionable;
  *
  * @author Stephan Saalfeld
  */
-public class Round< LocalizablePositionable extends Localizable & Positionable > extends AbstractPositionableTransform< LocalizablePositionable >
+public class Round< LocalizablePositionable extends Localizable & Positionable >
+		extends AbstractPositionableTransform< LocalizablePositionable >
 {
 	public Round( final LocalizablePositionable target )
 	{

--- a/src/main/java/net/imglib2/test/ImgLib2Assert.java
+++ b/src/main/java/net/imglib2/test/ImgLib2Assert.java
@@ -64,7 +64,8 @@ public class ImgLib2Assert
 	 * {@link ValueEquals#valueEquals(Object)}.
 	 */
 	public static < A extends ValueEquals< B >, B >
-			void assertImageEquals( final RandomAccessibleInterval< ? extends A > expected, final RandomAccessibleInterval< ? extends B > actual )
+			void assertImageEquals( final RandomAccessibleInterval< ? extends A > expected,
+					final RandomAccessibleInterval< ? extends B > actual )
 	{
 		assertImageEquals( expected, actual, ValueEquals::valueEquals );
 	}
@@ -75,7 +76,8 @@ public class ImgLib2Assert
 	 * if the values returned by {@link RealType#getRealDouble()} differ by less
 	 * than "tolerance".
 	 */
-	public static void assertImageEqualsRealType( final RandomAccessibleInterval< ? extends RealType< ? > > expected, final RandomAccessibleInterval< ? extends RealType< ? > > actual, final double tolerance )
+	public static void assertImageEqualsRealType( final RandomAccessibleInterval< ? extends RealType< ? > > expected,
+			final RandomAccessibleInterval< ? extends RealType< ? > > actual, final double tolerance )
 	{
 		assertImageEquals( expected, actual, ( a, e ) -> Math.abs( a.getRealDouble() - e.getRealDouble() ) <= tolerance );
 	}
@@ -85,7 +87,8 @@ public class ImgLib2Assert
 	 * differ. Comparision is done pixel wise. Two pixels are considered equal,
 	 * if the values returned by {@link IntegerType#getIntegerLong()} are equal.
 	 */
-	public static void assertImageEqualsIntegerType( final RandomAccessibleInterval< ? extends IntegerType< ? > > expected, final RandomAccessibleInterval< ? extends IntegerType< ? > > actual )
+	public static void assertImageEqualsIntegerType( final RandomAccessibleInterval< ? extends IntegerType< ? > > expected,
+			final RandomAccessibleInterval< ? extends IntegerType< ? > > actual )
 	{
 		assertImageEquals( expected, actual, ( a, e ) -> a.getIntegerLong() == e.getIntegerLong() );
 	}
@@ -96,7 +99,8 @@ public class ImgLib2Assert
 	 * if the give predicate returns true.
 	 */
 	public static < A, B >
-			void assertImageEquals( final RandomAccessibleInterval< ? extends A > expected, final RandomAccessibleInterval< ? extends B > actual, final BiPredicate< A, B > equals )
+			void assertImageEquals( final RandomAccessibleInterval< ? extends A > expected,
+					final RandomAccessibleInterval< ? extends B > actual, final BiPredicate< A, B > equals )
 	{
 		assertIntervalEquals( expected, actual );
 		final IntervalView< ? extends Pair< ? extends A, ? extends B > > pairs = Views.interval( Views.pair( expected, actual ), actual );

--- a/src/main/java/net/imglib2/test/RandomImgs.java
+++ b/src/main/java/net/imglib2/test/RandomImgs.java
@@ -103,7 +103,7 @@ public class RandomImgs
 	 * @return Reference to the given image
 	 */
 	public < I extends RandomAccessibleInterval< T >, T >
-	I randomize( final I image )
+			I randomize( final I image )
 	{
 		final T type = Util.getTypeFromInterval( image );
 		Views.iterable( image ).forEach( randomSetter( type ) );

--- a/src/main/java/net/imglib2/transform/integer/ComponentMappingTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/ComponentMappingTransform.java
@@ -54,7 +54,8 @@ import net.imglib2.concatenate.PreConcatenable;
  * 
  * @author Tobias Pietzsch
  */
-public class ComponentMappingTransform extends AbstractMixedTransform implements ComponentMapping, Concatenable< ComponentMapping >, PreConcatenable< ComponentMapping >
+public class ComponentMappingTransform extends AbstractMixedTransform
+		implements ComponentMapping, Concatenable< ComponentMapping >, PreConcatenable< ComponentMapping >
 {
 	/**
 	 * for each component of the target vector: from which source vector

--- a/src/main/java/net/imglib2/transform/integer/MixedTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/MixedTransform.java
@@ -502,7 +502,10 @@ public class MixedTransform extends AbstractMixedTransform implements Concatenab
 		}
 		for ( int d = 0; d < numSourceDimensions; ++d )
 		{
-			if ( !sourceMapped[ d ] ) { return false; }
+			if ( !sourceMapped[ d ] )
+			{
+				return false;
+			}
 		}
 		return true;
 	}

--- a/src/main/java/net/imglib2/transform/integer/SlicingTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/SlicingTransform.java
@@ -385,7 +385,10 @@ public class SlicingTransform extends AbstractMixedTransform implements Slicing,
 		}
 		for ( int d = 0; d < numSourceDimensions; ++d )
 		{
-			if ( !sourceMapped[ d ] ) { return false; }
+			if ( !sourceMapped[ d ] )
+			{
+				return false;
+			}
 		}
 		return true;
 	}

--- a/src/main/java/net/imglib2/transform/integer/TranslationTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/TranslationTransform.java
@@ -43,7 +43,8 @@ import net.imglib2.concatenate.PreConcatenable;
  * TODO
  * 
  */
-public class TranslationTransform extends AbstractMixedTransform implements Translation, Concatenable< Translation >, PreConcatenable< Translation >
+public class TranslationTransform extends AbstractMixedTransform
+		implements Translation, Concatenable< Translation >, PreConcatenable< Translation >
 {
 	/**
 	 * target = source + translation.
@@ -209,7 +210,8 @@ public class TranslationTransform extends AbstractMixedTransform implements Tran
 			source.setPosition( target.getLongPosition( d ) - translation[ d ], d );
 	}
 
-	public class InverseTranslationTransform extends AbstractMixedTransform implements Translation, Concatenable< Translation >, PreConcatenable< Translation >
+	public class InverseTranslationTransform extends AbstractMixedTransform
+			implements Translation, Concatenable< Translation >, PreConcatenable< Translation >
 	{
 		InverseTranslationTransform( final int targetDim )
 		{

--- a/src/main/java/net/imglib2/transform/integer/permutation/PermutationTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/permutation/PermutationTransform.java
@@ -102,7 +102,8 @@ public class PermutationTransform extends AbstractPermutationTransform
 	@Override
 	public void apply( final Localizable source, final Positionable target )
 	{
-		assert source.numDimensions() >= this.numTargetDimensions && target.numDimensions() >= this.numTargetDimensions: "Dimensions do not match.";
+		assert source.numDimensions() >= this.numTargetDimensions && target.numDimensions() >= this.numTargetDimensions
+				: "Dimensions do not match.";
 
 		for ( int d = 0; d < this.numTargetDimensions; ++d )
 			target.setPosition( this.apply( source.getIntPosition( d ) ), d );
@@ -129,7 +130,8 @@ public class PermutationTransform extends AbstractPermutationTransform
 	@Override
 	public void applyInverse( final Positionable source, final Localizable target )
 	{
-		assert source.numDimensions() >= this.numSourceDimensions && target.numDimensions() >= this.numSourceDimensions: "Dimensions do not match.";
+		assert source.numDimensions() >= this.numSourceDimensions && target.numDimensions() >= this.numSourceDimensions
+				: "Dimensions do not match.";
 
 		for ( int d = 0; d < this.numSourceDimensions; ++d )
 			source.setPosition( this.applyInverse( target.getIntPosition( d ) ), d );

--- a/src/main/java/net/imglib2/transform/integer/shear/AbstractShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/AbstractShearTransform.java
@@ -56,15 +56,15 @@ import net.imglib2.transform.integer.BoundingBoxTransform;
  */
 public abstract class AbstractShearTransform implements InvertibleTransform, BoundingBoxTransform
 {
-	
-	
+
 	protected final int nDim;
+
 	protected final int shearDimension;
+
 	protected final int referenceDimension;
-	
+
 	protected AbstractShearTransform inverse;
-	
-	
+
 	protected AbstractShearTransform(
 			int nDim,
 			int shearDimension,
@@ -72,87 +72,75 @@ public abstract class AbstractShearTransform implements InvertibleTransform, Bou
 	{
 		this( nDim, shearDimension, referenceDimension, null );
 	}
-	
-	
+
 	protected AbstractShearTransform(
 			int nDim,
 			int shearDimension,
 			int referenceDimension,
 			AbstractShearTransform inverse )
 	{
-		this.nDim               = nDim;
-		this.shearDimension     = shearDimension;
+		this.nDim = nDim;
+		this.shearDimension = shearDimension;
 		this.referenceDimension = referenceDimension;
-		this.inverse            = inverse;
+		this.inverse = inverse;
 	}
-	
-	
-	public int getReferenceDimension() {
+
+	public int getReferenceDimension()
+	{
 		return referenceDimension;
 	}
 
-
 	@Override
-	public int numSourceDimensions() 
+	public int numSourceDimensions()
 	{
 		return this.numDimensions();
 	}
-	
 
 	@Override
-	public int numTargetDimensions() 
+	public int numTargetDimensions()
 	{
 		return this.numDimensions();
 	}
-	
-	
-	public int numDimensions() 
+
+	public int numDimensions()
 	{
 		return nDim;
 	}
-	
-	
+
 	public int getShearDimension()
 	{
 		return this.shearDimension;
 	}
-	
 
 	@Override
-	public void applyInverse( long[] source, long[] target ) 
+	public void applyInverse( long[] source, long[] target )
 	{
 		// for inverse, source and target need to be switched
 		this.inverse.apply( target, source );
 	}
-	
 
 	@Override
-	public void applyInverse(int[] source, int[] target) 
+	public void applyInverse( int[] source, int[] target )
 	{
 		// for inverse, source and target need to be switched
 		this.inverse.apply( target, source );
 	}
-	
 
 	@Override
-	public void applyInverse( Positionable source, Localizable target ) 
+	public void applyInverse( Positionable source, Localizable target )
 	{
 		// for inverse, source and target need to be switched
 		this.inverse.apply( target, source );
 	}
-	
 
 	@Override
-	public AbstractShearTransform inverse() 
+	public AbstractShearTransform inverse()
 	{
 		return this.inverse;
 	}
-	
-	
+
 	public abstract long[] getShear();
 
-	
 	public abstract AbstractShearTransform copy();
-	
-	
+
 }

--- a/src/main/java/net/imglib2/transform/integer/shear/InverseShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/InverseShearTransform.java
@@ -50,8 +50,7 @@ import net.imglib2.transform.integer.BoundingBox;
  */
 public class InverseShearTransform extends AbstractShearTransform
 {
-	
-	
+
 	/**
 	 * @param nDim					Number of dimensions (source and target dimensions must be the same)
 	 * @param shearDimension		Dimension to be sheared.
@@ -63,14 +62,13 @@ public class InverseShearTransform extends AbstractShearTransform
 			int referenceDimension )
 	{
 		super( nDim, shearDimension, referenceDimension );
-		this.inverse = new ShearTransform( 
-				nDim, 
+		this.inverse = new ShearTransform(
+				nDim,
 				shearDimension,
 				referenceDimension,
 				this );
 	}
 
-	
 	/**
 	 * Protected constructor for passing an inverse to avoid construction of unnecessary objects.
 	 * 
@@ -79,24 +77,22 @@ public class InverseShearTransform extends AbstractShearTransform
 	 * @param referenceDimension	Dimension used as reference for shear.
 	 * @param inverse				
 	 */
-	protected InverseShearTransform( 
-			int nDim, 
+	protected InverseShearTransform(
+			int nDim,
 			int shearDimension,
-			int referenceDimension, 
+			int referenceDimension,
 			AbstractShearTransform inverse )
 	{
 		super( nDim, shearDimension, referenceDimension, inverse );
 	}
 
-
 	@Override
-	public void apply( long[] source, long[] target ) 
+	public void apply( long[] source, long[] target )
 	{
 		assert source.length >= this.nDim && target.length >= nDim;
 		System.arraycopy( source, 0, target, 0, source.length );
 		target[ shearDimension ] -= target[ referenceDimension ];
 	}
-	
 
 	@Override
 	public void apply( int[] source, int[] target )
@@ -105,10 +101,9 @@ public class InverseShearTransform extends AbstractShearTransform
 		System.arraycopy( source, 0, target, 0, source.length );
 		target[ shearDimension ] -= target[ referenceDimension ];
 	}
-	
 
 	@Override
-	public void apply( Localizable source, Positionable target ) 
+	public void apply( Localizable source, Positionable target )
 	{
 		assert source.numDimensions() >= this.nDim && target.numDimensions() >= nDim;
 		target.setPosition( source );
@@ -121,25 +116,23 @@ public class InverseShearTransform extends AbstractShearTransform
 		return new InverseShearTransform( nDim, shearDimension, referenceDimension ); // return this; ?
 	}
 
-
 	@Override
-	public long[] getShear() 
+	public long[] getShear()
 	{
 		long[] shear = new long[ this.nDim ];
 		shear[ this.shearDimension ] = -1;
 		return shear;
 	}
 
-	
-	@Override public BoundingBox transform( BoundingBox bb )
+	@Override
+	public BoundingBox transform( BoundingBox bb )
 	{
 		bb.orderMinMax();
 		long[] c = bb.corner1;
 		// assume that corner2[ i ] > corner1[ i ]
 		long diff = bb.corner2[ this.referenceDimension ] - c[ this.referenceDimension ];
-		c[ this.shearDimension ] -=diff;
+		c[ this.shearDimension ] -= diff;
 		return bb;
 	}
 
-	
 }

--- a/src/main/java/net/imglib2/transform/integer/shear/ShearTransform.java
+++ b/src/main/java/net/imglib2/transform/integer/shear/ShearTransform.java
@@ -49,7 +49,6 @@ import net.imglib2.transform.integer.BoundingBox;
  */
 public class ShearTransform extends AbstractShearTransform
 {
-	
 
 	/**
 	 * @param nDim					Number of dimensions (source and target dimensions must be the same)
@@ -57,19 +56,18 @@ public class ShearTransform extends AbstractShearTransform
 	 * @param referenceDimension	Dimension used as reference for shear.
 	 */
 	public ShearTransform(
-			int nDim, 
+			int nDim,
 			int shearDimension,
-			int referenceDimension ) 
+			int referenceDimension )
 	{
 		super( nDim, shearDimension, referenceDimension );
-		this.inverse = new InverseShearTransform( 
-				nDim, 
+		this.inverse = new InverseShearTransform(
+				nDim,
 				shearDimension,
 				referenceDimension,
 				this );
 	}
-	
-	
+
 	/**
 	 * Protected constructor for passing an inverse to avoid construction of unnecessary objects.
 	 * 
@@ -78,24 +76,22 @@ public class ShearTransform extends AbstractShearTransform
 	 * @param referenceDimension	Dimension used as reference for shear.
 	 * @param inverse				
 	 */
-	protected ShearTransform( 
-			int nDim, 
+	protected ShearTransform(
+			int nDim,
 			int shearDimension,
-			int referenceDimension, 
-			AbstractShearTransform inverse ) 
+			int referenceDimension,
+			AbstractShearTransform inverse )
 	{
 		super( nDim, shearDimension, referenceDimension, inverse );
 	}
 
-
 	@Override
-	public void apply( long[] source, long[] target ) 
+	public void apply( long[] source, long[] target )
 	{
 		assert source.length >= this.nDim && target.length >= nDim;
 		System.arraycopy( source, 0, target, 0, source.length );
 		target[ shearDimension ] += target[ referenceDimension ];
 	}
-	
 
 	@Override
 	public void apply( int[] source, int[] target )
@@ -104,24 +100,21 @@ public class ShearTransform extends AbstractShearTransform
 		System.arraycopy( source, 0, target, 0, source.length );
 		target[ shearDimension ] += target[ referenceDimension ];
 	}
-	
 
 	@Override
-	public void apply( Localizable source, Positionable target ) 
+	public void apply( Localizable source, Positionable target )
 	{
 		assert source.numDimensions() >= this.nDim && target.numDimensions() >= nDim;
 		target.setPosition( source );
 		target.setPosition( source.getLongPosition( shearDimension ) + source.getLongPosition( referenceDimension ), shearDimension );
 	}
-	
 
 	@Override
 	public ShearTransform copy()
 	{
-//		do just return this; ?
+		//		do just return this; ?
 		return new ShearTransform( this.nDim, this.shearDimension, this.referenceDimension );
 	}
-
 
 	@Override
 	public long[] getShear()
@@ -130,17 +123,16 @@ public class ShearTransform extends AbstractShearTransform
 		shear[ this.shearDimension ] = 1;
 		return shear;
 	}
-	
-	
-	@Override public BoundingBox transform( BoundingBox bb )
+
+	@Override
+	public BoundingBox transform( BoundingBox bb )
 	{
 		bb.orderMinMax();
 		long[] c = bb.corner2;
 		// assume that corner2[ i ] > corner1[ i ]
 		long diff = c[ this.referenceDimension ] - bb.corner1[ this.referenceDimension ];
-		c[ this.shearDimension ] +=diff;
+		c[ this.shearDimension ] += diff;
 		return bb;
 	}
-	
 
 }

--- a/src/main/java/net/imglib2/type/AbstractBit64Type.java
+++ b/src/main/java/net/imglib2/type/AbstractBit64Type.java
@@ -32,7 +32,6 @@
  * #L%
  */
 
-
 package net.imglib2.type;
 
 import net.imglib2.img.NativeImg;
@@ -71,7 +70,7 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 		else if ( nBits == 64 )
 			this.mask = -1l; // all 1s
 		else
-			this.mask = ((long)(Math.pow(2, nBits) -1));
+			this.mask = ( ( long ) ( Math.pow( 2, nBits ) - 1 ) );
 		this.invMask = ~mask;
 	}
 
@@ -91,7 +90,10 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 	}
 
 	// this is the constructor if you want it to be a variable
-	public AbstractBit64Type( final int nBits ) { this( 0, nBits ); }
+	public AbstractBit64Type( final int nBits )
+	{
+		this( 0, nBits );
+	}
 
 	/**
 	 * Writes the current "subLong" location of the LongAccess into the lower nBits bits of the long value
@@ -101,24 +103,31 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 	 *
 	 * @return
 	 */
-	protected long getBits() {
+	protected long getBits()
+	{
 		final long k = i.get() * nBits;
-		final int i1 = (int)(k >>> 6); // k / 64;
+		final int i1 = ( int ) ( k >>> 6 ); // k / 64;
 		final long shift = k & 63; // Same as k % 64;
-		final long v = dataAccess.getValue(i1);
-		if (0 == shift) {
+		final long v = dataAccess.getValue( i1 );
+		if ( 0 == shift )
+		{
 			// Number contained in a single long, ending exactly at the first bit
 			return v & mask;
-		} else {
+		}
+		else
+		{
 			final long antiShift = 64 - shift;
-			if (antiShift < nBits) {
+			if ( antiShift < nBits )
+			{
 				// Number split between two adjacent long
-				final long v1 = (v >>> shift) & (mask >>> (nBits - antiShift)); // lower part, stored at the upper end
-				final long v2 = (dataAccess.getValue(i1 + 1) & (mask >>> antiShift)) << antiShift; // upper part, stored at the lower end
+				final long v1 = ( v >>> shift ) & ( mask >>> ( nBits - antiShift ) ); // lower part, stored at the upper end
+				final long v2 = ( dataAccess.getValue( i1 + 1 ) & ( mask >>> antiShift ) ) << antiShift; // upper part, stored at the lower end
 				return v1 | v2;
-			} else {
+			}
+			else
+			{
 				// Number contained inside a single long
-				return (v >>> shift) & mask;
+				return ( v >>> shift ) & mask;
 			}
 		}
 	}
@@ -131,36 +140,47 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 	 *
 	 * @param value
 	 */
-	protected void setBits( final long value ) {
+	protected void setBits( final long value )
+	{
 		final long k = i.get() * nBits;
-		final int i1 = (int)(k >>> 6); // k / 64;
+		final int i1 = ( int ) ( k >>> 6 ); // k / 64;
 		final long shift = k & 63; // Same as k % 64;
 		final long safeValue = value & mask;
-		synchronized ( dataAccess ) {
-			if (0 == shift) {
+		synchronized ( dataAccess )
+		{
+			if ( 0 == shift )
+			{
 				// Number contained in a single long, ending exactly at the first bit
-				dataAccess.setValue(i1, (dataAccess.getValue(i1) & invMask) | safeValue);
-			} else {
+				dataAccess.setValue( i1, ( dataAccess.getValue( i1 ) & invMask ) | safeValue );
+			}
+			else
+			{
 				final long antiShift = 64 - shift;
-				final long v = dataAccess.getValue(i1);
-				if (antiShift < nBits) {
+				final long v = dataAccess.getValue( i1 );
+				if ( antiShift < nBits )
+				{
 					// Number split between two adjacent longs
 					// 1. Store the lower bits of safeValue at the upper bits of v1
-					final long v1 = (v & (0xffffffffffffffffL >>> antiShift)) // clear upper bits, keep other values
-							| ((safeValue & (mask >>> (nBits - antiShift))) << shift); // the lower part of safeValue, stored at the upper end
-					dataAccess.setValue(i1, v1);
+					final long v1 = ( v & ( 0xffffffffffffffffL >>> antiShift ) ) // clear upper bits, keep other values
+							| ( ( safeValue & ( mask >>> ( nBits - antiShift ) ) ) << shift ); // the lower part of safeValue, stored at the upper end
+					dataAccess.setValue( i1, v1 );
 					// 2. Store the upper bits of safeValue at the lower bits of v2
-					final long v2 = (dataAccess.getValue(i1 + 1) & (0xffffffffffffffffL << (nBits - antiShift))) // other
-							| (safeValue >>> antiShift); // upper part of safeValue, stored at the lower end
-					dataAccess.setValue(i1 + 1, v2);
-				} else {
+					final long v2 = ( dataAccess.getValue( i1 + 1 ) & ( 0xffffffffffffffffL << ( nBits - antiShift ) ) ) // other
+							| ( safeValue >>> antiShift ); // upper part of safeValue, stored at the lower end
+					dataAccess.setValue( i1 + 1, v2 );
+				}
+				else
+				{
 					// Number contained inside a single long
-					if (0 == v) {
+					if ( 0 == v )
+					{
 						// Trivial case
-						dataAccess.setValue(i1, safeValue << shift);
-					} else {
+						dataAccess.setValue( i1, safeValue << shift );
+					}
+					else
+					{
 						// Clear the bits first
-						dataAccess.setValue(i1, (v & ~(mask << shift)) | (safeValue << shift));
+						dataAccess.setValue( i1, ( v & ~( mask << shift ) ) | ( safeValue << shift ) );
 					}
 				}
 			}

--- a/src/main/java/net/imglib2/type/AbstractNativeType.java
+++ b/src/main/java/net/imglib2/type/AbstractNativeType.java
@@ -40,7 +40,7 @@ package net.imglib2.type;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public abstract class AbstractNativeType< T extends AbstractNativeType< T >> implements NativeType< T >
+public abstract class AbstractNativeType< T extends AbstractNativeType< T > > implements NativeType< T >
 {
 	protected final Index i;
 

--- a/src/main/java/net/imglib2/type/BasePairType.java
+++ b/src/main/java/net/imglib2/type/BasePairType.java
@@ -42,7 +42,7 @@ import net.imglib2.type.label.BasePairBitType.Base;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface BasePairType< T extends BasePairType< T >> extends Type< T >, Comparable< T >
+public interface BasePairType< T extends BasePairType< T > > extends Type< T >, Comparable< T >
 {
 	void set( Base base );
 

--- a/src/main/java/net/imglib2/type/Index.java
+++ b/src/main/java/net/imglib2/type/Index.java
@@ -56,7 +56,7 @@ public final class Index
 	 * This is used by accessors (e.g., a {@code Cursor}) to position {@code
 	 * NativeType}s in the container.
 	 */
-	public void set( final int index)
+	public void set( final int index )
 	{
 		i = index;
 	}

--- a/src/main/java/net/imglib2/type/NativeTypeFactory.java
+++ b/src/main/java/net/imglib2/type/NativeTypeFactory.java
@@ -112,42 +112,50 @@ public final class NativeTypeFactory< T extends NativeType< T >, A >
 		return createLinkedType.apply( img );
 	}
 
-	public static < T extends NativeType< T >, A extends BooleanAccess > NativeTypeFactory< T, A > BOOLEAN( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	public static < T extends NativeType< T >, A extends BooleanAccess > NativeTypeFactory< T, A >
+			BOOLEAN( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
 	{
 		return new NativeTypeFactory<>( PrimitiveType.BOOLEAN, createLinkedType );
 	}
 
-	public static < T extends NativeType< T >, A extends ByteAccess > NativeTypeFactory< T, A > BYTE( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	public static < T extends NativeType< T >, A extends ByteAccess > NativeTypeFactory< T, A >
+			BYTE( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
 	{
 		return new NativeTypeFactory<>( PrimitiveType.BYTE, createLinkedType );
 	}
 
-	public static < T extends NativeType< T >, A extends CharAccess > NativeTypeFactory< T, A > CHAR( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	public static < T extends NativeType< T >, A extends CharAccess > NativeTypeFactory< T, A >
+			CHAR( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
 	{
 		return new NativeTypeFactory<>( PrimitiveType.CHAR, createLinkedType );
 	}
 
-	public static < T extends NativeType< T >, A extends ShortAccess > NativeTypeFactory< T, A > SHORT( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	public static < T extends NativeType< T >, A extends ShortAccess > NativeTypeFactory< T, A >
+			SHORT( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
 	{
 		return new NativeTypeFactory<>( PrimitiveType.SHORT, createLinkedType );
 	}
 
-	public static < T extends NativeType< T >, A extends IntAccess > NativeTypeFactory< T, A > INT( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	public static < T extends NativeType< T >, A extends IntAccess > NativeTypeFactory< T, A >
+			INT( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
 	{
 		return new NativeTypeFactory<>( PrimitiveType.INT, createLinkedType );
 	}
 
-	public static < T extends NativeType< T >, A extends LongAccess > NativeTypeFactory< T, A > LONG( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	public static < T extends NativeType< T >, A extends LongAccess > NativeTypeFactory< T, A >
+			LONG( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
 	{
 		return new NativeTypeFactory<>( PrimitiveType.LONG, createLinkedType );
 	}
 
-	public static < T extends NativeType< T >, A extends FloatAccess > NativeTypeFactory< T, A > FLOAT( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	public static < T extends NativeType< T >, A extends FloatAccess > NativeTypeFactory< T, A >
+			FLOAT( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
 	{
 		return new NativeTypeFactory<>( PrimitiveType.FLOAT, createLinkedType );
 	}
 
-	public static < T extends NativeType< T >, A extends DoubleAccess > NativeTypeFactory< T, A > DOUBLE( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
+	public static < T extends NativeType< T >, A extends DoubleAccess > NativeTypeFactory< T, A >
+			DOUBLE( final Function< NativeImg< T, ? extends A >, T > createLinkedType )
 	{
 		return new NativeTypeFactory<>( PrimitiveType.DOUBLE, createLinkedType );
 	}

--- a/src/main/java/net/imglib2/type/label/BasePairBitType.java
+++ b/src/main/java/net/imglib2/type/label/BasePairBitType.java
@@ -115,7 +115,10 @@ public class BasePairBitType extends AbstractBit64Type< BasePairBitType > implem
 	}
 
 	@Override
-	public BasePairBitType duplicateTypeOnSameNativeImg() { return new BasePairBitType( img ); }
+	public BasePairBitType duplicateTypeOnSameNativeImg()
+	{
+		return new BasePairBitType( img );
+	}
 
 	private static final NativeTypeFactory< BasePairBitType, LongAccess > typeFactory = NativeTypeFactory.LONG( BasePairBitType::new );
 
@@ -149,12 +152,23 @@ public class BasePairBitType extends AbstractBit64Type< BasePairBitType > implem
 		final Base base = get();
 		switch ( base )
 		{
-			case A: set( Base.T ); break;
-			case T: set( Base.A ); break;
-			case G: set( Base.C ); break;
-			case C: set( Base.G ); break;
-			case U: set( Base.A ); break;
-			default: break;
+		case A:
+			set( Base.T );
+			break;
+		case T:
+			set( Base.A );
+			break;
+		case G:
+			set( Base.C );
+			break;
+		case C:
+			set( Base.G );
+			break;
+		case U:
+			set( Base.A );
+			break;
+		default:
+			break;
 		}
 	}
 

--- a/src/main/java/net/imglib2/type/logic/BitType.java
+++ b/src/main/java/net/imglib2/type/logic/BitType.java
@@ -136,7 +136,7 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 		// Same as above, minus one multiplication, plus one shift to multiply the reminder by 2
 		final int j = i.get();
 		final int i1 = j >>> 6; // Same as i / 64
-		final long bit = 1l << (j & 63);
+		final long bit = 1l << ( j & 63 );
 		synchronized ( dataAccess )
 		{
 			// Clear or set the bit
@@ -323,7 +323,7 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	@Override
 	public Fraction getEntitiesPerPixel()
 	{
-		return new Fraction(1, 64);
+		return new Fraction( 1, 64 );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/logic/BoolType.java
+++ b/src/main/java/net/imglib2/type/logic/BoolType.java
@@ -58,7 +58,7 @@ public class BoolType extends AbstractIntegerType< BoolType > implements Boolean
 		this.value = value;
 	}
 
-	public < T extends BooleanType<T> >BoolType( final T type )
+	public < T extends BooleanType< T > > BoolType( final T type )
 	{
 		this( type.get() );
 	}
@@ -183,7 +183,7 @@ public class BoolType extends AbstractIntegerType< BoolType > implements Boolean
 	@Override
 	public void setBigInteger( final BigInteger b )
 	{
-		set( b.compareTo(BigInteger.ZERO) > 0 );
+		set( b.compareTo( BigInteger.ZERO ) > 0 );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/logic/NativeBoolType.java
+++ b/src/main/java/net/imglib2/type/logic/NativeBoolType.java
@@ -52,7 +52,8 @@ import net.imglib2.util.Util;
  *
  * @author Curtis Rueden
  */
-public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implements BooleanType< NativeBoolType >, NativeType< NativeBoolType >
+public class NativeBoolType extends AbstractIntegerType< NativeBoolType >
+		implements BooleanType< NativeBoolType >, NativeType< NativeBoolType >
 {
 	final Index i;
 
@@ -144,19 +145,34 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 	}
 
 	@Override
-	public void set( final NativeBoolType c ) { set( c.get() ); }
+	public void set( final NativeBoolType c )
+	{
+		set( c.get() );
+	}
 
 	@Override
-	public void and( final NativeBoolType c ) { set( get() && c.get() ); }
+	public void and( final NativeBoolType c )
+	{
+		set( get() && c.get() );
+	}
 
 	@Override
-	public void or( final NativeBoolType c ) { set( get() || c.get() ); }
+	public void or( final NativeBoolType c )
+	{
+		set( get() || c.get() );
+	}
 
 	@Override
-	public void xor( final NativeBoolType c ) { set( get() ^ c.get() ); }
+	public void xor( final NativeBoolType c )
+	{
+		set( get() ^ c.get() );
+	}
 
 	@Override
-	public void not() { set( !get() ); }
+	public void not()
+	{
+		set( !get() );
+	}
 
 	@Override
 	public void add( final NativeBoolType c )
@@ -201,17 +217,28 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 	}
 
 	@Override
-	public void setOne() { set( true ); }
+	public void setOne()
+	{
+		set( true );
+	}
 
 	@Override
-	public void setZero() { set( false ); }
+	public void setZero()
+	{
+		set( false );
+	}
 
 	@Override
-	public void inc() { not(); }
+	public void inc()
+	{
+		not();
+	}
 
 	@Override
-	public void dec() { not(); }
-
+	public void dec()
+	{
+		not();
+	}
 
 	@Override
 	public String toString()

--- a/src/main/java/net/imglib2/type/numeric/ARGBType.java
+++ b/src/main/java/net/imglib2/type/numeric/ARGBType.java
@@ -172,7 +172,8 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 		final int value1 = get();
 		final int value2 = c.get();
 
-		set( rgba( red( value1 ) + red( value2 ), green( value1 ) + green( value2 ), blue( value1 ) + blue( value2 ), alpha( value1 ) + alpha( value2 ) ) );
+		set( rgba( red( value1 ) + red( value2 ), green( value1 ) + green( value2 ), blue( value1 ) + blue( value2 ),
+				alpha( value1 ) + alpha( value2 ) ) );
 	}
 
 	@Override
@@ -181,7 +182,8 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 		final int value1 = get();
 		final int value2 = c.get();
 
-		set( rgba( red( value1 ) / red( value2 ), green( value1 ) / green( value2 ), blue( value1 ) / blue( value2 ), alpha( value1 ) / alpha( value2 ) ) );
+		set( rgba( red( value1 ) / red( value2 ), green( value1 ) / green( value2 ), blue( value1 ) / blue( value2 ),
+				alpha( value1 ) / alpha( value2 ) ) );
 	}
 
 	@Override
@@ -190,7 +192,8 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 		final int value1 = get();
 		final int value2 = c.get();
 
-		set( rgba( red( value1 ) * red( value2 ), green( value1 ) * green( value2 ), blue( value1 ) * blue( value2 ), alpha( value1 ) * alpha( value2 ) ) );
+		set( rgba( red( value1 ) * red( value2 ), green( value1 ) * green( value2 ), blue( value1 ) * blue( value2 ),
+				alpha( value1 ) * alpha( value2 ) ) );
 	}
 
 	@Override
@@ -199,7 +202,8 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 		final int value1 = get();
 		final int value2 = c.get();
 
-		set( rgba( red( value1 ) - red( value2 ), green( value1 ) - green( value2 ), blue( value1 ) - blue( value2 ), alpha( value1 ) - alpha( value2 ) ) );
+		set( rgba( red( value1 ) - red( value2 ), green( value1 ) - green( value2 ), blue( value1 ) - blue( value2 ),
+				alpha( value1 ) - alpha( value2 ) ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
@@ -180,8 +180,7 @@ abstract public class AbstractARGBDoubleType< T extends AbstractARGBDoubleType< 
 	@Override
 	public boolean valueEquals( T t )
 	{
-		return
-				( getA() == t.getA() ) &&
+		return ( getA() == t.getA() ) &&
 				( getR() == t.getR() ) &&
 				( getG() == t.getG() ) &&
 				( getB() == t.getB() );
@@ -190,7 +189,7 @@ abstract public class AbstractARGBDoubleType< T extends AbstractARGBDoubleType< 
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if ( ! getClass().isInstance( obj ) )
+		if ( !getClass().isInstance( obj ) )
 			return false;
 		@SuppressWarnings( "unchecked" )
 		T t = ( T ) obj;

--- a/src/main/java/net/imglib2/type/numeric/ComplexType.java
+++ b/src/main/java/net/imglib2/type/numeric/ComplexType.java
@@ -38,7 +38,7 @@ package net.imglib2.type.numeric;
  * TODO
  * 
  */
-public interface ComplexType< T extends ComplexType< T >> extends NumericType< T >
+public interface ComplexType< T extends ComplexType< T > > extends NumericType< T >
 {
 	double getRealDouble();
 

--- a/src/main/java/net/imglib2/type/numeric/IntegerType.java
+++ b/src/main/java/net/imglib2/type/numeric/IntegerType.java
@@ -40,7 +40,7 @@ import java.math.BigInteger;
  * TODO
  * 
  */
-public interface IntegerType< T extends IntegerType< T >> extends RealType< T >
+public interface IntegerType< T extends IntegerType< T > > extends RealType< T >
 {
 	int getInteger();
 

--- a/src/main/java/net/imglib2/type/numeric/NativeARGBDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/NativeARGBDoubleType.java
@@ -98,7 +98,8 @@ public class NativeARGBDoubleType extends AbstractARGBDoubleType< NativeARGBDoub
 		return new NativeARGBDoubleType( img );
 	}
 
-	private static final NativeTypeFactory< NativeARGBDoubleType, DoubleAccess > typeFactory = NativeTypeFactory.DOUBLE( NativeARGBDoubleType::new );
+	private static final NativeTypeFactory< NativeARGBDoubleType, DoubleAccess > typeFactory =
+			NativeTypeFactory.DOUBLE( NativeARGBDoubleType::new );
 
 	@Override
 	public NativeTypeFactory< NativeARGBDoubleType, DoubleAccess > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/numeric/NumericType.java
+++ b/src/main/java/net/imglib2/type/numeric/NumericType.java
@@ -49,6 +49,6 @@ import net.imglib2.type.operators.Sub;
  * TODO
  * 
  */
-public interface NumericType< T extends NumericType< T >> extends Type< T >, Add< T >, Mul< T >, Sub< T >, Div< T >, Pow< T >, SetOne, SetZero, MulFloatingPoint, PowFloatingPoint
-{
-}
+public interface NumericType< T extends NumericType< T > >
+		extends Type< T >, Add< T >, Mul< T >, Sub< T >, Div< T >, Pow< T >, SetOne, SetZero, MulFloatingPoint, PowFloatingPoint
+{}

--- a/src/main/java/net/imglib2/type/numeric/RealType.java
+++ b/src/main/java/net/imglib2/type/numeric/RealType.java
@@ -40,7 +40,7 @@ package net.imglib2.type.numeric;
  * @author Stephan Preibisch
  * @author Stephan Saalfeld
  */
-public interface RealType< T extends RealType< T >> extends ComplexType< T >, Comparable< T >
+public interface RealType< T extends RealType< T > > extends ComplexType< T >, Comparable< T >
 {
 	void inc();
 

--- a/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
@@ -42,7 +42,7 @@ import net.imglib2.util.Util;
  * TODO
  * 
  */
-public abstract class AbstractComplexType< T extends AbstractComplexType< T >> implements ComplexType< T >
+public abstract class AbstractComplexType< T extends AbstractComplexType< T > > implements ComplexType< T >
 {
 	@Override
 	public void set( final T c )
@@ -112,7 +112,7 @@ public abstract class AbstractComplexType< T extends AbstractComplexType< T >> i
 		setReal( Math.pow( getRealDouble(), c.getRealDouble() ) );
 		setImaginary( Math.pow( getImaginaryDouble(), c.getImaginaryDouble() ) );
 	}
-	
+
 	@Override
 	public void pow( final double power )
 	{
@@ -194,10 +194,10 @@ public abstract class AbstractComplexType< T extends AbstractComplexType< T >> i
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if ( !getClass().isInstance(obj) )
+		if ( !getClass().isInstance( obj ) )
 			return false;
-		@SuppressWarnings("unchecked")
-		final T t = (T) obj;
+		@SuppressWarnings( "unchecked" )
+		final T t = ( T ) obj;
 		return AbstractComplexType.this.valueEquals( t );
 	}
 

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
@@ -108,7 +108,8 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 		return new ComplexDoubleType( img );
 	}
 
-	private static final NativeTypeFactory< ComplexDoubleType, DoubleAccess > typeFactory = NativeTypeFactory.DOUBLE( ComplexDoubleType::new );
+	private static final NativeTypeFactory< ComplexDoubleType, DoubleAccess > typeFactory =
+			NativeTypeFactory.DOUBLE( ComplexDoubleType::new );
 
 	@Override
 	public NativeTypeFactory< ComplexDoubleType, DoubleAccess > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
@@ -32,7 +32,6 @@
  * #L%
  */
 
-
 package net.imglib2.type.numeric.integer;
 
 import java.math.BigInteger;
@@ -48,7 +47,8 @@ import net.imglib2.util.Util;
  *
  * @author Albert Cardona
  */
-public abstract class AbstractIntegerBitType< T extends AbstractIntegerBitType< T > > extends AbstractBitType< T > implements IntegerType< T >
+public abstract class AbstractIntegerBitType< T extends AbstractIntegerBitType< T > > extends AbstractBitType< T >
+		implements IntegerType< T >
 {
 	// Maximum count is Integer.MAX_VALUE * (64 / getBitsPerPixel())
 	//protected long i = 0;
@@ -71,113 +71,233 @@ public abstract class AbstractIntegerBitType< T extends AbstractIntegerBitType< 
 	public abstract void set( long value );
 
 	@Override
-	public int getBitsPerPixel() { return nBits; }
+	public int getBitsPerPixel()
+	{
+		return nBits;
+	}
 
 	@Override
-	public double getMinIncrement() { return 1; }
+	public double getMinIncrement()
+	{
+		return 1;
+	}
 
 	@Override
-	public void mul( final float c ) { setReal( getRealDouble() * c ); }
+	public void mul( final float c )
+	{
+		setReal( getRealDouble() * c );
+	}
 
 	@Override
-	public void mul( final double c ) { setReal( getRealDouble() * c ); }
+	public void mul( final double c )
+	{
+		setReal( getRealDouble() * c );
+	}
 
 	@Override
-	public float getRealFloat() { return getIntegerLong(); }
-	@Override
-	public double getRealDouble() { return getIntegerLong(); }
+	public float getRealFloat()
+	{
+		return getIntegerLong();
+	}
 
 	@Override
-	public void setReal( final float real ){ setInteger( Util.round( real ) ); }
-	@Override
-	public void setReal( final double real ){ setInteger( Util.round( real ) ); }
+	public double getRealDouble()
+	{
+		return getIntegerLong();
+	}
 
 	@Override
-	public void setZero() { setInteger( 0 ); }
-	@Override
-	public void setOne() { setInteger( 1 ); }
+	public void setReal( final float real )
+	{
+		setInteger( Util.round( real ) );
+	}
 
 	@Override
-	public String toString() { return "" + getIntegerLong(); }
+	public void setReal( final double real )
+	{
+		setInteger( Util.round( real ) );
+	}
 
 	@Override
-	public int getInteger() { return (int)get(); }
+	public void setZero()
+	{
+		setInteger( 0 );
+	}
 
 	@Override
-	public long getIntegerLong() { return get(); }
+	public void setOne()
+	{
+		setInteger( 1 );
+	}
 
 	@Override
-	public BigInteger getBigInteger() { return BigInteger.valueOf( get() ); }
+	public String toString()
+	{
+		return "" + getIntegerLong();
+	}
 
 	@Override
-	public void setInteger( final int f ) { set( f ); }
+	public int getInteger()
+	{
+		return ( int ) get();
+	}
 
 	@Override
-	public void setInteger( final long f ) { set( f ); }
+	public long getIntegerLong()
+	{
+		return get();
+	}
 
 	@Override
-	public void setBigInteger( final BigInteger b) { set( b.longValue() ); }
+	public BigInteger getBigInteger()
+	{
+		return BigInteger.valueOf( get() );
+	}
+
+	@Override
+	public void setInteger( final int f )
+	{
+		set( f );
+	}
+
+	@Override
+	public void setInteger( final long f )
+	{
+		set( f );
+	}
+
+	@Override
+	public void setBigInteger( final BigInteger b )
+	{
+		set( b.longValue() );
+	}
 
 	/** The maximum value that can be stored is {@code Math.pow(2, nBits) -1}. */
 	@Override
-	public double getMaxValue() { return Math.pow(2, getBitsPerPixel()) -1; }
-	@Override
-	public double getMinValue()  { return 0; }
+	public double getMaxValue()
+	{
+		return Math.pow( 2, getBitsPerPixel() ) - 1;
+	}
 
 	@Override
-	public void inc() {	set(get() + 1); }
+	public double getMinValue()
+	{
+		return 0;
+	}
 
 	@Override
-	public void dec() {	set(get() - 1); }
+	public void inc()
+	{
+		set( get() + 1 );
+	}
 
 	@Override
-	public void add(final T t) { set(get() + t.get()); }
+	public void dec()
+	{
+		set( get() - 1 );
+	}
 
 	@Override
-	public void sub(final T t) { set(get() - t.get()); }
+	public void add( final T t )
+	{
+		set( get() + t.get() );
+	}
 
 	@Override
-	public void mul(final T t) { set(get() * t.get()); }
+	public void sub( final T t )
+	{
+		set( get() - t.get() );
+	}
 
 	@Override
-	public void div(final T t) { set(get() / t.get()); }
-	
-	@Override
-	public void pow(final T t) { setReal( Math.pow( get(), t.get() ) ); }
-	
-	@Override
-	public void pow(final double power) { setReal( Math.pow( get(), power) ); }
+	public void mul( final T t )
+	{
+		set( get() * t.get() );
+	}
 
 	@Override
-	public void set( final T c ) { set( c.get() ); }
+	public void div( final T t )
+	{
+		set( get() / t.get() );
+	}
 
 	@Override
-	public float getImaginaryFloat() { return 0; }
-	@Override
-	public double getImaginaryDouble() { return 0; }
+	public void pow( final T t )
+	{
+		setReal( Math.pow( get(), t.get() ) );
+	}
 
 	@Override
-	public void setImaginary( final float complex ){}
-	@Override
-	public void setImaginary( final double complex ){}
+	public void pow( final double power )
+	{
+		setReal( Math.pow( get(), power ) );
+	}
 
 	@Override
-	public float getPhaseFloat() { return 0; }
-	@Override
-	public double getPhaseDouble() { return 0; }
+	public void set( final T c )
+	{
+		set( c.get() );
+	}
 
 	@Override
-	public float getPowerFloat() { return getRealFloat(); }
-	@Override
-	public double getPowerDouble() { return getRealDouble(); }
+	public float getImaginaryFloat()
+	{
+		return 0;
+	}
 
 	@Override
-	public void setComplexNumber( final float r, final float i ) { setReal( r ); }
-	@Override
-	public void setComplexNumber( final double r, final double i ) { setReal( r ); }
+	public double getImaginaryDouble()
+	{
+		return 0;
+	}
 
 	@Override
-	public void complexConjugate(){}
+	public void setImaginary( final float complex )
+	{}
+
+	@Override
+	public void setImaginary( final double complex )
+	{}
+
+	@Override
+	public float getPhaseFloat()
+	{
+		return 0;
+	}
+
+	@Override
+	public double getPhaseDouble()
+	{
+		return 0;
+	}
+
+	@Override
+	public float getPowerFloat()
+	{
+		return getRealFloat();
+	}
+
+	@Override
+	public double getPowerDouble()
+	{
+		return getRealDouble();
+	}
+
+	@Override
+	public void setComplexNumber( final float r, final float i )
+	{
+		setReal( r );
+	}
+
+	@Override
+	public void setComplexNumber( final double r, final double i )
+	{
+		setReal( r );
+	}
+
+	@Override
+	public void complexConjugate()
+	{}
 
 	@Override
 	public int compareTo( final T other )

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericShortType.java
@@ -250,7 +250,7 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if ( ! getClass().isInstance( obj ) )
+		if ( !getClass().isInstance( obj ) )
 			return false;
 		@SuppressWarnings( "unchecked" )
 		final T t = ( T ) obj;

--- a/src/main/java/net/imglib2/type/numeric/integer/IntegerTypes.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/IntegerTypes.java
@@ -41,9 +41,11 @@ import net.imglib2.type.numeric.IntegerType;
 
 public class IntegerTypes
 {
-	private static List< ? extends IntegerType< ? > > signedTypes = Arrays.asList( new ByteType(), new ShortType(), new IntType(), new LongType() );
+	private static List< ? extends IntegerType< ? > > signedTypes =
+			Arrays.asList( new ByteType(), new ShortType(), new IntType(), new LongType() );
 
-	private static List< ? extends IntegerType< ? > > unsignedTypes = Arrays.asList( new BitType(), new UnsignedByteType(), new UnsignedShortType(), new UnsignedIntType(), new UnsignedLongType() );
+	private static List< ? extends IntegerType< ? > > unsignedTypes =
+			Arrays.asList( new BitType(), new UnsignedByteType(), new UnsignedShortType(), new UnsignedIntType(), new UnsignedLongType() );
 
 	private IntegerTypes()
 	{
@@ -85,7 +87,8 @@ public class IntegerTypes
 			throw new IllegalArgumentException( "Wrong usage: min (" + min + ") > max (" + max + ")" );
 		if ( min >= 0 ) // unsigned
 		{
-			return unsignedTypes.stream().filter( i -> min >= i.getMinValue() && max <= i.getMaxValue() ).findFirst().get().createVariable();
+			return unsignedTypes.stream().filter( i -> min >= i.getMinValue() && max <= i.getMaxValue() ).findFirst().get()
+					.createVariable();
 		}
 		return signedTypes.stream().filter( i -> min >= i.getMinValue() && max <= i.getMaxValue() ).findFirst().get().createVariable();
 	}

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
@@ -124,7 +124,8 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 		return new Unsigned128BitType( img );
 	}
 
-	private static final NativeTypeFactory< Unsigned128BitType, LongAccess > typeFactory = NativeTypeFactory.LONG( Unsigned128BitType::new );
+	private static final NativeTypeFactory< Unsigned128BitType, LongAccess > typeFactory =
+			NativeTypeFactory.LONG( Unsigned128BitType::new );
 
 	@Override
 	public NativeTypeFactory< Unsigned128BitType, LongAccess > getNativeTypeFactory()
@@ -216,7 +217,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public float getRealFloat()
 	{
-		return (float) getRealDouble();
+		return ( float ) getRealDouble();
 	}
 
 	@Override
@@ -254,7 +255,7 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	@Override
 	public void setReal( float real )
 	{
-		setReal( (double) real );
+		setReal( ( double ) real );
 	}
 
 	@Override
@@ -262,10 +263,10 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	{
 		real = Math.floor( real + 0.5 );
 		final double base = Math.pow( 2, 64 );
-		double upper = Math.floor(real / base );
+		double upper = Math.floor( real / base );
 		double lower = real - base * upper;
 		set( UnsignedLongType.doubleToUnsignedLong( lower ),
-				UnsignedLongType.doubleToUnsignedLong( upper ));
+				UnsignedLongType.doubleToUnsignedLong( upper ) );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
@@ -275,16 +275,14 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 
 	static long doubleToUnsignedLong( double real )
 	{
-		double value = real < MAX_LONG_PLUS_ONE ?
-				Math.max(0, real) :
-				Math.min(-1, real - MAX_VALUE_PLUS_ONE);
+		double value = real < MAX_LONG_PLUS_ONE ? Math.max( 0, real ) : Math.min( -1, real - MAX_VALUE_PLUS_ONE );
 		return Util.round( value );
 	}
 
 	@Override
 	public void setReal( float real )
 	{
-		setReal( (double) real );
+		setReal( ( double ) real );
 	}
 
 	public void set( final BigInteger bi )
@@ -352,7 +350,7 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 	public float getRealFloat()
 	{
 		long l = get();
-		return l >= 0 ? l : ((float) MAX_VALUE_PLUS_ONE + l);
+		return l >= 0 ? l : ( ( float ) MAX_VALUE_PLUS_ONE + l );
 	}
 
 	@Override
@@ -363,7 +361,7 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 
 	static double unsignedLongToDouble( long l )
 	{
-		return l >= 0 ? l : (MAX_VALUE_PLUS_ONE + l);
+		return l >= 0 ? l : ( MAX_VALUE_PLUS_ONE + l );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
@@ -99,7 +99,8 @@ public class UnsignedShortType extends GenericShortType< UnsignedShortType >
 		return new UnsignedShortType( img );
 	}
 
-	private static final NativeTypeFactory< UnsignedShortType, ShortAccess > typeFactory = NativeTypeFactory.SHORT( UnsignedShortType::new );
+	private static final NativeTypeFactory< UnsignedShortType, ShortAccess > typeFactory =
+			NativeTypeFactory.SHORT( UnsignedShortType::new );
 
 	@Override
 	public NativeTypeFactory< UnsignedShortType, ShortAccess > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
@@ -56,7 +56,8 @@ import net.imglib2.util.Util;
  * @author Albert Cardona
  * @author Stephan Preibisch
  */
-public class UnsignedVariableBitLengthType extends AbstractBit64Type< UnsignedVariableBitLengthType > implements IntegerType< UnsignedVariableBitLengthType >
+public class UnsignedVariableBitLengthType extends AbstractBit64Type< UnsignedVariableBitLengthType >
+		implements IntegerType< UnsignedVariableBitLengthType >
 {
 	// this is the constructor if you want it to read from an array
 	public UnsignedVariableBitLengthType( final NativeImg< ?, ? extends LongAccess > bitStorage, final int nBits )
@@ -104,7 +105,8 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type< UnsignedVa
 		return new UnsignedVariableBitLengthType( img, nBits );
 	}
 
-	private final NativeTypeFactory< UnsignedVariableBitLengthType, LongAccess > typeFactory = NativeTypeFactory.LONG( img -> new UnsignedVariableBitLengthType( img, nBits ) );
+	private final NativeTypeFactory< UnsignedVariableBitLengthType, LongAccess > typeFactory =
+			NativeTypeFactory.LONG( img -> new UnsignedVariableBitLengthType( img, nBits ) );
 
 	@Override
 	public NativeTypeFactory< UnsignedVariableBitLengthType, LongAccess > getNativeTypeFactory()
@@ -281,13 +283,15 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type< UnsignedVa
 	}
 
 	@Override
-	public void pow( final UnsignedVariableBitLengthType c) {
+	public void pow( final UnsignedVariableBitLengthType c )
+	{
 		setReal( Math.pow( get(), c.get() ) );
 	}
 
 	@Override
-	public void pow( final double power ) {
-		setReal( Math.pow( get(), power) );
+	public void pow( final double power )
+	{
+		setReal( Math.pow( get(), power ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
@@ -41,7 +41,7 @@ import net.imglib2.type.numeric.complex.AbstractComplexType;
  * TODO
  * 
  */
-public abstract class AbstractRealType< T extends AbstractRealType< T >> extends AbstractComplexType< T > implements RealType< T >
+public abstract class AbstractRealType< T extends AbstractRealType< T > > extends AbstractComplexType< T > implements RealType< T >
 {
 	@Override
 	public float getImaginaryFloat()
@@ -116,13 +116,13 @@ public abstract class AbstractRealType< T extends AbstractRealType< T >> extends
 	{
 		setReal( getRealDouble() - c.getRealDouble() );
 	}
-	
+
 	@Override
 	public void pow( final T c )
 	{
 		setReal( Math.pow( getRealDouble(), c.getRealDouble() ) );
 	}
-	
+
 	@Override
 	public void pow( final double power )
 	{
@@ -158,8 +158,8 @@ public abstract class AbstractRealType< T extends AbstractRealType< T >> extends
 	{
 		if ( !getClass().isInstance( obj ) )
 			return false;
-		@SuppressWarnings("unchecked")
-		final T t = (T) obj;
+		@SuppressWarnings( "unchecked" )
+		final T t = ( T ) obj;
 		return AbstractRealType.this.valueEquals( t );
 	}
 

--- a/src/main/java/net/imglib2/type/operators/MulFloatingPoint.java
+++ b/src/main/java/net/imglib2/type/operators/MulFloatingPoint.java
@@ -39,5 +39,6 @@ package net.imglib2.type.operators;
 public interface MulFloatingPoint
 {
 	void mul( float c );
+
 	void mul( double c );
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNativeNumericType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNativeNumericType.java
@@ -51,9 +51,10 @@ import net.imglib2.util.Fraction;
  * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
  * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
  */
-public abstract class AbstractVolatileNativeNumericType< N extends NumericType< N > & NativeType< N >, T extends AbstractVolatileNativeNumericType< N, T > >
-	extends AbstractVolatileNumericType< N, T >
-	implements NativeType< T >
+public abstract class AbstractVolatileNativeNumericType< N extends NumericType< N > & NativeType< N >,
+		T extends AbstractVolatileNativeNumericType< N, T > >
+		extends AbstractVolatileNumericType< N, T >
+		implements NativeType< T >
 {
 	public AbstractVolatileNativeNumericType( final N t, final boolean valid )
 	{

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNativeRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNativeRealType.java
@@ -50,9 +50,10 @@ import net.imglib2.util.Fraction;
  *
  * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
  */
-public abstract class AbstractVolatileNativeRealType< R extends RealType< R > & NativeType< R >, T extends AbstractVolatileNativeRealType< R, T > >
-	extends AbstractVolatileRealType< R, T >
-	implements NativeType< T >
+public abstract class AbstractVolatileNativeRealType< R extends RealType< R > & NativeType< R >,
+		T extends AbstractVolatileNativeRealType< R, T > >
+		extends AbstractVolatileRealType< R, T >
+		implements NativeType< T >
 {
 	public AbstractVolatileNativeRealType( final R t, final boolean valid )
 	{

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
@@ -144,7 +144,7 @@ abstract public class AbstractVolatileNumericType< N extends NumericType< N >, T
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if ( ! getClass().isInstance( obj ) )
+		if ( !getClass().isInstance( obj ) )
 			return false;
 		@SuppressWarnings( "unchecked" )
 		T t = ( T ) obj;

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
@@ -270,7 +270,7 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if ( ! getClass().isInstance( obj ) )
+		if ( !getClass().isInstance( obj ) )
 			return false;
 		@SuppressWarnings( "unchecked" )
 		T t = ( T ) obj;

--- a/src/main/java/net/imglib2/type/volatiles/VolatileARGBType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileARGBType.java
@@ -133,7 +133,8 @@ public class VolatileARGBType extends AbstractVolatileNativeNumericType< ARGBTyp
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileARGBType, VolatileIntAccess > typeFactory = NativeTypeFactory.INT( VolatileARGBType::new );
+	private static final NativeTypeFactory< VolatileARGBType, VolatileIntAccess > typeFactory =
+			NativeTypeFactory.INT( VolatileARGBType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileARGBType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileByteType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileByteType.java
@@ -54,7 +54,7 @@ public class VolatileByteType extends AbstractVolatileNativeRealType< ByteType, 
 
 	private static class WrappedByteType extends ByteType
 	{
-		public WrappedByteType( final NativeImg<?, ? extends ByteAccess> img )
+		public WrappedByteType( final NativeImg< ?, ? extends ByteAccess > img )
 		{
 			super( img );
 		}
@@ -94,7 +94,7 @@ public class VolatileByteType extends AbstractVolatileNativeRealType< ByteType, 
 	// this is the constructor if you want it to be a variable
 	public VolatileByteType()
 	{
-		this( ( byte )0 );
+		this( ( byte ) 0 );
 	}
 
 	public void set( final byte value )
@@ -106,7 +106,7 @@ public class VolatileByteType extends AbstractVolatileNativeRealType< ByteType, 
 	public void updateContainer( final Object c )
 	{
 		final VolatileByteAccess a = img.update( c );
-		( (WrappedByteType) t ).setAccess( a );
+		( ( WrappedByteType ) t ).setAccess( a );
 		setValid( a.isValid() );
 	}
 
@@ -130,7 +130,8 @@ public class VolatileByteType extends AbstractVolatileNativeRealType< ByteType, 
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileByteType, VolatileByteAccess > typeFactory = NativeTypeFactory.BYTE( VolatileByteType::new );
+	private static final NativeTypeFactory< VolatileByteType, VolatileByteAccess > typeFactory =
+			NativeTypeFactory.BYTE( VolatileByteType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileByteType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileDoubleType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileDoubleType.java
@@ -54,7 +54,7 @@ public class VolatileDoubleType extends AbstractVolatileNativeRealType< DoubleTy
 
 	private static class WrappedDoubleType extends DoubleType
 	{
-		public WrappedDoubleType( final NativeImg<?, ? extends DoubleAccess> img )
+		public WrappedDoubleType( final NativeImg< ?, ? extends DoubleAccess > img )
 		{
 			super( img );
 		}
@@ -106,7 +106,7 @@ public class VolatileDoubleType extends AbstractVolatileNativeRealType< DoubleTy
 	public void updateContainer( final Object c )
 	{
 		final VolatileDoubleAccess a = img.update( c );
-		( ( WrappedDoubleType )t ).setAccess( a );
+		( ( WrappedDoubleType ) t ).setAccess( a );
 		setValid( a.isValid() );
 	}
 
@@ -130,7 +130,8 @@ public class VolatileDoubleType extends AbstractVolatileNativeRealType< DoubleTy
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileDoubleType, VolatileDoubleAccess > typeFactory = NativeTypeFactory.DOUBLE( VolatileDoubleType::new );
+	private static final NativeTypeFactory< VolatileDoubleType, VolatileDoubleAccess > typeFactory =
+			NativeTypeFactory.DOUBLE( VolatileDoubleType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileDoubleType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileFloatType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileFloatType.java
@@ -54,7 +54,7 @@ public class VolatileFloatType extends AbstractVolatileNativeRealType< FloatType
 
 	private static class WrappedFloatType extends FloatType
 	{
-		public WrappedFloatType( final NativeImg<?, ? extends FloatAccess> img )
+		public WrappedFloatType( final NativeImg< ?, ? extends FloatAccess > img )
 		{
 			super( img );
 		}
@@ -106,7 +106,7 @@ public class VolatileFloatType extends AbstractVolatileNativeRealType< FloatType
 	public void updateContainer( final Object c )
 	{
 		final VolatileFloatAccess a = img.update( c );
-		( ( WrappedFloatType )t ).setAccess( a );
+		( ( WrappedFloatType ) t ).setAccess( a );
 		setValid( a.isValid() );
 	}
 
@@ -130,7 +130,8 @@ public class VolatileFloatType extends AbstractVolatileNativeRealType< FloatType
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileFloatType, VolatileFloatAccess > typeFactory = NativeTypeFactory.FLOAT( VolatileFloatType::new );
+	private static final NativeTypeFactory< VolatileFloatType, VolatileFloatAccess > typeFactory =
+			NativeTypeFactory.FLOAT( VolatileFloatType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileFloatType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileIntType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileIntType.java
@@ -54,7 +54,7 @@ public class VolatileIntType extends AbstractVolatileNativeRealType< IntType, Vo
 
 	private static class WrappedIntType extends IntType
 	{
-		public WrappedIntType( final NativeImg<?, ? extends IntAccess> img )
+		public WrappedIntType( final NativeImg< ?, ? extends IntAccess > img )
 		{
 			super( img );
 		}
@@ -106,7 +106,7 @@ public class VolatileIntType extends AbstractVolatileNativeRealType< IntType, Vo
 	public void updateContainer( final Object c )
 	{
 		final VolatileIntAccess a = img.update( c );
-		( (WrappedIntType) t ).setAccess( a );
+		( ( WrappedIntType ) t ).setAccess( a );
 		setValid( a.isValid() );
 	}
 
@@ -130,7 +130,8 @@ public class VolatileIntType extends AbstractVolatileNativeRealType< IntType, Vo
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileIntType, VolatileIntAccess > typeFactory = NativeTypeFactory.INT( VolatileIntType::new );
+	private static final NativeTypeFactory< VolatileIntType, VolatileIntAccess > typeFactory =
+			NativeTypeFactory.INT( VolatileIntType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileIntType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileLongType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileLongType.java
@@ -54,7 +54,7 @@ public class VolatileLongType extends AbstractVolatileNativeRealType< LongType, 
 
 	private static class WrappedLongType extends LongType
 	{
-		public WrappedLongType( final NativeImg<?, ? extends LongAccess> img )
+		public WrappedLongType( final NativeImg< ?, ? extends LongAccess > img )
 		{
 			super( img );
 		}
@@ -106,7 +106,7 @@ public class VolatileLongType extends AbstractVolatileNativeRealType< LongType, 
 	public void updateContainer( final Object c )
 	{
 		final VolatileLongAccess a = img.update( c );
-		( (WrappedLongType) t ).setAccess( a );
+		( ( WrappedLongType ) t ).setAccess( a );
 		setValid( a.isValid() );
 	}
 
@@ -130,7 +130,8 @@ public class VolatileLongType extends AbstractVolatileNativeRealType< LongType, 
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileLongType, VolatileLongAccess > typeFactory = NativeTypeFactory.LONG( VolatileLongType::new );
+	private static final NativeTypeFactory< VolatileLongType, VolatileLongAccess > typeFactory =
+			NativeTypeFactory.LONG( VolatileLongType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileLongType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileShortType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileShortType.java
@@ -54,7 +54,7 @@ public class VolatileShortType extends AbstractVolatileNativeRealType< ShortType
 
 	private static class WrappedShortType extends ShortType
 	{
-		public WrappedShortType( final NativeImg<?, ? extends ShortAccess> img )
+		public WrappedShortType( final NativeImg< ?, ? extends ShortAccess > img )
 		{
 			super( img );
 		}
@@ -106,7 +106,7 @@ public class VolatileShortType extends AbstractVolatileNativeRealType< ShortType
 	public void updateContainer( final Object c )
 	{
 		final VolatileShortAccess a = img.update( c );
-		( (WrappedShortType) t ).setAccess( a );
+		( ( WrappedShortType ) t ).setAccess( a );
 		setValid( a.isValid() );
 	}
 
@@ -130,7 +130,8 @@ public class VolatileShortType extends AbstractVolatileNativeRealType< ShortType
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileShortType, VolatileShortAccess > typeFactory = NativeTypeFactory.SHORT( VolatileShortType::new );
+	private static final NativeTypeFactory< VolatileShortType, VolatileShortAccess > typeFactory =
+			NativeTypeFactory.SHORT( VolatileShortType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileShortType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileUnsignedByteType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileUnsignedByteType.java
@@ -55,7 +55,7 @@ public class VolatileUnsignedByteType extends AbstractVolatileNativeRealType< Un
 
 	private static class WrappedUnsignedByteType extends UnsignedByteType
 	{
-		public WrappedUnsignedByteType( final NativeImg<?, ? extends ByteAccess> img )
+		public WrappedUnsignedByteType( final NativeImg< ?, ? extends ByteAccess > img )
 		{
 			super( img );
 		}
@@ -107,7 +107,7 @@ public class VolatileUnsignedByteType extends AbstractVolatileNativeRealType< Un
 	public void updateContainer( final Object c )
 	{
 		final VolatileByteAccess a = img.update( c );
-		( ( WrappedUnsignedByteType )t ).setAccess( a );
+		( ( WrappedUnsignedByteType ) t ).setAccess( a );
 		setValid( a.isValid() );
 	}
 
@@ -131,7 +131,8 @@ public class VolatileUnsignedByteType extends AbstractVolatileNativeRealType< Un
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileUnsignedByteType, VolatileByteAccess > typeFactory = NativeTypeFactory.BYTE( VolatileUnsignedByteType::new );
+	private static final NativeTypeFactory< VolatileUnsignedByteType, VolatileByteAccess > typeFactory =
+			NativeTypeFactory.BYTE( VolatileUnsignedByteType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileUnsignedByteType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileUnsignedIntType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileUnsignedIntType.java
@@ -53,7 +53,7 @@ public class VolatileUnsignedIntType extends AbstractVolatileNativeRealType< Uns
 
 	private static class WrappedUnsignedIntType extends UnsignedIntType
 	{
-		public WrappedUnsignedIntType( final NativeImg<?, ? extends IntAccess> img )
+		public WrappedUnsignedIntType( final NativeImg< ?, ? extends IntAccess > img )
 		{
 			super( img );
 		}
@@ -129,7 +129,8 @@ public class VolatileUnsignedIntType extends AbstractVolatileNativeRealType< Uns
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileUnsignedIntType, VolatileIntAccess > typeFactory = NativeTypeFactory.INT( VolatileUnsignedIntType::new );
+	private static final NativeTypeFactory< VolatileUnsignedIntType, VolatileIntAccess > typeFactory =
+			NativeTypeFactory.INT( VolatileUnsignedIntType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileUnsignedIntType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileUnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileUnsignedLongType.java
@@ -53,7 +53,7 @@ public class VolatileUnsignedLongType extends AbstractVolatileNativeRealType< Un
 
 	private static class WrappedUnsignedLongType extends UnsignedLongType
 	{
-		public WrappedUnsignedLongType( final NativeImg<?, ? extends LongAccess> img )
+		public WrappedUnsignedLongType( final NativeImg< ?, ? extends LongAccess > img )
 		{
 			super( img );
 		}
@@ -129,7 +129,8 @@ public class VolatileUnsignedLongType extends AbstractVolatileNativeRealType< Un
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileUnsignedLongType, VolatileLongAccess > typeFactory = NativeTypeFactory.LONG( VolatileUnsignedLongType::new );
+	private static final NativeTypeFactory< VolatileUnsignedLongType, VolatileLongAccess > typeFactory =
+			NativeTypeFactory.LONG( VolatileUnsignedLongType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileUnsignedLongType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/type/volatiles/VolatileUnsignedShortType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileUnsignedShortType.java
@@ -54,7 +54,7 @@ public class VolatileUnsignedShortType extends AbstractVolatileNativeRealType< U
 
 	private static class WrappedUnsignedShortType extends UnsignedShortType
 	{
-		public WrappedUnsignedShortType( final NativeImg<?, ? extends ShortAccess> img )
+		public WrappedUnsignedShortType( final NativeImg< ?, ? extends ShortAccess > img )
 		{
 			super( img );
 		}
@@ -106,7 +106,7 @@ public class VolatileUnsignedShortType extends AbstractVolatileNativeRealType< U
 	public void updateContainer( final Object c )
 	{
 		final VolatileShortAccess a = img.update( c );
-		( (WrappedUnsignedShortType) t ).setAccess( a );
+		( ( WrappedUnsignedShortType ) t ).setAccess( a );
 		setValid( a.isValid() );
 	}
 
@@ -130,7 +130,8 @@ public class VolatileUnsignedShortType extends AbstractVolatileNativeRealType< U
 		return v;
 	}
 
-	private static final NativeTypeFactory< VolatileUnsignedShortType, VolatileShortAccess > typeFactory = NativeTypeFactory.SHORT( VolatileUnsignedShortType::new );
+	private static final NativeTypeFactory< VolatileUnsignedShortType, VolatileShortAccess > typeFactory =
+			NativeTypeFactory.SHORT( VolatileUnsignedShortType::new );
 
 	@Override
 	public NativeTypeFactory< VolatileUnsignedShortType, ? > getNativeTypeFactory()

--- a/src/main/java/net/imglib2/util/ConstantUtils.java
+++ b/src/main/java/net/imglib2/util/ConstantUtils.java
@@ -97,7 +97,8 @@ public class ConstantUtils
 	}
 
 	@Deprecated
-	public static < T > RandomAccessibleInterval< T > constantRandomAccessibleInterval( final T constant, final int numDimensions, final Interval interval )
+	public static < T > RandomAccessibleInterval< T > constantRandomAccessibleInterval( final T constant, final int numDimensions,
+			final Interval interval )
 	{
 		return Views.interval( constantRandomAccessible( constant, numDimensions ), interval );
 	}

--- a/src/main/java/net/imglib2/util/Fraction.java
+++ b/src/main/java/net/imglib2/util/Fraction.java
@@ -39,10 +39,10 @@ package net.imglib2.util;
  * 
  * @author Stephan Preibisch
  */
-public class Fraction 
+public class Fraction
 {
 	long numerator, denominator;
-	
+
 	/**
 	 * Creates a new fraction with the respective values
 	 * 
@@ -54,26 +54,38 @@ public class Fraction
 		this.numerator = numerator;
 		this.denominator = denominator;
 	}
-	
+
 	/**
 	 * Instantiate a {@link Fraction} with a value of 1
 	 */
-	public Fraction() { this( 1, 1 ); }
-	
+	public Fraction()
+	{
+		this( 1, 1 );
+	}
+
 	/**
 	 * @return - the numerator (above the fraction bar)
 	 */
-	public long getNumerator() { return numerator; }
-	
+	public long getNumerator()
+	{
+		return numerator;
+	}
+
 	/**
 	 * @return - the denominator (below the fraction bar)
 	 */
-	public long getDenominator() { return denominator; }
-	
+	public long getDenominator()
+	{
+		return denominator;
+	}
+
 	/**
 	 * @return - an estimate of the ratio in double, i.e. numerator/denominator
 	 */
-	public double getRatio() { return (double)numerator / (double)denominator; }
+	public double getRatio()
+	{
+		return ( double ) numerator / ( double ) denominator;
+	}
 
 	/**
 	 * Inverts this fraction by exchanging numerator and denominator
@@ -84,7 +96,7 @@ public class Fraction
 		numerator = denominator;
 		denominator = tmp;
 	}
-	
+
 	public void mul( final Fraction fraction )
 	{
 		this.numerator *= fraction.getNumerator();
@@ -104,16 +116,16 @@ public class Fraction
 	 * @param value
 	 * @return
 	 */
-	public long mulCeil( final long value ) 
-	{ 
+	public long mulCeil( final long value )
+	{
 		final long tmp = value * numerator;
-		
+
 		if ( tmp % denominator != 0 )
 			return tmp / denominator + 1;
 		else
 			return tmp / denominator;
 	}
-	
+
 	@Override
 	public Fraction clone()
 	{

--- a/src/main/java/net/imglib2/util/ImgUtil.java
+++ b/src/main/java/net/imglib2/util/ImgUtil.java
@@ -81,7 +81,7 @@ public class ImgUtil
 	 * @param dest
 	 *            - the destination for the copy
 	 */
-	public static < T extends RealType< T >> void copy( final double[] src, final int offset, final int[] stride, final Img< T > dest )
+	public static < T extends RealType< T > > void copy( final double[] src, final int offset, final int[] stride, final Img< T > dest )
 	{
 		final Cursor< T > c = dest.localizingCursor();
 		final int[] location = new int[ dest.numDimensions() ];
@@ -101,7 +101,7 @@ public class ImgUtil
 	/**
 	 * @see ImgUtil#copy(double[], int, int[], Img)
 	 */
-	public static < T extends RealType< T >> void copy( final float[] src, final int offset, final int[] stride, final Img< T > dest )
+	public static < T extends RealType< T > > void copy( final float[] src, final int offset, final int[] stride, final Img< T > dest )
 	{
 		final Cursor< T > c = dest.localizingCursor();
 		final int[] location = new int[ dest.numDimensions() ];
@@ -121,7 +121,7 @@ public class ImgUtil
 	/**
 	 * @see ImgUtil#copy(double[], int, int[], Img)
 	 */
-	public static < T extends IntegerType< T >> void copy( final long[] src, final int offset, final int[] stride, final Img< T > dest )
+	public static < T extends IntegerType< T > > void copy( final long[] src, final int offset, final int[] stride, final Img< T > dest )
 	{
 		final Cursor< T > c = dest.localizingCursor();
 		final int[] location = new int[ dest.numDimensions() ];
@@ -141,7 +141,7 @@ public class ImgUtil
 	/**
 	 * @see ImgUtil#copy(double[], int, int[], Img)
 	 */
-	public static < T extends IntegerType< T >> void copy( final int[] src, final int offset, final int[] stride, final Img< T > dest )
+	public static < T extends IntegerType< T > > void copy( final int[] src, final int offset, final int[] stride, final Img< T > dest )
 	{
 		final Cursor< T > c = dest.localizingCursor();
 		final int[] location = new int[ dest.numDimensions() ];
@@ -161,7 +161,7 @@ public class ImgUtil
 	/**
 	 * @see ImgUtil#copy(double[], int, int[], Img)
 	 */
-	public static < T extends BooleanType< T >> void copy( final boolean[] src, final int offset, final int[] stride, final Img< T > dest )
+	public static < T extends BooleanType< T > > void copy( final boolean[] src, final int offset, final int[] stride, final Img< T > dest )
 	{
 		final Cursor< T > c = dest.localizingCursor();
 		final int[] location = new int[ dest.numDimensions() ];
@@ -195,7 +195,7 @@ public class ImgUtil
 	 * @see ImgUtil#copy(double[], int, int[], Img) for a more comprehensive
 	 *      description of addressing
 	 */
-	public static < T extends RealType< T >> void copy( final Img< T > src, final double[] dest, final int offset, final int[] stride )
+	public static < T extends RealType< T > > void copy( final Img< T > src, final double[] dest, final int offset, final int[] stride )
 	{
 		final Cursor< T > c = src.localizingCursor();
 		final int[] location = new int[ src.numDimensions() ];
@@ -215,7 +215,7 @@ public class ImgUtil
 	/**
 	 * @see ImgUtil#copy(Img, double[], int, int[])
 	 */
-	public static < T extends RealType< T >> void copy( final Img< T > src, final float[] dest, final int offset, final int[] stride )
+	public static < T extends RealType< T > > void copy( final Img< T > src, final float[] dest, final int offset, final int[] stride )
 	{
 		final Cursor< T > c = src.localizingCursor();
 		final int[] location = new int[ src.numDimensions() ];
@@ -235,7 +235,7 @@ public class ImgUtil
 	/**
 	 * @see ImgUtil#copy(Img, double[], int, int[])
 	 */
-	public static < T extends IntegerType< T >> void copy( final Img< T > src, final long[] dest, final int offset, final int[] stride )
+	public static < T extends IntegerType< T > > void copy( final Img< T > src, final long[] dest, final int offset, final int[] stride )
 	{
 		final Cursor< T > c = src.localizingCursor();
 		final int[] location = new int[ src.numDimensions() ];
@@ -255,7 +255,7 @@ public class ImgUtil
 	/**
 	 * @see ImgUtil#copy(Img, double[], int, int[])
 	 */
-	public static < T extends IntegerType< T >> void copy( final Img< T > src, final int[] dest, final int offset, final int[] stride )
+	public static < T extends IntegerType< T > > void copy( final Img< T > src, final int[] dest, final int offset, final int[] stride )
 	{
 		final Cursor< T > c = src.localizingCursor();
 		final int[] location = new int[ src.numDimensions() ];
@@ -271,11 +271,11 @@ public class ImgUtil
 			dest[ this_offset ] = t.getInteger();
 		}
 	}
-	
+
 	/**
 	 * @see ImgUtil#copy(Img, double[], int, int[])
 	 */
-	public static < T extends IntegerType< T >> void copy( final Img< T > src, final short[] dest, final int offset, final int[] stride )
+	public static < T extends IntegerType< T > > void copy( final Img< T > src, final short[] dest, final int offset, final int[] stride )
 	{
 		final Cursor< T > c = src.localizingCursor();
 		final int[] location = new int[ src.numDimensions() ];
@@ -288,14 +288,14 @@ public class ImgUtil
 			{
 				this_offset += location[ i ] * stride[ i ];
 			}
-			dest[ this_offset ] = (short) t.getInteger();
+			dest[ this_offset ] = ( short ) t.getInteger();
 		}
 	}
 
 	/**
 	 * @see ImgUtil#copy(Img, double[], int, int[])
 	 */
-	public static < T extends BooleanType< T >> void copy( final Img< T > src, final boolean[] dest, final int offset, final int[] stride )
+	public static < T extends BooleanType< T > > void copy( final Img< T > src, final boolean[] dest, final int offset, final int[] stride )
 	{
 		final Cursor< T > c = src.localizingCursor();
 		final int[] location = new int[ src.numDimensions() ];
@@ -311,14 +311,15 @@ public class ImgUtil
 			dest[ this_offset ] = t.get();
 		}
 	}
-	
+
 	/**
 	 * Copy one image into another, multi-threaded.
 	 */
-	public static < T extends Type< T >> void copy( final RandomAccessibleInterval< T > source, final RandomAccessibleInterval< T > destination )
+	public static < T extends Type< T > > void copy( final RandomAccessibleInterval< T > source,
+			final RandomAccessibleInterval< T > destination )
 	{
-		LoopBuilder.setImages(source, destination)
+		LoopBuilder.setImages( source, destination )
 				.multiThreaded()
-				.forEachPixel( (i,o) -> o.set(i) );
+				.forEachPixel( ( i, o ) -> o.set( i ) );
 	}
 }

--- a/src/main/java/net/imglib2/util/IntervalIndexer.java
+++ b/src/main/java/net/imglib2/util/IntervalIndexer.java
@@ -324,17 +324,20 @@ public class IntervalIndexer
 		return ( index / steps[ dimension ] ) % dimensions[ dimension ];
 	}
 
-	final static public int indexToPositionWithOffset( final int index, final int[] dimensions, final int[] steps, final int[] offset, final int dimension )
+	final static public int indexToPositionWithOffset( final int index, final int[] dimensions, final int[] steps, final int[] offset,
+			final int dimension )
 	{
 		return indexToPosition( index, dimensions, steps, dimension ) + offset[ dimension ];
 	}
 
-	public static long indexToPositionWithOffset( final int index, final int[] dimensions, final int[] steps, final long[] offset, final int dimension )
+	public static long indexToPositionWithOffset( final int index, final int[] dimensions, final int[] steps, final long[] offset,
+			final int dimension )
 	{
 		return indexToPosition( index, dimensions, steps, dimension ) + offset[ dimension ];
 	}
 
-	final static public long indexToPositionWithOffset( final long index, final long[] dimensions, final long[] steps, final long[] offsets, final int dimension )
+	final static public long indexToPositionWithOffset( final long index, final long[] dimensions, final long[] steps, final long[] offsets,
+			final int dimension )
 	{
 		return indexToPosition( index, dimensions, steps, dimension ) + offsets[ dimension ];
 	}

--- a/src/main/java/net/imglib2/util/Intervals.java
+++ b/src/main/java/net/imglib2/util/Intervals.java
@@ -584,9 +584,9 @@ public class Intervals
 	{
 		assert intervalA.numDimensions() == intervalB.numDimensions();
 
-		if( isEmpty( intervalA ))
+		if ( isEmpty( intervalA ) )
 			return new FinalInterval( intervalB );
-		else if( isEmpty( intervalB ))
+		else if ( isEmpty( intervalB ) )
 			return new FinalInterval( intervalA );
 
 		return unionUnsafe( intervalA, intervalB );
@@ -636,9 +636,9 @@ public class Intervals
 	{
 		assert intervalA.numDimensions() == intervalB.numDimensions();
 
-		if( isEmpty( intervalA ))
+		if ( isEmpty( intervalA ) )
 			return new FinalRealInterval( intervalB );
-		else if( isEmpty( intervalB ))
+		else if ( isEmpty( intervalB ) )
 			return new FinalRealInterval( intervalA );
 
 		return unionUnsafe( intervalA, intervalB );
@@ -881,7 +881,7 @@ public class Intervals
 	 * With respect to the given tolerance.
 	 */
 	public static boolean equals( final RealInterval a, final RealInterval b,
-			final double tolerance)
+			final double tolerance )
 	{
 		if ( a.numDimensions() != b.numDimensions() )
 			return false;
@@ -1120,8 +1120,9 @@ public class Intervals
 	 * @param interval
 	 *            Interval of the returned image.
 	 */
-	public static RandomAccessibleInterval< Localizable > positions( final Interval interval ) {
-		return Localizables.randomAccessibleInterval( interval);
+	public static RandomAccessibleInterval< Localizable > positions( final Interval interval )
+	{
+		return Localizables.randomAccessibleInterval( interval );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/util/IterablePair.java
+++ b/src/main/java/net/imglib2/util/IterablePair.java
@@ -53,49 +53,64 @@ import java.util.Iterator;
  * @param <A>
  * @param <B>
  */
-public class IterablePair<A, B> implements Iterable<Pair<A, B>> {
+public class IterablePair< A, B > implements Iterable< Pair< A, B > >
+{
 
-	private final Iterable<A> iter1;
-	private final Iterable<B> iter2;
+	private final Iterable< A > iter1;
 
-	public IterablePair(final Iterable<A> iter1, final Iterable<B> iter2) {
+	private final Iterable< B > iter2;
+
+	public IterablePair( final Iterable< A > iter1, final Iterable< B > iter2 )
+	{
 		this.iter1 = iter1;
 		this.iter2 = iter2;
 	}
 
 	@Override
-	public Iterator<Pair<A, B>> iterator() {
-		return new Iterator<Pair<A, B>>() {
+	public Iterator< Pair< A, B > > iterator()
+	{
+		return new Iterator< Pair< A, B > >()
+		{
 
-			private final Iterator<A> i1 = iter1.iterator();
-			private final Iterator<B> i2 = iter2.iterator();
+			private final Iterator< A > i1 = iter1.iterator();
+
+			private final Iterator< B > i2 = iter2.iterator();
+
 			private A e1;
+
 			private B e2;
-			private final Pair<A, B> value = new Pair<A, B>() {
+
+			private final Pair< A, B > value = new Pair< A, B >()
+			{
 
 				@Override
-				public A getA() {
+				public A getA()
+				{
 					return e1;
 				}
 
 				@Override
-				public B getB() {
+				public B getB()
+				{
 					return e2;
 				}
 
 				@Override
-				public String toString() {
+				public String toString()
+				{
 					return e1 + ", " + e2;
 				}
 			};
 
 			@Override
-			public boolean hasNext() {
+			public boolean hasNext()
+			{
 				return i1.hasNext() && i2.hasNext();
 			}
 
 			@Override
-			public Pair<A, B> next() {
+			public Pair< A, B > next()
+			{
 				e1 = i1.next();
 				e2 = i2.next();
 				return value;

--- a/src/main/java/net/imglib2/util/KthElement.java
+++ b/src/main/java/net/imglib2/util/KthElement.java
@@ -513,7 +513,8 @@ public class KthElement
 	 * @param comparator
 	 *            ordering function on T
 	 */
-	public static < T > void kthElement( final ListIterator< T > i, final ListIterator< T > j, final int k, final Comparator< ? super T > comparator )
+	public static < T > void kthElement( final ListIterator< T > i, final ListIterator< T > j, final int k,
+			final Comparator< ? super T > comparator )
 	{
 		while ( true )
 		{
@@ -620,7 +621,8 @@ public class KthElement
 	 * @param comparator
 	 *            ordering function on T
 	 */
-	public static < T > void kthElement( int i, int j, final int k, final List< T > values, final int[] permutation, final Comparator< ? super T > comparator )
+	public static < T > void kthElement( int i, int j, final int k, final List< T > values, final int[] permutation,
+			final Comparator< ? super T > comparator )
 	{
 		while ( true )
 		{
@@ -665,7 +667,8 @@ public class KthElement
 	 * @param comparator
 	 *            ordering function on T
 	 */
-	public static < T > void kthElement( final int k, final List< T > values, final int[] permutation, final Comparator< ? super T > comparator )
+	public static < T > void kthElement( final int k, final List< T > values, final int[] permutation,
+			final Comparator< ? super T > comparator )
 	{
 		kthElement( 0, values.size() - 1, k, values, permutation, comparator );
 	}
@@ -697,7 +700,8 @@ public class KthElement
 	 *            elements of this array are permuted in the same way as the
 	 *            elements in the values list
 	 */
-	public static < T extends Comparable< T > > void kthElement( int i, int j, final int k, final List< T > values, final int[] permutation )
+	public static < T extends Comparable< T > > void kthElement( int i, int j, final int k, final List< T > values,
+			final int[] permutation )
 	{
 		while ( true )
 		{
@@ -780,7 +784,8 @@ public class KthElement
 	 * @param comparator
 	 *            ordering function on T
 	 */
-	public static < T > void kthElement( final ListIterator< T > i, final ListIterator< T > j, final int k, final int[] permutation, final Comparator< ? super T > comparator )
+	public static < T > void kthElement( final ListIterator< T > i, final ListIterator< T > j, final int k, final int[] permutation,
+			final Comparator< ? super T > comparator )
 	{
 		while ( true )
 		{
@@ -842,7 +847,8 @@ public class KthElement
 	 *            elements of this array are permuted in the same way as the
 	 *            elements in the values list
 	 */
-	public static < T extends Comparable< T > > void kthElement( final ListIterator< T > i, final ListIterator< T > j, final int k, final int[] permutation )
+	public static < T extends Comparable< T > > void kthElement( final ListIterator< T > i, final ListIterator< T > j, final int k,
+			final int[] permutation )
 	{
 		while ( true )
 		{

--- a/src/main/java/net/imglib2/util/LinAlgHelpers.java
+++ b/src/main/java/net/imglib2/util/LinAlgHelpers.java
@@ -815,17 +815,15 @@ public class LinAlgHelpers
 	 */
 	final static public double det3x3( final double[] a )
 	{
-		assert a.length >= 9 : "Not enough coordinates.";
+		assert a.length >= 9: "Not enough coordinates.";
 
-		return
-			a[ 0 ] * a[ 4 ] * a[ 8 ] +
-			a[ 3 ] * a[ 7 ] * a[ 2 ] +
-			a[ 6 ] * a[ 1 ] * a[ 5 ] -
-			a[ 2 ] * a[ 4 ] * a[ 6 ] -
-			a[ 5 ] * a[ 7 ] * a[ 0 ] -
-			a[ 8 ] * a[ 1 ] * a[ 3 ];
+		return a[ 0 ] * a[ 4 ] * a[ 8 ] +
+				a[ 3 ] * a[ 7 ] * a[ 2 ] +
+				a[ 6 ] * a[ 1 ] * a[ 5 ] -
+				a[ 2 ] * a[ 4 ] * a[ 6 ] -
+				a[ 5 ] * a[ 7 ] * a[ 0 ] -
+				a[ 8 ] * a[ 1 ] * a[ 3 ];
 	}
-
 
 	/**
 	 * Calculate the determinant of a 3x3 matrix.
@@ -847,13 +845,12 @@ public class LinAlgHelpers
 			final double m10, final double m11, final double m12,
 			final double m20, final double m21, final double m22 )
 	{
-		return
-			m00 * m11 * m22 +
-			m10 * m21 * m02 +
-			m20 * m01 * m12 -
-			m02 * m11 * m20 -
-			m12 * m21 * m00 -
-			m22 * m01 * m10;
+		return m00 * m11 * m22 +
+				m10 * m21 * m02 +
+				m20 * m01 * m12 -
+				m02 * m11 * m20 -
+				m12 * m21 * m00 -
+				m22 * m01 * m10;
 	}
 
 	/**
@@ -865,10 +862,11 @@ public class LinAlgHelpers
 	 */
 	final static public void invert3x3( final double[] m ) throws IllegalArgumentException
 	{
-		assert m.length >= 9 : "Not enough coordinates.";
+		assert m.length >= 9: "Not enough coordinates.";
 
 		final double det = det3x3( m );
-		if ( det == 0 ) throw new IllegalArgumentException( "Matrix not invertible." );
+		if ( det == 0 )
+			throw new IllegalArgumentException( "Matrix not invertible." );
 
 		final double i00 = ( m[ 4 ] * m[ 8 ] - m[ 5 ] * m[ 7 ] ) / det;
 		final double i01 = ( m[ 2 ] * m[ 7 ] - m[ 1 ] * m[ 8 ] ) / det;
@@ -908,9 +906,10 @@ public class LinAlgHelpers
 			final double m20, final double m21, final double m22 ) throws IllegalArgumentException
 	{
 		final double det = det3x3( m00, m01, m02, m10, m11, m12, m20, m21, m22 );
-		if ( det == 0 ) throw new IllegalArgumentException( "Matrix not invertible." );
+		if ( det == 0 )
+			throw new IllegalArgumentException( "Matrix not invertible." );
 
-		return new double[]{
+		return new double[] {
 				( m11 * m22 - m12 * m21 ) / det, ( m02 * m21 - m01 * m22 ) / det, ( m01 * m12 - m02 * m11 ) / det,
 				( m12 * m20 - m10 * m22 ) / det, ( m00 * m22 - m02 * m20 ) / det, ( m02 * m10 - m00 * m12 ) / det,
 				( m10 * m21 - m11 * m20 ) / det, ( m01 * m20 - m00 * m21 ) / det, ( m00 * m11 - m01 * m10 ) / det };

--- a/src/main/java/net/imglib2/util/Partition.java
+++ b/src/main/java/net/imglib2/util/Partition.java
@@ -843,7 +843,8 @@ public class Partition
 	 *            ordering function on T
 	 * @return index of pivot element
 	 */
-	public static < T > int partitionSubList( int i, int j, final List< T > values, final int[] permutation, final Comparator< ? super T > compare )
+	public static < T > int partitionSubList( int i, int j, final List< T > values, final int[] permutation,
+			final Comparator< ? super T > compare )
 	{
 		final int pivotIndex = j;
 		final int permutationPivot = permutation[ j ];
@@ -1026,7 +1027,8 @@ public class Partition
 	 * @param compare
 	 *            ordering function on T
 	 */
-	public static < T > void partitionSubList( final ListIterator< T > i, final ListIterator< T > j, final int[] permutation, final Comparator< ? super T > compare )
+	public static < T > void partitionSubList( final ListIterator< T > i, final ListIterator< T > j, final int[] permutation,
+			final Comparator< ? super T > compare )
 	{
 		final int pivotIndex = j.previousIndex();
 		final int permutationPivot = permutation[ pivotIndex ];
@@ -1113,7 +1115,8 @@ public class Partition
 	 *            elements of this array are permuted in the same way as the
 	 *            elements in the values list
 	 */
-	public static < T extends Comparable< T > > void partitionSubList( final ListIterator< T > i, final ListIterator< T > j, final int[] permutation )
+	public static < T extends Comparable< T > > void partitionSubList( final ListIterator< T > i, final ListIterator< T > j,
+			final int[] permutation )
 	{
 		final int pivotIndex = j.previousIndex();
 		final int permutationPivot = permutation[ pivotIndex ];

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -332,7 +332,7 @@ public class Util
 
 		return median;
 	}
-	
+
 	public static void quicksort( final long[] data )
 	{
 		quicksort( data, 0, data.length - 1 );
@@ -542,7 +542,6 @@ public class Util
 	{
 		return ( long ) ( value + ( 0.5d * Math.signum( value ) ) );
 	}
-
 
 	/**
 	 * This method creates a gaussian kernel
@@ -821,7 +820,7 @@ public class Util
 	 *            - the {@link RandomAccessibleInterval}
 	 * @return - an instance of T
 	 */
-	final public static < T, F extends RealInterval & RealRandomAccessible< T >> T getTypeFromRealInterval( final F rai )
+	final public static < T, F extends RealInterval & RealRandomAccessible< T > > T getTypeFromRealInterval( final F rai )
 	{
 		// create RealRandomAccess
 		final RealRandomAccess< T > realRandomAccess = rai.realRandomAccess();
@@ -864,14 +863,16 @@ public class Util
 	 *            type of the factory.
 	 * @return an {@link ArrayImgFactory} or a {@link CellImgFactory}.
 	 */
-	public static < T extends NativeType< T > > ImgFactory< T > getArrayOrCellImgFactory( final Dimensions targetSize, final int targetCellSize, final T type )
+	public static < T extends NativeType< T > > ImgFactory< T > getArrayOrCellImgFactory( final Dimensions targetSize,
+			final int targetCellSize, final T type )
 	{
 		Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		final long numElements = Intervals.numElements( targetSize );
 		final long numEntities = entitiesPerPixel.mulCeil( numElements );
 		if ( numElements <= Integer.MAX_VALUE && numEntities <= MAX_ARRAY_SIZE )
 			return new ArrayImgFactory<>( type );
-		final int maxCellSize = ( int ) Math.pow( Math.min( MAX_ARRAY_SIZE / entitiesPerPixel.getRatio(), Integer.MAX_VALUE ), 1.0 / targetSize.numDimensions() );
+		final int maxCellSize = ( int ) Math.pow( Math.min( MAX_ARRAY_SIZE / entitiesPerPixel.getRatio(), Integer.MAX_VALUE ),
+				1.0 / targetSize.numDimensions() );
 		final int cellSize = Math.min( targetCellSize, maxCellSize );
 		return new CellImgFactory<>( type, cellSize );
 	}
@@ -903,8 +904,7 @@ public class Util
 					return factory.imgFactory( type );
 				}
 				catch ( IncompatibleTypeException e )
-				{
-				}
+				{}
 			}
 		}
 		if ( type instanceof NativeType )
@@ -1011,7 +1011,8 @@ public class Util
 	/**
 	 * Checks if both images have equal intervals and content.
 	 */
-	public static < T extends ValueEquals< U >, U > boolean imagesEqual( final RandomAccessibleInterval< ? extends T > a, final RandomAccessibleInterval< ? extends U > b )
+	public static < T extends ValueEquals< U >, U > boolean imagesEqual( final RandomAccessibleInterval< ? extends T > a,
+			final RandomAccessibleInterval< ? extends U > b )
 	{
 		return imagesEqual( a, b, ValueEquals::valueEquals );
 	}
@@ -1020,7 +1021,8 @@ public class Util
 	 * Checks if both images have equal intervals and content.
 	 * A predicate must be given to check if two pixels are equal.
 	 */
-	public static < T, U > boolean imagesEqual( final RandomAccessibleInterval< ? extends T > a, final RandomAccessibleInterval< ? extends U > b, final BiPredicate< T, U > pixelEquals )
+	public static < T, U > boolean imagesEqual( final RandomAccessibleInterval< ? extends T > a,
+			final RandomAccessibleInterval< ? extends U > b, final BiPredicate< T, U > pixelEquals )
 	{
 		if ( !Intervals.equals( a, b ) )
 			return false;

--- a/src/main/java/net/imglib2/util/ValuePair.java
+++ b/src/main/java/net/imglib2/util/ValuePair.java
@@ -34,7 +34,6 @@
 
 package net.imglib2.util;
 
-
 /**
  * TODO
  * 
@@ -62,7 +61,7 @@ public class ValuePair< A, B > implements Pair< A, B >
 	{
 		return b;
 	}
-	
+
 	@Override
 	public int hashCode()
 	{
@@ -74,15 +73,15 @@ public class ValuePair< A, B > implements Pair< A, B >
 	}
 
 	@Override
-	public boolean equals(Object obj)
+	public boolean equals( Object obj )
 	{
 		if ( this == obj )
 			return true;
 		if ( obj == null )
 			return false;
-		if ( !(obj instanceof Pair) )
+		if ( !( obj instanceof Pair ) )
 			return false;
-		Pair other = (Pair) obj;
+		Pair other = ( Pair ) obj;
 		if ( a == null )
 		{
 			if ( other.getA() != null )

--- a/src/main/java/net/imglib2/view/ExtendedRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/view/ExtendedRandomAccessibleInterval.java
@@ -80,7 +80,10 @@ final public class ExtendedRandomAccessibleInterval< T, F extends RandomAccessib
 	{
 		assert source.numDimensions() == interval.numDimensions();
 
-		if ( Intervals.contains( source, interval ) ) { return source.randomAccess( interval ); }
+		if ( Intervals.contains( source, interval ) )
+		{
+			return source.randomAccess( interval );
+		}
 		return randomAccess();
 	}
 
@@ -88,7 +91,7 @@ final public class ExtendedRandomAccessibleInterval< T, F extends RandomAccessib
 	{
 		return source;
 	}
-	
+
 	public OutOfBoundsFactory< T, ? super F > getOutOfBoundsFactory()
 	{
 		return factory;

--- a/src/main/java/net/imglib2/view/ExtendedRealRandomAccessibleRealInterval.java
+++ b/src/main/java/net/imglib2/view/ExtendedRealRandomAccessibleRealInterval.java
@@ -49,7 +49,8 @@ import net.imglib2.util.Intervals;
  * 
  * @author Stephan Saalfeld
  */
-final public class ExtendedRealRandomAccessibleRealInterval< T, F extends RealRandomAccessibleRealInterval< T > > implements RealRandomAccessible< T >
+final public class ExtendedRealRandomAccessibleRealInterval< T, F extends RealRandomAccessibleRealInterval< T > >
+		implements RealRandomAccessible< T >
 {
 	final protected F source;
 
@@ -78,7 +79,10 @@ final public class ExtendedRealRandomAccessibleRealInterval< T, F extends RealRa
 	{
 		assert source.numDimensions() == interval.numDimensions();
 
-		if ( Intervals.contains( source, interval ) ) { return source.realRandomAccess(); }
+		if ( Intervals.contains( source, interval ) )
+		{
+			return source.realRandomAccess();
+		}
 		return realRandomAccess();
 	}
 

--- a/src/main/java/net/imglib2/view/HyperSlice.java
+++ b/src/main/java/net/imglib2/view/HyperSlice.java
@@ -48,6 +48,7 @@ import net.imglib2.RandomAccessible;
 public class HyperSlice< T > implements RandomAccessible< T >
 {
 	final protected RandomAccessible< T > source;
+
 	final protected int numDimensions;
 
 	/* in the hyperslice */
@@ -66,7 +67,7 @@ public class HyperSlice< T > implements RandomAccessible< T >
 	 */
 	private Interval sourceInterval( final Interval interval )
 	{
-		assert interval.numDimensions() == axes.length : "Interval dimensions do not match Hyperslice dimensions.";
+		assert interval.numDimensions() == axes.length: "Interval dimensions do not match Hyperslice dimensions.";
 
 		final long[] min = new long[ numDimensions ];
 		final long[] max = new long[ numDimensions ];
@@ -280,8 +281,8 @@ public class HyperSlice< T > implements RandomAccessible< T >
 				axes[ db++ ] = d;
 		}
 
-//		System.out.println( "axes       " + Arrays.toString( axes ) );
-//		System.out.println( "fixed axes " + Arrays.toString( sortedFixedAxes ) );
+		//		System.out.println( "axes       " + Arrays.toString( axes ) );
+		//		System.out.println( "fixed axes " + Arrays.toString( sortedFixedAxes ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/view/HyperSlicesView.java
+++ b/src/main/java/net/imglib2/view/HyperSlicesView.java
@@ -55,6 +55,7 @@ import net.imglib2.RandomAccessible;
 public class HyperSlicesView< T > implements RandomAccessible< HyperSlice< T > >
 {
 	final protected RandomAccessible< T > source;
+
 	final protected int numDimensions;
 
 	/* outside of the hyperslice */
@@ -122,6 +123,5 @@ public class HyperSlicesView< T > implements RandomAccessible< HyperSlice< T > >
 		 * one pixel thick (constant) in all outer dimensions */
 		return randomAccess();
 	}
-
 
 }

--- a/src/main/java/net/imglib2/view/IntervalView.java
+++ b/src/main/java/net/imglib2/view/IntervalView.java
@@ -64,7 +64,7 @@ public class IntervalView< T > extends AbstractInterval implements RandomAccessi
 	 * TODO Javadoc
 	 */
 	protected RandomAccessible< T > fullViewRandomAccessible;
-	
+
 	/**
 	 * TODO Javadoc
 	 */
@@ -130,7 +130,7 @@ public class IntervalView< T > extends AbstractInterval implements RandomAccessi
 			fullViewRandomAccessible = TransformBuilder.getEfficientRandomAccessible( this, this );
 		return fullViewRandomAccessible.randomAccess();
 	}
-	
+
 	protected IterableInterval< T > getFullViewIterableInterval()
 	{
 		if ( fullViewIterableInterval == null )

--- a/src/main/java/net/imglib2/view/IterableRandomAccessibleInterval.java
+++ b/src/main/java/net/imglib2/view/IterableRandomAccessibleInterval.java
@@ -52,7 +52,8 @@ import net.imglib2.View;
  * 
  * @author Stephan Saalfeld
  */
-public class IterableRandomAccessibleInterval< T > extends AbstractWrappedInterval< RandomAccessibleInterval< T > > implements IterableInterval< T >, RandomAccessibleInterval< T >, View
+public class IterableRandomAccessibleInterval< T > extends AbstractWrappedInterval< RandomAccessibleInterval< T > >
+		implements IterableInterval< T >, RandomAccessibleInterval< T >, View
 {
 	final long size;
 

--- a/src/main/java/net/imglib2/view/RandomAccessibleOnRealRandomAccessible.java
+++ b/src/main/java/net/imglib2/view/RandomAccessibleOnRealRandomAccessible.java
@@ -209,7 +209,7 @@ public class RandomAccessibleOnRealRandomAccessible< T > extends AbstractEuclide
 
 	public RealRandomAccessible< T > getSource()
 	{
-	    return source;
+		return source;
 	}
 
 	public RandomAccessibleOnRealRandomAccessible( final RealRandomAccessible< T > source )

--- a/src/main/java/net/imglib2/view/RandomAccessiblePair.java
+++ b/src/main/java/net/imglib2/view/RandomAccessiblePair.java
@@ -49,11 +49,13 @@ import net.imglib2.util.Pair;
 public class RandomAccessiblePair< A, B > implements RandomAccessible< Pair< A, B > >
 {
 	final protected RandomAccessible< A > sourceA;
+
 	final protected RandomAccessible< B > sourceB;
 
 	public class RandomAccess implements Pair< A, B >, net.imglib2.RandomAccess< Pair< A, B > >
 	{
 		final protected net.imglib2.RandomAccess< A > a;
+
 		final protected net.imglib2.RandomAccess< B > b;
 
 		public RandomAccess()

--- a/src/main/java/net/imglib2/view/StackView.java
+++ b/src/main/java/net/imglib2/view/StackView.java
@@ -134,17 +134,15 @@ public class StackView< T > extends AbstractInterval implements RandomAccessible
 	@Override
 	public RandomAccess< T > randomAccess()
 	{
-		return stackAccessMode == StackAccessMode.MOVE_ALL_SLICE_ACCESSES ?
-				new MoveAllSlicesRA< T >( slices ) :
-				new DefaultRA< T >( slices );
+		return stackAccessMode == StackAccessMode.MOVE_ALL_SLICE_ACCESSES ? new MoveAllSlicesRA< T >( slices )
+				: new DefaultRA< T >( slices );
 	}
 
 	@Override
 	public RandomAccess< T > randomAccess( final Interval interval )
 	{
-		return stackAccessMode == StackAccessMode.MOVE_ALL_SLICE_ACCESSES ?
-				new MoveAllSlicesRA< T >( slices, interval ) :
-				new DefaultRA< T >( slices, interval );
+		return stackAccessMode == StackAccessMode.MOVE_ALL_SLICE_ACCESSES ? new MoveAllSlicesRA< T >( slices, interval )
+				: new DefaultRA< T >( slices, interval );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/view/SubsampleIntervalView.java
+++ b/src/main/java/net/imglib2/view/SubsampleIntervalView.java
@@ -67,7 +67,7 @@ public class SubsampleIntervalView< T > extends SubsampleView< T > implements Ra
 		for ( int d = 0; d < steps.length; ++d )
 		{
 			steps[ d ] = step;
-			dimensions[ d ] = ( int )Math.ceil( ( double )source.dimension( d ) / step );
+			dimensions[ d ] = ( int ) Math.ceil( ( double ) source.dimension( d ) / step );
 			max[ d ] = dimensions[ d ] - 1;
 		}
 	}
@@ -81,7 +81,7 @@ public class SubsampleIntervalView< T > extends SubsampleView< T > implements Ra
 		for ( int d = 0; d < steps.length; ++d )
 		{
 			this.steps[ d ] = steps[ d ];
-			dimensions[ d ] = ( int )Math.ceil( ( double )source.dimension( d ) / steps[ d ]);
+			dimensions[ d ] = ( int ) Math.ceil( ( double ) source.dimension( d ) / steps[ d ] );
 			max[ d ] = dimensions[ d ] - 1;
 		}
 	}

--- a/src/main/java/net/imglib2/view/TransformBuilder.java
+++ b/src/main/java/net/imglib2/view/TransformBuilder.java
@@ -76,7 +76,8 @@ public class TransformBuilder< T >
 	 *            The interval in which access is needed.
 	 * @param randomAccessible
 	 */
-	public static < S > RandomAccessible< S > getEfficientRandomAccessible( final Interval interval, final RandomAccessible< S > randomAccessible )
+	public static < S > RandomAccessible< S > getEfficientRandomAccessible( final Interval interval,
+			final RandomAccessible< S > randomAccessible )
 	{
 		return new TransformBuilder< S >( interval, randomAccessible ).build();
 	}
@@ -315,13 +316,13 @@ public class TransformBuilder< T >
 					i.set( new TranslationTransform( translation ) );
 				}
 				// else if ( isComponentMapping( mixed ) )
-//				{
-//					// found pure component mapping
-//					// replace by a ComponentMappingTransform
-//					final int[] component = new int[ mixed.numTargetDimensions() ];
-//					mixed.getComponentMapping( component );
-//					i.set( new ComponentMappingTransform( component ) );
-//				}
+				//				{
+				//					// found pure component mapping
+				//					// replace by a ComponentMappingTransform
+				//					final int[] component = new int[ mixed.numTargetDimensions() ];
+				//					mixed.getComponentMapping( component );
+				//					i.set( new ComponentMappingTransform( component ) );
+				//				}
 				else if ( isSlicing( mixed ) )
 				{
 					// found pure slicing

--- a/src/main/java/net/imglib2/view/TransformRandomAccess.java
+++ b/src/main/java/net/imglib2/view/TransformRandomAccess.java
@@ -184,8 +184,8 @@ public final class TransformRandomAccess< T > extends AbstractLocalizable implem
 	@Override
 	public T get()
 	{
-        transformToSource.apply( position, tmp );
-        source.setPosition( tmp );
+		transformToSource.apply( position, tmp );
+		source.setPosition( tmp );
 		return source.get();
 	}
 

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -109,7 +109,8 @@ public class Views
 	 *            source
 	 * @return
 	 */
-	public static < T, F extends EuclideanSpace > RealRandomAccessible< T > interpolate( final F source, final InterpolatorFactory< T, F > factory )
+	public static < T, F extends EuclideanSpace > RealRandomAccessible< T > interpolate( final F source,
+			final InterpolatorFactory< T, F > factory )
 	{
 		return new Interpolant<>( source, factory, source.numDimensions() );
 	}
@@ -140,7 +141,8 @@ public class Views
 	 * @return (unbounded) RandomAccessible which extends the input interval to
 	 *         infinity.
 	 */
-	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extend( final F source, final OutOfBoundsFactory< T, ? super F > factory )
+	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extend( final F source,
+			final OutOfBoundsFactory< T, ? super F > factory )
 	{
 		return new ExtendedRandomAccessibleInterval<>( source, factory );
 	}
@@ -156,7 +158,8 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsMirrorSingleBoundary
 	 */
-	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendMirrorSingle( final F source )
+	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendMirrorSingle( final F source )
 	{
 		return new ExtendedRandomAccessibleInterval<>( source, new OutOfBoundsMirrorFactory<>( OutOfBoundsMirrorFactory.Boundary.SINGLE ) );
 	}
@@ -171,7 +174,8 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsMirrorDoubleBoundary
 	 */
-	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendMirrorDouble( final F source )
+	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendMirrorDouble( final F source )
 	{
 		return new ExtendedRandomAccessibleInterval<>( source, new OutOfBoundsMirrorFactory<>( OutOfBoundsMirrorFactory.Boundary.DOUBLE ) );
 	}
@@ -186,7 +190,8 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final T value )
+	public static < T, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source,
+			final T value )
 	{
 		return new ExtendedRandomAccessibleInterval<>( source, new OutOfBoundsConstantValueFactory<>( value ) );
 	}
@@ -202,9 +207,10 @@ public class Views
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 * @deprecated use {@code extendValue} with unbounded type parameter T
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes", "cast" })
+	@SuppressWarnings( { "unchecked", "rawtypes", "cast" } )
 	@Deprecated
-	public static < T extends Type< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final T value )
+	public static < T extends Type< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendValue( final F source, final T value )
 	{
 		return ( ExtendedRandomAccessibleInterval< T, F > ) Views.extendValue( ( RandomAccessibleInterval ) source, ( Object ) value );
 	}
@@ -221,7 +227,8 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T extends RealType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final float value )
+	public static < T extends RealType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendValue( final F source, final float value )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.setReal( value );
@@ -240,7 +247,8 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T extends RealType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final double value )
+	public static < T extends RealType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendValue( final F source, final double value )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.setReal( value );
@@ -259,7 +267,8 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T extends IntegerType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final int value )
+	public static < T extends IntegerType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendValue( final F source, final int value )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.setInteger( value );
@@ -278,7 +287,8 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T extends IntegerType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final long value )
+	public static < T extends IntegerType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendValue( final F source, final long value )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.setInteger( value );
@@ -297,7 +307,8 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T extends BooleanType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendValue( final F source, final boolean value )
+	public static < T extends BooleanType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendValue( final F source, final boolean value )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.set( value );
@@ -314,7 +325,8 @@ public class Views
 	 *         infinity with a constant value of zero.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T extends NumericType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendZero( final F source )
+	public static < T extends NumericType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendZero( final F source )
 	{
 		final T zero = Util.getTypeFromInterval( source ).createVariable();
 		zero.setZero();
@@ -335,9 +347,11 @@ public class Views
 	 *         infinity.
 	 * @see net.imglib2.outofbounds.OutOfBoundsRandomValue
 	 */
-	public static < T extends RealType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendRandom( final F source, final double min, final double max )
+	public static < T extends RealType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F >
+			extendRandom( final F source, final double min, final double max )
 	{
-		return new ExtendedRandomAccessibleInterval<>( source, new OutOfBoundsRandomValueFactory<>( Util.getTypeFromInterval( source ), min, max ) );
+		return new ExtendedRandomAccessibleInterval<>( source,
+				new OutOfBoundsRandomValueFactory<>( Util.getTypeFromInterval( source ), min, max ) );
 	}
 
 	/**
@@ -412,7 +426,8 @@ public class Views
 	 * interval of an image, this method returns a RandomAccessible of the tiles
 	 * of that image.
 	 */
-	public static < T > RandomAccessible< RandomAccessibleInterval< T > > intervals( final RandomAccessible< T > img, final RandomAccessible< ? extends Interval > intervals )
+	public static < T > RandomAccessible< RandomAccessibleInterval< T > > intervals( final RandomAccessible< T > img,
+			final RandomAccessible< ? extends Interval > intervals )
 	{
 		return new FunctionView<>( intervals, interval -> Views.interval( img, interval ) );
 	}
@@ -426,7 +441,8 @@ public class Views
 	 * interval of an image, this method returns a RandomAccessible of the tiles
 	 * of that image.
 	 */
-	public static < T > RandomAccessibleInterval< RandomAccessibleInterval< T > > intervals( final RandomAccessible< T > img, final RandomAccessibleInterval< ? extends Interval > intervals )
+	public static < T > RandomAccessibleInterval< RandomAccessibleInterval< T > > intervals( final RandomAccessible< T > img,
+			final RandomAccessibleInterval< ? extends Interval > intervals )
 	{
 		return Views.interval( intervals( img, ( RandomAccessible< ? extends Interval > ) intervals ), intervals );
 	}
@@ -439,7 +455,8 @@ public class Views
 	 *     If {@code tileSize.length} doesn't match the number of {@code source}
 	 *     dimensions, it is truncated or extended with 1s.
 	 */
-	public static < T > RandomAccessibleInterval< RandomAccessibleInterval< T > > tiles( final RandomAccessibleInterval< T > source, final long... tileSize )
+	public static < T > RandomAccessibleInterval< RandomAccessibleInterval< T > > tiles( final RandomAccessibleInterval< T > source,
+			final long... tileSize )
 	{
 		long[] b = tileSize;
 		if ( tileSize.length != source.numDimensions() )
@@ -460,7 +477,8 @@ public class Views
 	 *     If {@code tileSize.length} doesn't match the number of {@code source}
 	 *     dimensions, it is truncated or extended with 1s.
 	 */
-	public static < T > RandomAccessibleInterval< RandomAccessibleInterval< T > > tiles( final RandomAccessibleInterval< T > source, final int... tileSize )
+	public static < T > RandomAccessibleInterval< RandomAccessibleInterval< T > > tiles( final RandomAccessibleInterval< T > source,
+			final int... tileSize )
 	{
 		return tiles( source, Util.int2long( tileSize ) );
 	}
@@ -495,7 +513,8 @@ public class Views
 	 */
 	public static < T > IntervalView< T > rotate( final RandomAccessibleInterval< T > interval, final int fromAxis, final int toAxis )
 	{
-		return Views.interval( Views.rotate( ( RandomAccessible< T > ) interval, fromAxis, toAxis ), Intervals.rotate( interval, fromAxis, toAxis ) );
+		return Views.interval( Views.rotate( ( RandomAccessible< T > ) interval, fromAxis, toAxis ),
+				Intervals.rotate( interval, fromAxis, toAxis ) );
 	}
 
 	/**
@@ -505,7 +524,8 @@ public class Views
 	 * is mapped to the Z-Axis of the permuted view and vice versa. For a XYZ
 	 * source, a ZYX view would be created.
 	 */
-	public static < T > MixedTransformView< T > permute( final RandomAccessible< T > randomAccessible, final int fromAxis, final int toAxis )
+	public static < T > MixedTransformView< T > permute( final RandomAccessible< T > randomAccessible, final int fromAxis,
+			final int toAxis )
 	{
 		final int n = randomAccessible.numDimensions();
 		return new MixedTransformView<>( randomAccessible, ViewTransforms.permute( n, fromAxis, toAxis ) );
@@ -520,7 +540,8 @@ public class Views
 	 */
 	public static < T > IntervalView< T > permute( final RandomAccessibleInterval< T > interval, final int fromAxis, final int toAxis )
 	{
-		return Views.interval( Views.permute( ( RandomAccessible< T > ) interval, fromAxis, toAxis ), Intervals.permuteAxes( interval, fromAxis, toAxis ) );
+		return Views.interval( Views.permute( ( RandomAccessible< T > ) interval, fromAxis, toAxis ),
+				Intervals.permuteAxes( interval, fromAxis, toAxis ) );
 	}
 
 	/**
@@ -542,7 +563,8 @@ public class Views
 	 * If fromAxis=2 and toAxis=4, and axis order of image is XYCZT, then a view
 	 * to the image with axis order XYZTC would be created.
 	 */
-	public static < T > RandomAccessibleInterval< T > moveAxis( final RandomAccessibleInterval< T > image, final int fromAxis, final int toAxis )
+	public static < T > RandomAccessibleInterval< T > moveAxis( final RandomAccessibleInterval< T > image, final int fromAxis,
+			final int toAxis )
 	{
 		final int n = image.numDimensions();
 		final Mixed t = ViewTransforms.moveAxis( n, fromAxis, toAxis );
@@ -737,7 +759,8 @@ public class Views
 	 * @param maxOfNewDim
 	 *            Interval max in the additional dimension.
 	 */
-	public static < T > IntervalView< T > addDimension( final RandomAccessibleInterval< T > interval, final long minOfNewDim, final long maxOfNewDim )
+	public static < T > IntervalView< T > addDimension( final RandomAccessibleInterval< T > interval, final long minOfNewDim,
+			final long maxOfNewDim )
 	{
 		return Views.interval( Views.addDimension( interval ), Intervals.addDimension( interval, minOfNewDim, maxOfNewDim ) );
 	}
@@ -782,7 +805,8 @@ public class Views
 	 *            size of the interval.
 	 * @return a RandomAccessibleInterval
 	 */
-	public static < T > IntervalView< T > offsetInterval( final RandomAccessible< T > randomAccessible, final long[] offset, final long[] dimension )
+	public static < T > IntervalView< T > offsetInterval( final RandomAccessible< T > randomAccessible, final long[] offset,
+			final long[] dimension )
 	{
 		final int n = randomAccessible.numDimensions();
 		final long[] min = new long[ n ];
@@ -863,7 +887,8 @@ public class Views
 	@SuppressWarnings( "unchecked" )
 	public static < T > IterableInterval< T > flatIterable( final RandomAccessibleInterval< T > randomAccessibleInterval )
 	{
-		if ( IterableInterval.class.isInstance( randomAccessibleInterval ) && FlatIterationOrder.class.isInstance( ( ( IterableInterval< T > ) randomAccessibleInterval ).iterationOrder() ) )
+		if ( IterableInterval.class.isInstance( randomAccessibleInterval )
+				&& FlatIterationOrder.class.isInstance( ( ( IterableInterval< T > ) randomAccessibleInterval ).iterationOrder() ) )
 		{
 			final Class< ? > raiType = Util.getTypeFromInterval( randomAccessibleInterval ).getClass();
 			final Iterator< ? > iter = ( ( IterableInterval< ? > ) randomAccessibleInterval ).iterator();
@@ -901,7 +926,8 @@ public class Views
 	 * @return an (<em>n</em>-1)-dimensional {@link CompositeIntervalView} of
 	 *         {@link RealComposite RealComposites}
 	 */
-	public static < T extends RealType< T > > CompositeIntervalView< T, RealComposite< T > > collapseReal( final RandomAccessibleInterval< T > source )
+	public static < T extends RealType< T > > CompositeIntervalView< T, RealComposite< T > >
+			collapseReal( final RandomAccessibleInterval< T > source )
 	{
 		return new CompositeIntervalView<>( source, new RealComposite.Factory<>( ( int ) source.dimension( source.numDimensions() - 1 ) ) );
 	}
@@ -917,9 +943,11 @@ public class Views
 	 * @return an (<em>n</em>-1)-dimensional {@link CompositeIntervalView} of
 	 *         {@link NumericComposite NumericComposites}
 	 */
-	public static < T extends NumericType< T > > CompositeIntervalView< T, NumericComposite< T > > collapseNumeric( final RandomAccessibleInterval< T > source )
+	public static < T extends NumericType< T > > CompositeIntervalView< T, NumericComposite< T > >
+			collapseNumeric( final RandomAccessibleInterval< T > source )
 	{
-		return new CompositeIntervalView<>( source, new NumericComposite.Factory<>( ( int ) source.dimension( source.numDimensions() - 1 ) ) );
+		return new CompositeIntervalView<>( source,
+				new NumericComposite.Factory<>( ( int ) source.dimension( source.numDimensions() - 1 ) ) );
 	}
 
 	/**
@@ -952,7 +980,8 @@ public class Views
 	 * @return an (<em>n</em>-1)-dimensional {@link CompositeView} of
 	 *         {@link RealComposite RealComposites}
 	 */
-	public static < T extends RealType< T > > CompositeView< T, RealComposite< T > > collapseReal( final RandomAccessible< T > source, final int numChannels )
+	public static < T extends RealType< T > > CompositeView< T, RealComposite< T > > collapseReal( final RandomAccessible< T > source,
+			final int numChannels )
 	{
 		return new CompositeView<>( source, new RealComposite.Factory<>( numChannels ) );
 	}
@@ -971,7 +1000,8 @@ public class Views
 	 * @return an (<em>n</em>-1)-dimensional {@link CompositeView} of
 	 *         {@link NumericComposite NumericComposites}
 	 */
-	public static < T extends NumericType< T > > CompositeView< T, NumericComposite< T > > collapseNumeric( final RandomAccessible< T > source, final int numChannels )
+	public static < T extends NumericType< T > > CompositeView< T, NumericComposite< T > >
+			collapseNumeric( final RandomAccessible< T > source, final int numChannels )
 	{
 		return new CompositeView<>( source, new NumericComposite.Factory<>( numChannels ) );
 	}
@@ -1112,7 +1142,8 @@ public class Views
 	 * @return a <em>(n+1)</em>-dimensional {@link RandomAccessibleInterval}
 	 *         where the final dimension is the index of the hyperslice.
 	 */
-	public static < T > RandomAccessibleInterval< T > stack( final StackAccessMode stackAccessMode, final List< ? extends RandomAccessibleInterval< T > > hyperslices )
+	public static < T > RandomAccessibleInterval< T > stack( final StackAccessMode stackAccessMode,
+			final List< ? extends RandomAccessibleInterval< T > > hyperslices )
 	{
 		return new StackView<>( hyperslices, stackAccessMode );
 	}
@@ -1132,7 +1163,8 @@ public class Views
 	 * @return a <em>(n+1)</em>-dimensional {@link RandomAccessibleInterval}
 	 *         where the final dimension is the index of the hyperslice.
 	 */
-	public static < T > RandomAccessibleInterval< T > stack( final StackAccessMode stackAccessMode, final RandomAccessibleInterval< T >... hyperslices )
+	public static < T > RandomAccessibleInterval< T > stack( final StackAccessMode stackAccessMode,
+			final RandomAccessibleInterval< T >... hyperslices )
 	{
 		return new StackView<>( Arrays.asList( hyperslices ), stackAccessMode );
 	}
@@ -1151,7 +1183,8 @@ public class Views
 	 *
 	 * @return {@link TransformView} containing the result.
 	 */
-	public static < T > TransformView< T > shear( final RandomAccessible< T > source, final int shearDimension, final int referenceDimension )
+	public static < T > TransformView< T > shear( final RandomAccessible< T > source, final int shearDimension,
+			final int referenceDimension )
 	{
 		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
 		return new TransformView<>( source, transform.inverse() );
@@ -1171,7 +1204,8 @@ public class Views
 	 *
 	 * @return {@link TransformView} containing the result.
 	 */
-	public static < T > TransformView< T > unshear( final RandomAccessible< T > source, final int shearDimension, final int referenceDimension )
+	public static < T > TransformView< T > unshear( final RandomAccessible< T > source, final int shearDimension,
+			final int referenceDimension )
 	{
 		final InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
 		return new TransformView<>( source, transform.inverse() );
@@ -1195,10 +1229,12 @@ public class Views
 	 *         interval's dimension are determined by applying the
 	 *         {@link ShearTransform#transform} method on the input interval.
 	 */
-	public static < T > IntervalView< T > shear( final RandomAccessible< T > source, final Interval interval, final int shearDimension, final int referenceDimension )
+	public static < T > IntervalView< T > shear( final RandomAccessible< T > source, final Interval interval, final int shearDimension,
+			final int referenceDimension )
 	{
 		final ShearTransform transform = new ShearTransform( source.numDimensions(), shearDimension, referenceDimension );
-		return Views.interval( Views.shear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval ) ).getInterval() );
+		return Views.interval( Views.shear( source, shearDimension, referenceDimension ),
+				transform.transform( new BoundingBox( interval ) ).getInterval() );
 	}
 
 	/**
@@ -1219,10 +1255,12 @@ public class Views
 	 *         interval's dimension are determined by applying the
 	 *         {@link ShearTransform#transform} method on the input interval.
 	 */
-	public static < T > IntervalView< T > unshear( final RandomAccessible< T > source, final Interval interval, final int shearDimension, final int referenceDimension )
+	public static < T > IntervalView< T > unshear( final RandomAccessible< T > source, final Interval interval, final int shearDimension,
+			final int referenceDimension )
 	{
 		final InverseShearTransform transform = new InverseShearTransform( source.numDimensions(), shearDimension, referenceDimension );
-		return Views.interval( Views.unshear( source, shearDimension, referenceDimension ), transform.transform( new BoundingBox( interval ) ).getInterval() );
+		return Views.interval( Views.unshear( source, shearDimension, referenceDimension ),
+				transform.transform( new BoundingBox( interval ) ).getInterval() );
 	}
 
 	/**
@@ -1264,7 +1302,8 @@ public class Views
 	 *
 	 * @return {@link IntervalView} of permuted source.
 	 */
-	public static < T > IntervalView< T > permuteCoordinates( final RandomAccessibleInterval< T > source, final int[] permutation, final int d )
+	public static < T > IntervalView< T > permuteCoordinates( final RandomAccessibleInterval< T > source, final int[] permutation,
+			final int d )
 	{
 		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
 		assert source.min( d ) == 0: "Source with min[d] coordinate != 0 passed to coordinate permutation.";
@@ -1318,7 +1357,8 @@ public class Views
 	 *             {@link Views#permuteCoordinatesInverse(RandomAccessibleInterval, int[], int)}
 	 */
 	@Deprecated
-	public static < T > IntervalView< T > permuteCoordinateInverse( final RandomAccessibleInterval< T > source, final int[] permutation, final int d )
+	public static < T > IntervalView< T > permuteCoordinateInverse( final RandomAccessibleInterval< T > source, final int[] permutation,
+			final int d )
 	{
 		return permuteCoordinatesInverse( source, permutation, d );
 	}
@@ -1338,14 +1378,16 @@ public class Views
 	 *
 	 * @return {@link IntervalView} of permuted source.
 	 */
-	public static < T > IntervalView< T > permuteCoordinatesInverse( final RandomAccessibleInterval< T > source, final int[] permutation, final int d )
+	public static < T > IntervalView< T > permuteCoordinatesInverse( final RandomAccessibleInterval< T > source, final int[] permutation,
+			final int d )
 	{
 		assert AbstractPermutationTransform.checkBijectivity( permutation ): "Non-bijective LUT passed for coordinate permuation.";
 		assert source.min( d ) == 0: "Source with min[d] coordinate != 0 passed to coordinate permutation.";
 		assert source.dimension( d ) == permutation.length: "Source with dimension[d] != LUT.length passed to coordinate permutation.";
 
 		final int nDim = source.numDimensions();
-		final SingleDimensionPermutationTransform transform = new SingleDimensionPermutationTransform( permutation, nDim, nDim, d ).inverse();
+		final SingleDimensionPermutationTransform transform =
+				new SingleDimensionPermutationTransform( permutation, nDim, nDim, d ).inverse();
 		return Views.interval( new TransformView<>( source, transform.inverse() ), source );
 	}
 
@@ -1374,7 +1416,8 @@ public class Views
 	 *
 	 * @return
 	 */
-	public static < T > RandomAccessible< ? extends RandomAccessible< T > > hyperSlices( final RandomAccessible< T > source, final int... axes )
+	public static < T > RandomAccessible< ? extends RandomAccessible< T > > hyperSlices( final RandomAccessible< T > source,
+			final int... axes )
 	{
 		return new HyperSlicesView<>( source, axes );
 	}
@@ -1390,7 +1433,8 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by oob and border.
 	 */
-	public static < T, F extends RandomAccessibleInterval< T > > IntervalView< T > expand( final F source, final OutOfBoundsFactory< T, ? super F > oob, final long... border )
+	public static < T, F extends RandomAccessibleInterval< T > > IntervalView< T > expand( final F source,
+			final OutOfBoundsFactory< T, ? super F > oob, final long... border )
 	{
 		return Views.interval( Views.extend( source, oob ), Intervals.expand( source, border ) );
 	}
@@ -1453,9 +1497,10 @@ public class Views
 	 *         specified by t and border.
 	 * @deprecated use {@code expandValue} with unbounded type parameter T
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
 	@Deprecated
-	public static < T extends Type< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final T t, final long... border )
+	public static < T extends Type< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final T t,
+			final long... border )
 	{
 		return expandValue( ( RandomAccessibleInterval ) source, ( Object ) t, border );
 	}
@@ -1471,7 +1516,8 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by t and border.
 	 */
-	public static < T extends RealType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final float value, final long... border )
+	public static < T extends RealType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final float value,
+			final long... border )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.setReal( value );
@@ -1489,7 +1535,8 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by t and border.
 	 */
-	public static < T extends RealType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final double value, final long... border )
+	public static < T extends RealType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final double value,
+			final long... border )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.setReal( value );
@@ -1507,7 +1554,8 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by t and border.
 	 */
-	public static < T extends IntegerType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final int value, final long... border )
+	public static < T extends IntegerType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final int value,
+			final long... border )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.setInteger( value );
@@ -1525,7 +1573,8 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by t and border.
 	 */
-	public static < T extends IntegerType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final long value, final long... border )
+	public static < T extends IntegerType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source,
+			final long value, final long... border )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.setInteger( value );
@@ -1543,7 +1592,8 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by t and border.
 	 */
-	public static < T extends BooleanType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source, final boolean value, final long... border )
+	public static < T extends BooleanType< T > > IntervalView< T > expandValue( final RandomAccessibleInterval< T > source,
+			final boolean value, final long... border )
 	{
 		final T extension = Util.getTypeFromInterval( source ).createVariable();
 		extension.set( value );
@@ -1559,7 +1609,8 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by border.
 	 */
-	public static < T extends NumericType< T > > IntervalView< T > expandZero( final RandomAccessibleInterval< T > source, final long... border )
+	public static < T extends NumericType< T > > IntervalView< T > expandZero( final RandomAccessibleInterval< T > source,
+			final long... border )
 	{
 		return interval( extendZero( source ), Intervals.expand( source, border ) );
 	}
@@ -1577,7 +1628,8 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by min, max, and border.
 	 */
-	public static < T extends RealType< T > > IntervalView< T > expandRandom( final RandomAccessibleInterval< T > source, final double min, final double max, final long... border )
+	public static < T extends RealType< T > > IntervalView< T > expandRandom( final RandomAccessibleInterval< T > source, final double min,
+			final double max, final long... border )
 	{
 		return interval( extendRandom( source, min, max ), Intervals.expand( source, border ) );
 	}
@@ -1712,7 +1764,8 @@ public class Views
 	 * @param source
 	 * @return {@link RandomAccessible} of T
 	 */
-	public static < T > InflateView< T > inflate( final RandomAccessible< ? extends Composite< T > > source ) {
+	public static < T > InflateView< T > inflate( final RandomAccessible< ? extends Composite< T > > source )
+	{
 
 		return new InflateView<>( source );
 	}
@@ -1726,7 +1779,8 @@ public class Views
 	 * @param source
 	 * @return {@link RandomAccessible} of T
 	 */
-	public static < T > InterleaveView< T > interleave( final RandomAccessible< ? extends Composite< T > > source ) {
+	public static < T > InterleaveView< T > interleave( final RandomAccessible< ? extends Composite< T > > source )
+	{
 
 		return new InterleaveView<>( source );
 	}

--- a/src/main/java/net/imglib2/view/composite/AbstractNumericComposite.java
+++ b/src/main/java/net/imglib2/view/composite/AbstractNumericComposite.java
@@ -45,7 +45,8 @@ import net.imglib2.type.numeric.NumericType;
  *
  * @author Stephan Saalfeld
  */
-abstract public class AbstractNumericComposite< T extends NumericType< T >, C extends AbstractNumericComposite< T, C > > extends AbstractComposite< T > implements NumericType< C >, Iterable< T >
+abstract public class AbstractNumericComposite< T extends NumericType< T >, C extends AbstractNumericComposite< T, C > >
+		extends AbstractComposite< T > implements NumericType< C >, Iterable< T >
 {
 	final protected int length;
 

--- a/src/main/java/net/imglib2/view/composite/CompositeIntervalView.java
+++ b/src/main/java/net/imglib2/view/composite/CompositeIntervalView.java
@@ -45,7 +45,8 @@ import net.imglib2.view.Views;
  * 
  * @author Stephan Saalfeld
  */
-public class CompositeIntervalView< T, C extends Composite< T > > extends CompositeView< T, C > implements RandomAccessibleInterval< C >, View
+public class CompositeIntervalView< T, C extends Composite< T > > extends CompositeView< T, C >
+		implements RandomAccessibleInterval< C >, View
 {
 	final Interval interval;
 

--- a/src/main/java/net/imglib2/view/composite/RealComposite.java
+++ b/src/main/java/net/imglib2/view/composite/RealComposite.java
@@ -51,7 +51,8 @@ import net.imglib2.type.numeric.RealType;
  *
  * @author Stephan Saalfeld
  */
-public class RealComposite< T extends RealType< T > > extends AbstractNumericComposite< T, RealComposite< T > > implements RealPositionable, RealLocalizable
+public class RealComposite< T extends RealType< T > > extends AbstractNumericComposite< T, RealComposite< T > >
+		implements RealPositionable, RealLocalizable
 {
 	static public class Factory< T extends RealType< T > > implements CompositeFactory< T, RealComposite< T > >
 	{

--- a/src/main/java/net/imglib2/view/iteration/IterableTransformBuilder.java
+++ b/src/main/java/net/imglib2/view/iteration/IterableTransformBuilder.java
@@ -72,7 +72,8 @@ public class IterableTransformBuilder< T > extends TransformBuilder< T >
 	 * @return an {@link IterableInterval} that iterates {@code interval} of
 	 *         {@code randomAccessible}.
 	 */
-	public static < S > IterableInterval< S > getEfficientIterableInterval( final Interval interval, final RandomAccessible< S > randomAccessible )
+	public static < S > IterableInterval< S > getEfficientIterableInterval( final Interval interval,
+			final RandomAccessible< S > randomAccessible )
 	{
 		return new IterableTransformBuilder< S >( interval, randomAccessible ).buildIterableInterval();
 	}
@@ -162,7 +163,8 @@ public class IterableTransformBuilder< T > extends TransformBuilder< T >
 
 		final boolean hasFlatIterationOrder;
 
-		public Slice( final SubIntervalIterable< T > iterableSource, final Interval sourceInterval, final SlicingTransform transformToSource, final boolean hasFlatIterationOrder )
+		public Slice( final SubIntervalIterable< T > iterableSource, final Interval sourceInterval,
+				final SlicingTransform transformToSource, final boolean hasFlatIterationOrder )
 		{
 			super( interval );
 			numElements = Intervals.numElements( interval );
@@ -245,9 +247,9 @@ public class IterableTransformBuilder< T > extends TransformBuilder< T >
 
 				if ( optimizable )
 				{
-//					System.out.println( "interval = " + Util.printInterval( interval ) );
+					//					System.out.println( "interval = " + Util.printInterval( interval ) );
 					final Interval sliceInterval = t.transform( new BoundingBox( interval ) ).getInterval();
-//					System.out.println( "transformed interval = " + Util.printInterval( sliceInterval ) );
+					//					System.out.println( "transformed interval = " + Util.printInterval( sliceInterval ) );
 					if ( iterableSource.supportsOptimizedCursor( sliceInterval ) )
 					{
 						// check for FlatIterationOrder

--- a/src/test/java/net/imglib2/FinalIntervalTest.java
+++ b/src/test/java/net/imglib2/FinalIntervalTest.java
@@ -55,7 +55,7 @@ public class FinalIntervalTest
 	@Test
 	public void testCtorDimensions()
 	{
-		final FinalDimensions source = new FinalDimensions(23, 45, 34);
+		final FinalDimensions source = new FinalDimensions( 23, 45, 34 );
 		final FinalInterval bounds = new FinalInterval( source );
 		assertInterval( 0, 0, 0, 22, 44, 33, 23, 45, 34, bounds );
 	}
@@ -125,7 +125,8 @@ public class FinalIntervalTest
 		assertInterval( 5, 3, 7, 17, 19, 17, 13, 17, 11, bounds );
 	}
 
-	private void assertInterval( int min0, int min1, int min2, int max0, int max1, int max2, int dim0, int dim1, int dim2, Interval interval )
+	private void assertInterval( int min0, int min1, int min2, int max0, int max1, int max2, int dim0, int dim1, int dim2,
+			Interval interval )
 	{
 		assertEquals( min0, interval.min( 0 ) );
 		assertEquals( min1, interval.min( 1 ) );

--- a/src/test/java/net/imglib2/RandomAccessTest.java
+++ b/src/test/java/net/imglib2/RandomAccessTest.java
@@ -54,7 +54,7 @@ public class RandomAccessTest
 	public void testSetPositionAndGet()
 	{
 		// setup
-		final Img< IntType > image = ArrayImgs.ints( new int[]{ 1, 2, 3, 4, 5, 6 }, 3, 2 );
+		final Img< IntType > image = ArrayImgs.ints( new int[] { 1, 2, 3, 4, 5, 6 }, 3, 2 );
 		RandomAccess< IntType > randomAccess = image.randomAccess();
 		// process & test
 		assertEquals( new IntType( 4 ), randomAccess.setPositionAndGet( new Point( 0L, 1L ) ) );

--- a/src/test/java/net/imglib2/RandomAccessibleTest.java
+++ b/src/test/java/net/imglib2/RandomAccessibleTest.java
@@ -54,7 +54,7 @@ public class RandomAccessibleTest
 	public void testGetAt()
 	{
 		// setup
-		final Img< IntType > image = ArrayImgs.ints( new int[]{ 1, 2, 3, 4, 5, 6 }, 3, 2 );
+		final Img< IntType > image = ArrayImgs.ints( new int[] { 1, 2, 3, 4, 5, 6 }, 3, 2 );
 		// process & test
 		assertEquals( new IntType( 4 ), image.getAt( new Point( 0L, 1L ) ) );
 		assertEquals( new IntType( 5 ), image.getAt( 1L, 1L ) );

--- a/src/test/java/net/imglib2/converter/AbstractConvertedRandomAccessibleIntervalTest.java
+++ b/src/test/java/net/imglib2/converter/AbstractConvertedRandomAccessibleIntervalTest.java
@@ -67,42 +67,44 @@ public class AbstractConvertedRandomAccessibleIntervalTest
 	@Test
 	public void test()
 	{
-		final AbstractConvertedRandomAccessibleInterval< DoubleType, DoubleType > converted = new AbstractConvertedRandomAccessibleInterval< DoubleType, DoubleType >( data )
-		{
-
-			@Override
-			public AbstractConvertedRandomAccess< DoubleType, DoubleType > randomAccess()
-			{
-				return new AbstractConvertedRandomAccess< DoubleType, DoubleType >( data.randomAccess() )
+		final AbstractConvertedRandomAccessibleInterval< DoubleType, DoubleType > converted =
+				new AbstractConvertedRandomAccessibleInterval< DoubleType, DoubleType >( data )
 				{
 
-					DoubleType t = new DoubleType();
-
 					@Override
-					public DoubleType get()
+					public AbstractConvertedRandomAccess< DoubleType, DoubleType > randomAccess()
 					{
-						t.set( this.source.get() );
-						t.mul( this.source.getDoublePosition( this.source.numDimensions() - 1 ) );
-						return t;
+						return new AbstractConvertedRandomAccess< DoubleType, DoubleType >( data.randomAccess() )
+						{
+
+							DoubleType t = new DoubleType();
+
+							@Override
+							public DoubleType get()
+							{
+								t.set( this.source.get() );
+								t.mul( this.source.getDoublePosition( this.source.numDimensions() - 1 ) );
+								return t;
+							}
+
+							@Override
+							public AbstractConvertedRandomAccess< DoubleType, DoubleType > copy()
+							{
+								return null;
+							}
+						};
 					}
 
 					@Override
-					public AbstractConvertedRandomAccess< DoubleType, DoubleType > copy()
+					public AbstractConvertedRandomAccess< DoubleType, DoubleType > randomAccess( final Interval interval )
 					{
-						return null;
+						return randomAccess();
 					}
+
 				};
-			}
 
-			@Override
-			public AbstractConvertedRandomAccess< DoubleType, DoubleType > randomAccess( final Interval interval )
-			{
-				return randomAccess();
-			}
-
-		};
-
-		for ( final Cursor< Pair< DoubleType, DoubleType > > c = Views.interval( Views.pair( data, converted ), data ).cursor(); c.hasNext(); )
+		for ( final Cursor< Pair< DoubleType, DoubleType > > c = Views.interval( Views.pair( data, converted ), data ).cursor();
+				c.hasNext(); )
 		{
 			final Pair< DoubleType, DoubleType > p = c.next();
 			final double pos = c.getDoublePosition( c.numDimensions() - 1 );

--- a/src/test/java/net/imglib2/converter/BiConvertersTest.java
+++ b/src/test/java/net/imglib2/converter/BiConvertersTest.java
@@ -99,10 +99,10 @@ public class BiConvertersTest
 		final RandomAccessibleInterval< IntType > sumRRA = Views.interval(
 				Views.raster(
 						Converters.convert(
-							Views.interpolate( Views.extendBorder( sourceA ), new NearestNeighborInterpolatorFactory<>() ),
-							Views.interpolate( Views.extendBorder( sourceB ), new NearestNeighborInterpolatorFactory<>() ),
-							( a, b, c ) -> c.set( a.get() + b.get() ),
-							new IntType() )),
+								Views.interpolate( Views.extendBorder( sourceA ), new NearestNeighborInterpolatorFactory<>() ),
+								Views.interpolate( Views.extendBorder( sourceB ), new NearestNeighborInterpolatorFactory<>() ),
+								( a, b, c ) -> c.set( a.get() + b.get() ),
+								new IntType() ) ),
 				sourceA );
 
 		final Cursor< IntType > sumCursorRAI = Views.iterable( sumRAI ).cursor();
@@ -154,13 +154,13 @@ public class BiConvertersTest
 		final RandomAccessibleInterval< int[] > sumRRA = Views.interval(
 				Views.raster(
 						Converters.convert2(
-							Views.interpolate( Views.extendBorder( sourceA ), new NearestNeighborInterpolatorFactory<>() ),
-							Views.interpolate( Views.extendBorder( sourceB ), new NearestNeighborInterpolatorFactory<>() ),
-							( a, b, c ) -> {
-								c[ 0 ] = a.get();
-								c[ 1 ] = b.get();
-							},
-							() -> new int[ 2 ] ) ),
+								Views.interpolate( Views.extendBorder( sourceA ), new NearestNeighborInterpolatorFactory<>() ),
+								Views.interpolate( Views.extendBorder( sourceB ), new NearestNeighborInterpolatorFactory<>() ),
+								( a, b, c ) -> {
+									c[ 0 ] = a.get();
+									c[ 1 ] = b.get();
+								},
+								() -> new int[ 2 ] ) ),
 				sourceA );
 
 		final Cursor< int[] > sumCursorRAI = Views.iterable( sumRAI ).cursor();
@@ -171,8 +171,8 @@ public class BiConvertersTest
 		while ( sumCursorRAI.hasNext() )
 		{
 			int[] t = sumCursorRAI.next();
-			assertEquals( t[0], dataA[ i ] );
-			assertEquals( t[1], dataB[ i ] );
+			assertEquals( t[ 0 ], dataA[ i ] );
+			assertEquals( t[ 1 ], dataB[ i ] );
 
 			t = sumCursorIterable.next();
 			assertEquals( t[ 0 ], dataA[ i ] );

--- a/src/test/java/net/imglib2/converter/ConvertersBenchmark.java
+++ b/src/test/java/net/imglib2/converter/ConvertersBenchmark.java
@@ -77,21 +77,26 @@ import java.util.concurrent.TimeUnit;
 public class ConvertersBenchmark
 {
 
-	private final RandomAccessibleInterval<ARGBType> colors = ArrayImgs.argbs( 1000, 1000 );
+	private final RandomAccessibleInterval< ARGBType > colors = ArrayImgs.argbs( 1000, 1000 );
 
-	private final RandomAccessibleInterval<ARGBType> colorsPlanarImg = PlanarImgs.argbs( 1000, 1000 );
+	private final RandomAccessibleInterval< ARGBType > colorsPlanarImg = PlanarImgs.argbs( 1000, 1000 );
 
-	private final RandomAccessibleInterval<ARGBType> colorsCellImg = new CellImgFactory<>( new ARGBType() ).create( 1000, 1000 );
+	private final RandomAccessibleInterval< ARGBType > colorsCellImg = new CellImgFactory<>( new ARGBType() ).create( 1000, 1000 );
 
-	private final RandomAccessibleInterval<UnsignedByteType> red = Converters.convert( colors, ( i, o ) -> o.set( ARGBType.red( i.get() ) ), new UnsignedByteType() );
+	private final RandomAccessibleInterval< UnsignedByteType > red =
+			Converters.convert( colors, ( i, o ) -> o.set( ARGBType.red( i.get() ) ), new UnsignedByteType() );
 
-	private final RandomAccessibleInterval<UnsignedByteType> green = Converters.convert( colors, ( i, o ) -> o.set( ARGBType.green( i.get() ) ), new UnsignedByteType() );
+	private final RandomAccessibleInterval< UnsignedByteType > green =
+			Converters.convert( colors, ( i, o ) -> o.set( ARGBType.green( i.get() ) ), new UnsignedByteType() );
 
-	private final RandomAccessibleInterval<UnsignedByteType> blue = Converters.convert( colors, ( i, o ) -> o.set( ARGBType.blue( i.get() ) ), new UnsignedByteType() );
+	private final RandomAccessibleInterval< UnsignedByteType > blue =
+			Converters.convert( colors, ( i, o ) -> o.set( ARGBType.blue( i.get() ) ), new UnsignedByteType() );
 
-	private final RandomAccessibleInterval<UnsignedByteType> redPlanarImg = Converters.convert( colorsPlanarImg, ( i, o ) -> o.set( ARGBType.red( i.get() ) ), new UnsignedByteType() );
+	private final RandomAccessibleInterval< UnsignedByteType > redPlanarImg =
+			Converters.convert( colorsPlanarImg, ( i, o ) -> o.set( ARGBType.red( i.get() ) ), new UnsignedByteType() );
 
-	private final RandomAccessibleInterval<UnsignedByteType> redCellImg = Converters.convert( colorsCellImg, ( i, o ) -> o.set( ARGBType.red( i.get() ) ), new UnsignedByteType() );
+	private final RandomAccessibleInterval< UnsignedByteType > redCellImg =
+			Converters.convert( colorsCellImg, ( i, o ) -> o.set( ARGBType.red( i.get() ) ), new UnsignedByteType() );
 
 	@Param( value = { "false", "true" } )
 	boolean slowdown;
@@ -128,10 +133,10 @@ public class ConvertersBenchmark
 		return sum[ 0 ];
 	}
 
-	public static double sum( final RandomAccessibleInterval<? extends RealType<?>> img )
+	public static double sum( final RandomAccessibleInterval< ? extends RealType< ? > > img )
 	{
 		double sum = 0;
-		final RandomAccess<? extends RealType<?>> ra = img.randomAccess();
+		final RandomAccess< ? extends RealType< ? > > ra = img.randomAccess();
 		ra.setPosition( img.min( 1 ), 1 );
 		for ( int y = 0; y < img.dimension( 1 ); y++ )
 		{
@@ -146,10 +151,10 @@ public class ConvertersBenchmark
 		return sum;
 	}
 
-	public static double sum2( final RandomAccessibleInterval<? extends RealType<?>> img )
+	public static double sum2( final RandomAccessibleInterval< ? extends RealType< ? > > img )
 	{
 		double sum = 0;
-		final RandomAccess<? extends RealType<?>> ra = img.randomAccess();
+		final RandomAccess< ? extends RealType< ? > > ra = img.randomAccess();
 		ra.setPosition( img.min( 1 ), 1 );
 		for ( int y = 0; y < img.dimension( 1 ); y++ )
 		{

--- a/src/test/java/net/imglib2/converter/ConvertersTest.java
+++ b/src/test/java/net/imglib2/converter/ConvertersTest.java
@@ -161,7 +161,7 @@ public class ConvertersTest
 		// process
 		final RandomAccessibleInterval< ARGBType > argb = Converters.mergeARGB( image, ColorChannelOrder.RGB );
 		// test
-		argb.randomAccess().get().set( new ARGBType( 0x00010203) );
+		argb.randomAccess().get().set( new ARGBType( 0x00010203 ) );
 		Assert.assertArrayEquals( new byte[] { 1, 2, 3 }, pixels );
 	}
 }

--- a/src/test/java/net/imglib2/converter/RealTypeConverterInternalsTest.java
+++ b/src/test/java/net/imglib2/converter/RealTypeConverterInternalsTest.java
@@ -143,14 +143,15 @@ public class RealTypeConverterInternalsTest
 		return value * ( 1.0 - FLOAT_PRECISION );
 	}
 
-	private void testValueConversion( double value, Converter< RealType< ? >, RealType< ? > > converter, RealType< ? > in, RealType< ? > out )
+	private void testValueConversion( double value, Converter< RealType< ? >, RealType< ? > > converter, RealType< ? > in,
+			RealType< ? > out )
 	{
 		in.setReal( value );
 		converter.convert( in, out );
 		double delta = value * FLOAT_PRECISION;
 		assertEquals( "Conversion of value: " + value +
-						" from: " + in.getClass().getSimpleName() + " (" + in + ")" +
-						" to: " + out.getClass().getSimpleName() + " (" + out + ")",
+				" from: " + in.getClass().getSimpleName() + " (" + in + ")" +
+				" to: " + out.getClass().getSimpleName() + " (" + out + ")",
 				in.getRealDouble(), out.getRealDouble(), delta );
 	}
 
@@ -189,10 +190,11 @@ public class RealTypeConverterInternalsTest
 	}
 
 	@Test
-	public void testConvertRandomAccessibleInterval() {
-		RandomAccessibleInterval<IntType> ints = ArrayImgs.ints( new int[] { 42 }, 1 );
-		RandomAccessibleInterval<UnsignedByteType> bytes = RealTypeConverters.convert( ints, new UnsignedByteType() );
-		RandomAccessibleInterval<UnsignedByteType> expected = ArrayImgs.unsignedBytes( new byte[] { 42 }, 1);
+	public void testConvertRandomAccessibleInterval()
+	{
+		RandomAccessibleInterval< IntType > ints = ArrayImgs.ints( new int[] { 42 }, 1 );
+		RandomAccessibleInterval< UnsignedByteType > bytes = RealTypeConverters.convert( ints, new UnsignedByteType() );
+		RandomAccessibleInterval< UnsignedByteType > expected = ArrayImgs.unsignedBytes( new byte[] { 42 }, 1 );
 		ImgLib2Assert.assertImageEquals( expected, bytes );
 	}
 

--- a/src/test/java/net/imglib2/converter/RealTypeConvertersImageSizeBenchmark.java
+++ b/src/test/java/net/imglib2/converter/RealTypeConvertersImageSizeBenchmark.java
@@ -66,29 +66,30 @@ import java.util.HashMap;
  * Compare execution time between single threaded and multi threaded
  * execution of {@link RealTypeConverters#copyFromTo(RandomAccessible, RandomAccessibleInterval)}.
  */
-@State(Scope.Benchmark)
-public class RealTypeConvertersImageSizeBenchmark {
+@State( Scope.Benchmark )
+public class RealTypeConvertersImageSizeBenchmark
+{
 
-	@Param({ "ImageSize" })
+	@Param( { "ImageSize" } )
 	public String imageSize;
 
 	private Img< FloatType > in;
 
 	private Img< FloatType > out;
 
-	@Setup(Level.Trial)
+	@Setup( Level.Trial )
 	public void setup()
 	{
-		int size = Integer.valueOf(imageSize);
-		in = RandomImgs.seed(42).nextImage(new FloatType(), 100, size / 100);
-		out = ArrayImgs.floats(100, size / 100);
+		int size = Integer.valueOf( imageSize );
+		in = RandomImgs.seed( 42 ).nextImage( new FloatType(), 100, size / 100 );
+		out = ArrayImgs.floats( 100, size / 100 );
 	}
 
 	@Benchmark
 	public void singleThreaded()
 	{
 		Parallelization.runSingleThreaded(
-				() -> RealTypeConverters.copyFromTo(in, out)
+				() -> RealTypeConverters.copyFromTo( in, out )
 		);
 	}
 
@@ -96,45 +97,47 @@ public class RealTypeConvertersImageSizeBenchmark {
 	public void multiThreaded()
 	{
 		Parallelization.runMultiThreaded(
-				() -> RealTypeConverters.copyFromTo(in, out)
+				() -> RealTypeConverters.copyFromTo( in, out )
 		);
 	}
 
-	public static void main(final String... args) throws RunnerException
+	public static void main( final String... args ) throws RunnerException
 	{
 		String[] imageSizes = { "100", "1000", "10000", "100000", "1000000", "10000000", "100000000" };
 		String simpleName =
 				RealTypeConvertersImageSizeBenchmark.class.getName();
-		final Options opt = new OptionsBuilder().include(simpleName).forks(1)
-				.warmupIterations(5).measurementIterations(10)
-				.warmupTime(TimeValue.milliseconds(500))
-				.measurementTime(TimeValue.milliseconds(500))
-				.param("imageSize", imageSizes)
+		final Options opt = new OptionsBuilder().include( simpleName ).forks( 1 )
+				.warmupIterations( 5 ).measurementIterations( 10 )
+				.warmupTime( TimeValue.milliseconds( 500 ) )
+				.measurementTime( TimeValue.milliseconds( 500 ) )
+				.param( "imageSize", imageSizes )
 				.build();
-		Collection< RunResult > results = new Runner(opt).run();
-		HashMap< Pair< String, String >, Double > map = asMap(results);
-		for (String imageSize : imageSizes) {
-			double s = map.get(new ValuePair<>(simpleName + ".singleThreaded",
-					imageSize));
-			double m = map.get(new ValuePair<>(simpleName + ".multiThreaded",
-					imageSize));
+		Collection< RunResult > results = new Runner( opt ).run();
+		HashMap< Pair< String, String >, Double > map = asMap( results );
+		for ( String imageSize : imageSizes )
+		{
+			double s = map.get( new ValuePair<>( simpleName + ".singleThreaded",
+					imageSize ) );
+			double m = map.get( new ValuePair<>( simpleName + ".multiThreaded",
+					imageSize ) );
 			System.out.println(
 					"Multi-threading speedup: " + m / s + " for image size: " +
-							imageSize);
+							imageSize );
 		}
 	}
 
 	public static HashMap< Pair< String, String >, Double > asMap(
-			Collection< RunResult > results)
+			Collection< RunResult > results )
 	{
 		HashMap< Pair< String, String >, Double > map = new HashMap<>();
-		for (RunResult result : results) {
+		for ( RunResult result : results )
+		{
 			BenchmarkResult aggregatedResult = result.getAggregatedResult();
 			BenchmarkParams params = aggregatedResult.getParams();
 			double score = aggregatedResult.getPrimaryResult().getScore();
 			String benchmark = params.getBenchmark();
-			String size = params.getParam("imageSize");
-			map.put(new ValuePair<>(benchmark, size), score);
+			String size = params.getParam( "imageSize" );
+			map.put( new ValuePair<>( benchmark, size ), score );
 		}
 		return map;
 	}

--- a/src/test/java/net/imglib2/converter/RealTypeConvertersTest.java
+++ b/src/test/java/net/imglib2/converter/RealTypeConvertersTest.java
@@ -54,17 +54,19 @@ public class RealTypeConvertersTest
 {
 
 	@Test
-	public void testGetConverter() {
+	public void testGetConverter()
+	{
 		UnsignedByteType input = new UnsignedByteType( 42 );
 		DoubleType output = new DoubleType();
-		Converter<UnsignedByteType, DoubleType> converter = RealTypeConverters.getConverter( input, output );
+		Converter< UnsignedByteType, DoubleType > converter = RealTypeConverters.getConverter( input, output );
 		converter.convert( input, output );
 		assertEquals( 42, output.getRealDouble(), 0 );
 	}
 
 	@Test
-	public void testConvert() {
-		Img<UnsignedByteType> input = ArrayImgs.unsignedBytes( new byte[] { 42 }, 1 );
+	public void testConvert()
+	{
+		Img< UnsignedByteType > input = ArrayImgs.unsignedBytes( new byte[] { 42 }, 1 );
 		RandomAccessibleInterval< FloatType > result = RealTypeConverters.convert( input, new FloatType() );
 		ImgLib2Assert.assertImageEqualsRealType( input, result, 0 );
 	}

--- a/src/test/java/net/imglib2/display/ARGBScreenImageExpectationChecking.java
+++ b/src/test/java/net/imglib2/display/ARGBScreenImageExpectationChecking.java
@@ -61,11 +61,14 @@ public class ARGBScreenImageExpectationChecking
 {
 	static public final void main( final String[] args )
 	{
-		System.out.println( "Painting on java.awt.Graphics alters original array: " + new ARGBScreenImageExpectationChecking().testFill2() );
-		System.out.println( "After painting, the image shows a yellow pixel at 0,0: " + new ARGBScreenImageExpectationChecking().testFillAndGrabPixel2() );
+		System.out
+				.println( "Painting on java.awt.Graphics alters original array: " + new ARGBScreenImageExpectationChecking().testFill2() );
+		System.out.println( "After painting, the image shows a yellow pixel at 0,0: "
+				+ new ARGBScreenImageExpectationChecking().testFillAndGrabPixel2() );
 		try
 		{
-			System.out.println( "After painting onto JPanel and capturing, the imageshows a red pixel at 100,100: " + new ARGBScreenImageExpectationChecking().testFillAndPaintPanelAndGrab2() );
+			System.out.println( "After painting onto JPanel and capturing, the imageshows a red pixel at 100,100: "
+					+ new ARGBScreenImageExpectationChecking().testFillAndPaintPanelAndGrab2() );
 		}
 		catch ( final Exception e )
 		{
@@ -147,7 +150,8 @@ public class ARGBScreenImageExpectationChecking
 	@Test
 	public void testFillAndPaintPanelAndGrab() throws InterruptedException, InvocationTargetException
 	{
-		assertTrue( "After painting onto JPanel and capturing, the image does not show a red pixel at 100,100", testFillAndPaintPanelAndGrab2() );
+		assertTrue( "After painting onto JPanel and capturing, the image does not show a red pixel at 100,100",
+				testFillAndPaintPanelAndGrab2() );
 	}
 
 	public boolean testFillAndPaintPanelAndGrab2() throws InterruptedException, InvocationTargetException

--- a/src/test/java/net/imglib2/histogram/HistogramNdTest.java
+++ b/src/test/java/net/imglib2/histogram/HistogramNdTest.java
@@ -64,8 +64,8 @@ public class HistogramNdTest
 
 		final List< UnsignedByteType > data1 = getData1();
 		final List< UnsignedByteType > data2 = getData2();
-		final List< Iterable< UnsignedByteType >> data =
-				new ArrayList< Iterable< UnsignedByteType >>();
+		final List< Iterable< UnsignedByteType > > data =
+				new ArrayList< Iterable< UnsignedByteType > >();
 		data.add( data1 );
 		data.add( data2 );
 
@@ -134,8 +134,8 @@ public class HistogramNdTest
 	{
 		final List< UnsignedByteType > data1 = getData1();
 		final List< UnsignedByteType > data2 = getData2();
-		final List< Iterable< UnsignedByteType >> data =
-				new ArrayList< Iterable< UnsignedByteType >>();
+		final List< Iterable< UnsignedByteType > > data =
+				new ArrayList< Iterable< UnsignedByteType > >();
 		data.add( data1 );
 		data.add( data2 );
 
@@ -205,8 +205,8 @@ public class HistogramNdTest
 
 		final List< UnsignedByteType > data1 = getData1();
 		final List< UnsignedByteType > data2 = getData2();
-		final List< Iterable< UnsignedByteType >> data =
-				new ArrayList< Iterable< UnsignedByteType >>();
+		final List< Iterable< UnsignedByteType > > data =
+				new ArrayList< Iterable< UnsignedByteType > >();
 		data.add( data1 );
 		data.add( data2 );
 
@@ -326,7 +326,7 @@ public class HistogramNdTest
 		return data;
 	}
 
-	private class RgbIterator implements Iterable< List< IntType >>
+	private class RgbIterator implements Iterable< List< IntType > >
 	{
 
 		private final Img< ARGBType > img;
@@ -337,9 +337,9 @@ public class HistogramNdTest
 		}
 
 		@Override
-		public Iterator< List< IntType >> iterator()
+		public Iterator< List< IntType > > iterator()
 		{
-			return new Iterator< List< IntType >>()
+			return new Iterator< List< IntType > >()
 			{
 
 				private Cursor< ARGBType > cursor;

--- a/src/test/java/net/imglib2/histogram/HistogramPerformanceTest.java
+++ b/src/test/java/net/imglib2/histogram/HistogramPerformanceTest.java
@@ -51,7 +51,7 @@ import net.imglib2.type.numeric.integer.UnsignedShortType;
  * @author Curtis Rueden
  * @author Barry DeZonia
  */
-public class HistogramPerformanceTest< T extends IntegerType< T > & NativeType< T >>
+public class HistogramPerformanceTest< T extends IntegerType< T > & NativeType< T > >
 {
 
 	private static final int[] DIMS = { 1024, 1024, 3, 5 };

--- a/src/test/java/net/imglib2/img/AbstractSubIntervalIterableCursorTest.java
+++ b/src/test/java/net/imglib2/img/AbstractSubIntervalIterableCursorTest.java
@@ -119,7 +119,7 @@ public abstract class AbstractSubIntervalIterableCursorTest< T extends Img< IntT
 	public void testLocalizingIterationShifted()
 	{
 		Cursor< IntType > cursor = Views.interval( img, intervalShifted ).localizingCursor();
-		
+
 		testCursorIteration( cursor, intervalShifted );
 	}
 

--- a/src/test/java/net/imglib2/img/ImgFactoryTest.java
+++ b/src/test/java/net/imglib2/img/ImgFactoryTest.java
@@ -55,7 +55,7 @@ public class ImgFactoryTest
 	@Deprecated
 	public final void testCreateSupplierOfTLongArray()
 	{
-		final ArrayImg< UnsignedByteType, ByteArray > img = ArrayImgs.unsignedBytes(1, 2, 3);
+		final ArrayImg< UnsignedByteType, ByteArray > img = ArrayImgs.unsignedBytes( 1, 2, 3 );
 		final Img< UnsignedByteType > copy = img.factory().create( UnsignedByteType::new, 1, 2, 3 );
 		Assert.assertTrue( ArrayImg.class.isInstance( copy ) );
 		Assert.assertTrue( UnsignedByteType.class.isInstance( copy.iterator().next() ) );

--- a/src/test/java/net/imglib2/img/IterableSubIntervalBenchmark.java
+++ b/src/test/java/net/imglib2/img/IterableSubIntervalBenchmark.java
@@ -117,7 +117,7 @@ public class IterableSubIntervalBenchmark
 		final ArrayImg< IntType, ? > arrayImg = ArrayImgs.ints( dimensions ); // fits
 																				// the
 																				// interval
-		// doesn't fit the interval
+																				// doesn't fit the interval
 		final ArrayImg< IntType, ? > arrayImgUnOp = ArrayImgs.ints( dimensionsUnoptimized );
 
 		// fits the interval
@@ -139,7 +139,8 @@ public class IterableSubIntervalBenchmark
 	 * while optimized cursors can be used for the first image given interval
 	 * this is not possible for the 2nd one.
 	 */
-	protected static void testArrayImg( final int numRuns, final boolean printIndividualTimes, final Interval interval, final ArrayImg< IntType, ? > arrayImg, final ArrayImg< IntType, ? > arrayImgUnOp )
+	protected static void testArrayImg( final int numRuns, final boolean printIndividualTimes, final Interval interval,
+			final ArrayImg< IntType, ? > arrayImg, final ArrayImg< IntType, ? > arrayImgUnOp )
 	{
 
 		// BLOCK 1
@@ -188,7 +189,8 @@ public class IterableSubIntervalBenchmark
 	 * while optimized cursors can be used for the first image given inter this
 	 * is not possible for the 2nd one.
 	 */
-	protected static void testPlanarImg( final int numRuns, final boolean printIndividualTimes, final Interval interval, final PlanarImg< IntType, ? > planarImg, final PlanarImg< IntType, ? > planarImgUnOp )
+	protected static void testPlanarImg( final int numRuns, final boolean printIndividualTimes, final Interval interval,
+			final PlanarImg< IntType, ? > planarImg, final PlanarImg< IntType, ? > planarImgUnOp )
 	{
 
 		// BLOCK 1
@@ -241,12 +243,16 @@ public class IterableSubIntervalBenchmark
 
 		final long[] statsNorm = computeStats( valuesNorm );
 		final long[] statsOpt = computeStats( valuesOpt );
-		final long[] statsDiff = new long[] { ( statsNorm[ 0 ] - statsOpt[ 0 ] ), ( statsNorm[ 1 ] - statsOpt[ 1 ] ), ( statsNorm[ 2 ] - statsOpt[ 2 ] ) };
+		final long[] statsDiff =
+				new long[] { ( statsNorm[ 0 ] - statsOpt[ 0 ] ), ( statsNorm[ 1 ] - statsOpt[ 1 ] ), ( statsNorm[ 2 ] - statsOpt[ 2 ] ) };
 		// print
 		System.out.println( "\t| Unoptimized \t| Optimized \t| Speedup Time \t| Speedup % \t|" );
-		System.out.println( "Median\t|\t" + statsNorm[ 0 ] + "\t|\t" + statsOpt[ 0 ] + "\t| " + statsDiff[ 0 ] + "ms   \t| " + ( ( int ) ( 1000.0 / statsNorm[ 0 ] * statsDiff[ 0 ] ) / 10.0 ) + "%   \t|" );
-		System.out.println( "Best\t|\t" + statsNorm[ 1 ] + "\t|\t" + statsOpt[ 1 ] + "\t| " + statsDiff[ 1 ] + "ms   \t| " + ( ( int ) ( 1000.0 / statsNorm[ 1 ] * statsDiff[ 1 ] ) / 10.0 ) + "%   \t|" );
-		System.out.println( "Worst\t|\t" + statsNorm[ 2 ] + "\t|\t" + statsOpt[ 2 ] + "\t| " + statsDiff[ 2 ] + "ms   \t| " + ( ( int ) ( 1000.0 / statsNorm[ 2 ] * statsDiff[ 2 ] ) / 10.0 ) + "%   \t|" );
+		System.out.println( "Median\t|\t" + statsNorm[ 0 ] + "\t|\t" + statsOpt[ 0 ] + "\t| " + statsDiff[ 0 ] + "ms   \t| "
+				+ ( ( int ) ( 1000.0 / statsNorm[ 0 ] * statsDiff[ 0 ] ) / 10.0 ) + "%   \t|" );
+		System.out.println( "Best\t|\t" + statsNorm[ 1 ] + "\t|\t" + statsOpt[ 1 ] + "\t| " + statsDiff[ 1 ] + "ms   \t| "
+				+ ( ( int ) ( 1000.0 / statsNorm[ 1 ] * statsDiff[ 1 ] ) / 10.0 ) + "%   \t|" );
+		System.out.println( "Worst\t|\t" + statsNorm[ 2 ] + "\t|\t" + statsOpt[ 2 ] + "\t| " + statsDiff[ 2 ] + "ms   \t| "
+				+ ( ( int ) ( 1000.0 / statsNorm[ 2 ] * statsDiff[ 2 ] ) / 10.0 ) + "%   \t|" );
 		System.out.println();
 	}
 

--- a/src/test/java/net/imglib2/img/array/ArrayImgsTest.java
+++ b/src/test/java/net/imglib2/img/array/ArrayImgsTest.java
@@ -474,7 +474,8 @@ public class ArrayImgsTest
 
 	}
 
-	public static < T extends NativeType< T > & IntegerType< T > > void testRange( final ArrayImg< T, ? > comp, final ArrayImg< T, ? > ref, final int start, final int stop )
+	public static < T extends NativeType< T > & IntegerType< T > > void testRange( final ArrayImg< T, ? > comp, final ArrayImg< T, ? > ref,
+			final int start, final int stop )
 	{
 		final ArrayCursor< T > c = comp.cursor();
 		final ArrayCursor< T > r = ref.cursor();

--- a/src/test/java/net/imglib2/img/array/ArrayIterableSubIntervalCursorTest.java
+++ b/src/test/java/net/imglib2/img/array/ArrayIterableSubIntervalCursorTest.java
@@ -55,7 +55,7 @@ import org.junit.Test;
  * TODO Javadoc
  * 
  */
-public class ArrayIterableSubIntervalCursorTest extends AbstractSubIntervalIterableCursorTest< ArrayImg< IntType, ? >>
+public class ArrayIterableSubIntervalCursorTest extends AbstractSubIntervalIterableCursorTest< ArrayImg< IntType, ? > >
 {
 	int numValues;
 
@@ -75,7 +75,8 @@ public class ArrayIterableSubIntervalCursorTest extends AbstractSubIntervalItera
 
 		intervalFastPart = new FinalInterval( new long[] { dimensions[ 0 ], 2, 3, 1, 1 } );
 
-		intervalShifted = new FinalInterval( new long[] { 0, 0, 3, 5, 1 }, new long[] { dimensions[ 0 ] - 1, dimensions[ 1 ] - 1, 4, 5, 1 } );
+		intervalShifted =
+				new FinalInterval( new long[] { 0, 0, 3, 5, 1 }, new long[] { dimensions[ 0 ] - 1, dimensions[ 1 ] - 1, 4, 5, 1 } );
 
 		numValues = 1;
 		for ( int d = 0; d < dimensions.length; ++d )

--- a/src/test/java/net/imglib2/img/cell/CellImgTest.java
+++ b/src/test/java/net/imglib2/img/cell/CellImgTest.java
@@ -62,17 +62,21 @@ public class CellImgTest
 			if ( dim[ i ].length > 1 )
 			{
 				assertTrue( "ArrayImg vs CellImg failed for dim = " + Util.printCoordinates( dim[ i ] ),
-						ImgTestHelper.testImg( dim[ i ], new ArrayImgFactory<>( new FloatType() ), new CellImgFactory<>( new FloatType(), 10 ) ) );
+						ImgTestHelper.testImg( dim[ i ], new ArrayImgFactory<>( new FloatType() ),
+								new CellImgFactory<>( new FloatType(), 10 ) ) );
 				assertTrue( "CellImg vs ArrayImg failed for dim = " + Util.printCoordinates( dim[ i ] ),
-						ImgTestHelper.testImg( dim[ i ], new CellImgFactory<>( new FloatType() ), new ArrayImgFactory<>( new FloatType() ) ) );
+						ImgTestHelper.testImg( dim[ i ], new CellImgFactory<>( new FloatType() ),
+								new ArrayImgFactory<>( new FloatType() ) ) );
 				assertTrue( "CellImg vs CellImg failed for dim = " + Util.printCoordinates( dim[ i ] ),
-						ImgTestHelper.testImg( dim[ i ], new CellImgFactory<>( new FloatType(), 5 ), new CellImgFactory<>( new FloatType() ) ) );
+						ImgTestHelper.testImg( dim[ i ], new CellImgFactory<>( new FloatType(), 5 ),
+								new CellImgFactory<>( new FloatType() ) ) );
 			}
 		}
 	}
 
 	@Test
-	public void testCellImgInvalidDimensions() {
+	public void testCellImgInvalidDimensions()
+	{
 		ImgTestHelper.assertInvalidDims( new CellImgFactory<>( new FloatType(), 100 ) );
 	}
 }

--- a/src/test/java/net/imglib2/img/cell/CellTest.java
+++ b/src/test/java/net/imglib2/img/cell/CellTest.java
@@ -69,12 +69,12 @@ public class CellTest
 	public void testLocalIndexCalculation()
 	{
 		final long[] min = new long[] { 0, 9876543210l, 222 };
-		final Cell< FloatArray > cell = new Cell<>( new int[] {20, 8, 10}, min, new FloatArray( 1 ) );
-		final long[][] position = { {3, 4, 5}, {12, 0, 3}, {3, 2, 0} };
+		final Cell< FloatArray > cell = new Cell<>( new int[] { 20, 8, 10 }, min, new FloatArray( 1 ) );
+		final long[][] position = { { 3, 4, 5 }, { 12, 0, 3 }, { 3, 2, 0 } };
 		final int[] expectedIndex = { 883, 492, 43 };
 		for ( int i = 0; i < position.length; ++i )
 		{
-			for ( int d =0; d <min.length; ++d)
+			for ( int d = 0; d < min.length; ++d )
 				position[ i ][ d ] += min[ d ];
 			assertTrue( cell.globalPositionToIndex( position[ i ] ) == expectedIndex[ i ] );
 		}
@@ -83,7 +83,7 @@ public class CellTest
 	@Test
 	public void testGlobalPositionCalculation()
 	{
-		final Cell< FloatArray > cell = new Cell<>( new int[] {20, 8, 10}, new long[] { 0, 9876543210l, 222 }, new FloatArray( 1 ) );
+		final Cell< FloatArray > cell = new Cell<>( new int[] { 20, 8, 10 }, new long[] { 0, 9876543210l, 222 }, new FloatArray( 1 ) );
 		final int[] index = { 883, 492, 43 };
 		final long[][] expectedPosition = { { 3, 9876543214l, 227 }, { 12, 9876543210l, 225 }, { 3, 9876543212l, 222 } };
 		for ( int i = 0; i < index.length; ++i )

--- a/src/test/java/net/imglib2/img/planar/PlanarImgTest.java
+++ b/src/test/java/net/imglib2/img/planar/PlanarImgTest.java
@@ -59,16 +59,20 @@ public class PlanarImgTest
 		for ( int i = 0; i < dim.length; ++i )
 		{
 			assertTrue( "ArrayImg vs PlanarImg failed for dim = " + Util.printCoordinates( dim[ i ] ),
-					ImgTestHelper.testImg( dim[ i ], new ArrayImgFactory<>( new FloatType() ), new PlanarImgFactory<>( new FloatType() ) ) );
+					ImgTestHelper.testImg( dim[ i ], new ArrayImgFactory<>( new FloatType() ),
+							new PlanarImgFactory<>( new FloatType() ) ) );
 			assertTrue( "PlanarImg vs ArrayImg failed for dim = " + Util.printCoordinates( dim[ i ] ),
-					ImgTestHelper.testImg( dim[ i ], new PlanarImgFactory<>( new FloatType() ), new ArrayImgFactory<>( new FloatType() ) ) );
+					ImgTestHelper.testImg( dim[ i ], new PlanarImgFactory<>( new FloatType() ),
+							new ArrayImgFactory<>( new FloatType() ) ) );
 			assertTrue( "PlanarImg vs PlanarImg failed for dim = " + Util.printCoordinates( dim[ i ] ),
-					ImgTestHelper.testImg( dim[ i ], new PlanarImgFactory<>( new FloatType() ), new PlanarImgFactory<>( new FloatType() ) ) );
+					ImgTestHelper.testImg( dim[ i ], new PlanarImgFactory<>( new FloatType() ),
+							new PlanarImgFactory<>( new FloatType() ) ) );
 		}
 	}
 
 	@Test
-	public void testPlanarImgInvalidDimensions() {
+	public void testPlanarImgInvalidDimensions()
+	{
 		ImgTestHelper.assertInvalidDims( new PlanarImgFactory<>( new FloatType() ) );
 	}
 }

--- a/src/test/java/net/imglib2/img/planar/PlanarIterableSubIntervalCursorTest.java
+++ b/src/test/java/net/imglib2/img/planar/PlanarIterableSubIntervalCursorTest.java
@@ -71,15 +71,18 @@ public class PlanarIterableSubIntervalCursorTest extends AbstractSubIntervalIter
 
 		intervalLine = new FinalInterval( new long[] { 0, 12, 3, 5, 1 }, new long[] { dimensions[ 0 ] - 1, 13, 3, 5, 1 } );
 
-		intervalShifted = new FinalInterval( new long[] { 0, 0, 3, 5, 1 }, new long[] { dimensions[ 0 ] - 1, dimensions[ 1 ] - 1, 4, 5, 1 } );
+		intervalShifted =
+				new FinalInterval( new long[] { 0, 0, 3, 5, 1 }, new long[] { dimensions[ 0 ] - 1, dimensions[ 1 ] - 1, 4, 5, 1 } );
 
 		intervalFast = new FinalInterval( new long[] { dimensions[ 0 ], dimensions[ 1 ], 5, 1, 1 } );
 
 		intervalFastPart = new FinalInterval( new long[] { dimensions[ 0 ], 2, 3, 1, 1 } );
 
-		intervalSinglePlaneShifted = new FinalInterval( new long[] { 0, 0, 3, 5, 1 }, new long[] { dimensions[ 0 ] - 1, dimensions[ 1 ] - 1, 3, 5, 1 } );
+		intervalSinglePlaneShifted =
+				new FinalInterval( new long[] { 0, 0, 3, 5, 1 }, new long[] { dimensions[ 0 ] - 1, dimensions[ 1 ] - 1, 3, 5, 1 } );
 
-		intervalSinglePlaneFull = new FinalInterval( new long[] { 0, 0, 1, 1, 1 }, new long[] { dimensions[ 0 ] - 1, dimensions[ 1 ] - 1, 1, 1, 1 } );
+		intervalSinglePlaneFull =
+				new FinalInterval( new long[] { 0, 0, 1, 1, 1 }, new long[] { dimensions[ 0 ] - 1, dimensions[ 1 ] - 1, 1, 1, 1 } );
 
 		// create random data for all dims and fill the planar img
 		numValues = 1;

--- a/src/test/java/net/imglib2/interpolation/stack/LinearRealRandomAccessibleStackInterpolatorTest.java
+++ b/src/test/java/net/imglib2/interpolation/stack/LinearRealRandomAccessibleStackInterpolatorTest.java
@@ -86,8 +86,10 @@ public class LinearRealRandomAccessibleStackInterpolatorTest
 			stack.add( Views.interpolate( indices, new NLinearInterpolatorFactory<>() ) );
 		}
 
-		final RealRandomAccessible< DoubleType > interpolatedStack = new Interpolant<>( stack, new LinearRealRandomAccessibleStackInterpolatorFactory<>(), 3 );
-		final RealRandomAccessible< DoubleType > interpolatedRAStack = Views.interpolate( Views.stack( raStack ), new NLinearInterpolatorFactory<>() );
+		final RealRandomAccessible< DoubleType > interpolatedStack =
+				new Interpolant<>( stack, new LinearRealRandomAccessibleStackInterpolatorFactory<>(), 3 );
+		final RealRandomAccessible< DoubleType > interpolatedRAStack =
+				Views.interpolate( Views.stack( raStack ), new NLinearInterpolatorFactory<>() );
 
 		int i = 0;
 		for ( final DoubleType t : Views.flatIterable( Views.interval( Views.raster( interpolatedStack ), cropInterval ) ) )
@@ -105,8 +107,8 @@ public class LinearRealRandomAccessibleStackInterpolatorTest
 				for ( double z = 0; z < interval.dimension( 1 ); z += 0.778 )
 				{
 					stackAccess.setPosition( z, 2 );
-					stackAccess.setPosition( new double[] {x, y, z} );
-					stackRAAccess.setPosition( new double[] {x, y, z} );
+					stackAccess.setPosition( new double[] { x, y, z } );
+					stackRAAccess.setPosition( new double[] { x, y, z } );
 
 					Assert.assertEquals( stackAccess.get().getRealDouble(), stackRAAccess.get().getRealDouble(), 0.01 );
 				}

--- a/src/test/java/net/imglib2/interpolation/stack/NearestNeighborRealRandomAccessibleStackInterpolatorTest.java
+++ b/src/test/java/net/imglib2/interpolation/stack/NearestNeighborRealRandomAccessibleStackInterpolatorTest.java
@@ -82,7 +82,8 @@ public class NearestNeighborRealRandomAccessibleStackInterpolatorTest
 			stack.add( Views.interpolate( indices, new NearestNeighborInterpolatorFactory<>() ) );
 		}
 
-		final RealRandomAccessible< LongType > interpolatedStack = new Interpolant<>( stack, new NearestNeighborRealRandomAccessibleStackInterpolatorFactory<>(), 3 );
+		final RealRandomAccessible< LongType > interpolatedStack =
+				new Interpolant<>( stack, new NearestNeighborRealRandomAccessibleStackInterpolatorFactory<>(), 3 );
 
 		int i = 0;
 		for ( final LongType t : Views.flatIterable( Views.interval( Views.raster( interpolatedStack ), cropInterval ) ) )

--- a/src/test/java/net/imglib2/iterator/RealIntervalIteratorTests.java
+++ b/src/test/java/net/imglib2/iterator/RealIntervalIteratorTests.java
@@ -7,24 +7,24 @@ import org.junit.Test;
 
 public class RealIntervalIteratorTests
 {
-	
+
 	@Test
 	public void realIntervalIteratorTest()
 	{
 		final double eps = 1e-6;
-		final double[] min = new double[] { -1, -1  };
+		final double[] min = new double[] { -1, -1 };
 		final double[] max = new double[] { 1 + eps / 2, 1 + eps / 2 };
 
-		final LocalizingRealIntervalIterator it = new LocalizingRealIntervalIterator( 
-				min, max, new double[] { 1, 0.5 });
+		final LocalizingRealIntervalIterator it = new LocalizingRealIntervalIterator(
+				min, max, new double[] { 1, 0.5 } );
 
 		int N = 0;
-		while( it.hasNext() )
+		while ( it.hasNext() )
 		{
 			it.fwd();
 
 			int j = ( N - ( N % 3 ) ) / 3;
-			assertEquals( (N % 3) - 1, it.getDoublePosition( 0 ), eps );
+			assertEquals( ( N % 3 ) - 1, it.getDoublePosition( 0 ), eps );
 			assertEquals( -1.0 + 0.5 * j, it.getDoublePosition( 1 ), eps );
 
 			N++;

--- a/src/test/java/net/imglib2/loops/IntervalChunksTest.java
+++ b/src/test/java/net/imglib2/loops/IntervalChunksTest.java
@@ -59,27 +59,29 @@ public class IntervalChunksTest
 	@Test
 	public void testSuggestCellSize()
 	{
-		assertArrayEquals( array ( 20 ), IntervalChunks.suggestChunkSize( array ( 40 ), 2 ) );
-		assertArrayEquals( array ( 5 ), IntervalChunks.suggestChunkSize( array ( 100 ), 19 ) );
-		assertArrayEquals( array ( 1 ), IntervalChunks.suggestChunkSize( array ( 10 ), 1000 ) );
-		assertArrayEquals( array ( 10, 10 ), IntervalChunks.suggestChunkSize( array ( 10, 10 ), 1 ) );
-		assertArrayEquals( array ( 10, 5 ), IntervalChunks.suggestChunkSize( array ( 10, 10 ), 2 ) );
-		assertArrayEquals( array ( 5, 1 ), IntervalChunks.suggestChunkSize( array ( 10, 10 ), 20 ) );
-		assertArrayEquals( array ( 5, 1 ), IntervalChunks.suggestChunkSize( array ( 10, 10 ), 17 ) );
+		assertArrayEquals( array( 20 ), IntervalChunks.suggestChunkSize( array( 40 ), 2 ) );
+		assertArrayEquals( array( 5 ), IntervalChunks.suggestChunkSize( array( 100 ), 19 ) );
+		assertArrayEquals( array( 1 ), IntervalChunks.suggestChunkSize( array( 10 ), 1000 ) );
+		assertArrayEquals( array( 10, 10 ), IntervalChunks.suggestChunkSize( array( 10, 10 ), 1 ) );
+		assertArrayEquals( array( 10, 5 ), IntervalChunks.suggestChunkSize( array( 10, 10 ), 2 ) );
+		assertArrayEquals( array( 5, 1 ), IntervalChunks.suggestChunkSize( array( 10, 10 ), 20 ) );
+		assertArrayEquals( array( 5, 1 ), IntervalChunks.suggestChunkSize( array( 10, 10 ), 17 ) );
 	}
 
 	@Test
-	public void testGenerateGrid() {
-		Interval total = Intervals.createMinSize( 2,3,10,10 );
-		List<Interval> chunks = IntervalChunks.generateGrid( total, array(5, 3) );
-		assertEquals(8, chunks.size());
+	public void testGenerateGrid()
+	{
+		Interval total = Intervals.createMinSize( 2, 3, 10, 10 );
+		List< Interval > chunks = IntervalChunks.generateGrid( total, array( 5, 3 ) );
+		assertEquals( 8, chunks.size() );
 		assertIntervalEquals( Intervals.createMinSize( 2, 3, 5, 3 ), chunks.get( 0 ) );
 		assertIntervalEquals( Intervals.createMinSize( 7, 3, 5, 3 ), chunks.get( 1 ) );
 		assertIntervalEquals( Intervals.createMinSize( 7, 12, 5, 1 ), chunks.get( 7 ) );
 	}
 
 	@Test
-	public void testChunkInterval() {
+	public void testChunkInterval()
+	{
 		// Test to chunk one dimensional interval of length 21 into 2 chunks.
 		Interval complete = Intervals.createMinSize( 5, 21 );
 		List< Interval > chunks = IntervalChunks.chunkInterval( complete, 2 );
@@ -88,8 +90,9 @@ public class IntervalChunksTest
 		assertIntervalEquals( Intervals.createMinSize( 25, 1 ), chunks.get( 2 ) );
 	}
 
-	private void assertArrayEquals( long[] expected, long[] actual ) {
-		if( !Arrays.equals(expected, actual))
+	private void assertArrayEquals( long[] expected, long[] actual )
+	{
+		if ( !Arrays.equals( expected, actual ) )
 			fail( "Arrays are different:\n"
 					+ "Expected :" + Arrays.toString( expected ) + "\n"
 					+ "Actual   :" + Arrays.toString( actual ) );

--- a/src/test/java/net/imglib2/loops/IterableLoopBuilderTest.java
+++ b/src/test/java/net/imglib2/loops/IterableLoopBuilderTest.java
@@ -48,48 +48,54 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests {@link IterableLoopBuilder}.
  */
-public class IterableLoopBuilderTest {
+public class IterableLoopBuilderTest
+{
 
 	@Test
-	public void testSingleImage() {
+	public void testSingleImage()
+	{
 		// Test IterableLoopBuilder by setting all pixels in a single image to one.
-		Img<IntType> image = ArrayImgs.ints(2,2);
-		IterableInterval<IntType> iterableInterval = image;
-		IterableLoopBuilder.setImages(iterableInterval).forEachPixel(pixel -> pixel.setOne());
-		Img<IntType> expected = ArrayImgs.ints(new int[]{1, 1, 1, 1}, 2, 2);
-		ImgLib2Assert.assertImageEquals(expected, image);
+		Img< IntType > image = ArrayImgs.ints( 2, 2 );
+		IterableInterval< IntType > iterableInterval = image;
+		IterableLoopBuilder.setImages( iterableInterval ).forEachPixel( pixel -> pixel.setOne() );
+		Img< IntType > expected = ArrayImgs.ints( new int[] { 1, 1, 1, 1 }, 2, 2 );
+		ImgLib2Assert.assertImageEquals( expected, image );
 	}
 
 	@Test
-	public void testTwoImages() {
+	public void testTwoImages()
+	{
 		// Test IterableLoopBuilder by using it to copy the content of a tiny image.
-		Img<IntType> source = ArrayImgs.ints(new int[]{1, 2, 3, 4}, 2,2);
-		Img<IntType> target = ArrayImgs.ints(2,2);
-		IterableInterval<IntType> iterableIntervalSource = source;
-		RandomAccessible<IntType> randomAccessibleTarget = target;
-		IterableLoopBuilder.setImages(iterableIntervalSource, randomAccessibleTarget).forEachPixel((s, t) -> t.set(s));
-		ImgLib2Assert.assertImageEquals(source, target);
+		Img< IntType > source = ArrayImgs.ints( new int[] { 1, 2, 3, 4 }, 2, 2 );
+		Img< IntType > target = ArrayImgs.ints( 2, 2 );
+		IterableInterval< IntType > iterableIntervalSource = source;
+		RandomAccessible< IntType > randomAccessibleTarget = target;
+		IterableLoopBuilder.setImages( iterableIntervalSource, randomAccessibleTarget ).forEachPixel( ( s, t ) -> t.set( s ) );
+		ImgLib2Assert.assertImageEquals( source, target );
 	}
 
 	@Test
-	public void testThreeImages() {
+	public void testThreeImages()
+	{
 		// Test IterableLoopBuilder by using it to calculate the difference between to tiny images.
-		Img<IntType> target = ArrayImgs.ints(2, 2);
-		IterableInterval<IntType> targetIterable = target;
-		RandomAccessible<IntType> imageA = ArrayImgs.ints(new int[]{1, 1, 0, 0}, 2, 2);
-		RandomAccessible<IntType> imageB = ArrayImgs.ints(new int[]{0, 2, 2, 0}, 2, 2);
-		IterableLoopBuilder.setImages(targetIterable, imageA, imageB).forEachPixel((t, a, b) -> t.setInteger(a.getInteger() - b.getInteger()));
-		RandomAccessibleInterval<IntType> expected = ArrayImgs.ints(new int[]{1, -1, -2, 0}, 2, 2);
-		ImgLib2Assert.assertImageEquals(expected, target);
+		Img< IntType > target = ArrayImgs.ints( 2, 2 );
+		IterableInterval< IntType > targetIterable = target;
+		RandomAccessible< IntType > imageA = ArrayImgs.ints( new int[] { 1, 1, 0, 0 }, 2, 2 );
+		RandomAccessible< IntType > imageB = ArrayImgs.ints( new int[] { 0, 2, 2, 0 }, 2, 2 );
+		IterableLoopBuilder.setImages( targetIterable, imageA, imageB )
+				.forEachPixel( ( t, a, b ) -> t.setInteger( a.getInteger() - b.getInteger() ) );
+		RandomAccessibleInterval< IntType > expected = ArrayImgs.ints( new int[] { 1, -1, -2, 0 }, 2, 2 );
+		ImgLib2Assert.assertImageEquals( expected, target );
 	}
 
 	@Test
-	public void testMultiThreading() {
+	public void testMultiThreading()
+	{
 		// Test if IterableLoopBuilder still produces a correct result when multi-threading is enabled.
-		Img<IntType> image = ArrayImgs.ints(10, 10);
-		Parallelization.runMultiThreaded(() -> {
-			IterableLoopBuilder.setImages(image).multithreaded().forEachPixel(pixel -> pixel.setOne());
-		});
-		image.forEach(pixel -> assertEquals(1, pixel.getInteger()));
+		Img< IntType > image = ArrayImgs.ints( 10, 10 );
+		Parallelization.runMultiThreaded( () -> {
+			IterableLoopBuilder.setImages( image ).multithreaded().forEachPixel( pixel -> pixel.setOne() );
+		} );
+		image.forEach( pixel -> assertEquals( 1, pixel.getInteger() ) );
 	}
 }

--- a/src/test/java/net/imglib2/loops/LoopBuilderTest.java
+++ b/src/test/java/net/imglib2/loops/LoopBuilderTest.java
@@ -89,7 +89,8 @@ public class LoopBuilderTest
 		return Views.translate( result, random.nextInt(), random.nextInt(), random.nextInt() );
 	}
 
-	private void assertSum( RandomAccessibleInterval< IntType > imageA, RandomAccessibleInterval< IntType > imageB, final RandomAccessibleInterval< IntType > sum )
+	private void assertSum( RandomAccessibleInterval< IntType > imageA, RandomAccessibleInterval< IntType > imageB,
+			final RandomAccessibleInterval< IntType > sum )
 	{
 		final Cursor< IntType > a = Views.iterable( imageA ).cursor();
 		final Cursor< IntType > b = Views.iterable( imageB ).cursor();
@@ -155,6 +156,7 @@ public class LoopBuilderTest
 	}
 
 	private final BiConsumer< IntType, IntType > COPY_ACTION = ( i, o ) -> o.set( i );
+
 	private final Function< LoopBuilder.Chunk< BiConsumer< IntType, IntType > >, Object > CHUNK_COPY_ACTION = chunk -> {
 		chunk.forEachPixel( COPY_ACTION );
 		return null;
@@ -222,9 +224,10 @@ public class LoopBuilderTest
 	}
 
 	@Test( expected = IllegalArgumentException.class )
-	public void testCheckDimensions() {
-		RandomAccessibleInterval<IntType> imageA = ArrayImgs.ints( 10, 10 );
-		RandomAccessibleInterval<IntType> imageB = ArrayImgs.ints( 10, 10, 2 );
-		LoopBuilder.setImages( imageA, imageB ).forEachPixel( (a, b) -> {} );
+	public void testCheckDimensions()
+	{
+		RandomAccessibleInterval< IntType > imageA = ArrayImgs.ints( 10, 10 );
+		RandomAccessibleInterval< IntType > imageB = ArrayImgs.ints( 10, 10, 2 );
+		LoopBuilder.setImages( imageA, imageB ).forEachPixel( ( a, b ) -> {} );
 	}
 }

--- a/src/test/java/net/imglib2/loops/LoopBuilderVsCursorsBenchmark.java
+++ b/src/test/java/net/imglib2/loops/LoopBuilderVsCursorsBenchmark.java
@@ -85,8 +85,7 @@ import java.util.stream.LongStream;
 public class LoopBuilderVsCursorsBenchmark
 {
 
-	private static final Map< String, Supplier< RandomAccessibleInterval< DoubleType > > >
-			IMG_FACTORIES = initImageFactories();
+	private static final Map< String, Supplier< RandomAccessibleInterval< DoubleType > > > IMG_FACTORIES = initImageFactories();
 
 	/**
 	 * This {@link Map} contains methods to create different types of
@@ -98,13 +97,18 @@ public class LoopBuilderVsCursorsBenchmark
 		final long[] DIMS = { 200, 200, 100 };
 		final HashMap< String, Supplier< RandomAccessibleInterval< DoubleType > > > map = new HashMap<>();
 		map.put( "ArrayImg", () -> ArrayImgs.doubles( DIMS ) );
-		map.put( "ArrayImg_Continuous_Subset", () -> Views.interval( ArrayImgs.doubles( 200, 200, 300 ), Intervals.createMinSize( 0, 0, 99, 200, 200, 100 ) ) );
-		map.put( "ArrayImg_Subset", () -> Views.interval( ArrayImgs.doubles( 300, 300, 100 ), Intervals.createMinSize( 50, 50, 0, 200, 200, 100 ) ) );
+		map.put( "ArrayImg_Continuous_Subset",
+				() -> Views.interval( ArrayImgs.doubles( 200, 200, 300 ), Intervals.createMinSize( 0, 0, 99, 200, 200, 100 ) ) );
+		map.put( "ArrayImg_Subset",
+				() -> Views.interval( ArrayImgs.doubles( 300, 300, 100 ), Intervals.createMinSize( 50, 50, 0, 200, 200, 100 ) ) );
 		map.put( "ArrayImg_HyperSlice", () -> Views.hyperSlice( ArrayImgs.doubles( 200, 200, 100, 10 ), 3, 0 ) );
-		map.put( "ArrayImg_Translated_Zero", () -> Views.translate( Views.translate( ArrayImgs.doubles( DIMS ), 10, 10, 10 ), -10, -10, -10 ) );
+		map.put( "ArrayImg_Translated_Zero",
+				() -> Views.translate( Views.translate( ArrayImgs.doubles( DIMS ), 10, 10, 10 ), -10, -10, -10 ) );
 		map.put( "PlanarImg", () -> PlanarImgs.doubles( DIMS ) );
-		map.put( "PlanarImg_Continuous_Subset", () -> Views.interval( PlanarImgs.doubles( 200, 200, 300 ), Intervals.createMinSize( 0, 0, 99, 200, 200, 100 ) ) );
-		map.put( "PlanarImg_Subset", () -> Views.interval( PlanarImgs.doubles( 300, 300, 100 ), Intervals.createMinSize( 50, 50, 0, 200, 200, 100 ) ) );
+		map.put( "PlanarImg_Continuous_Subset",
+				() -> Views.interval( PlanarImgs.doubles( 200, 200, 300 ), Intervals.createMinSize( 0, 0, 99, 200, 200, 100 ) ) );
+		map.put( "PlanarImg_Subset",
+				() -> Views.interval( PlanarImgs.doubles( 300, 300, 100 ), Intervals.createMinSize( 50, 50, 0, 200, 200, 100 ) ) );
 		map.put( "PlanarImg_HyperSlice", () -> Views.hyperSlice( PlanarImgs.doubles( 200, 200, 100, 10 ), 3, 0 ) );
 		map.put( "PlanarImg_Translated_Zero", () -> Views.hyperSlice( PlanarImgs.doubles( 200, 200, 100, 10 ), 3, 0 ) );
 		map.put( "CellImg", () -> new CellImgFactory<>( new DoubleType(), 64, 64, 64 ).create( DIMS ) );
@@ -140,7 +144,7 @@ public class LoopBuilderVsCursorsBenchmark
 	@Setup
 	public void setup()
 	{
-		if(slowDown)
+		if ( slowDown )
 			slowDown();
 		in = IMG_FACTORIES.get( inputImage ).get();
 		out = IMG_FACTORIES.get( outputImage ).get();

--- a/src/test/java/net/imglib2/loops/LoopPerformanceBenchmark.java
+++ b/src/test/java/net/imglib2/loops/LoopPerformanceBenchmark.java
@@ -71,9 +71,11 @@ public class LoopPerformanceBenchmark
 
 	private final RandomAccessibleInterval< DoubleType > out = ArrayImgs.doubles( dim );
 
-	private final RandomAccessibleInterval< DoubleType > backIn = Views.interval( Views.extendBorder( in ), Intervals.translate( out, 1, 0 ) );
+	private final RandomAccessibleInterval< DoubleType > backIn =
+			Views.interval( Views.extendBorder( in ), Intervals.translate( out, 1, 0 ) );
 
-	private final RandomAccessibleInterval< DoubleType > frontIn = Views.interval( Views.extendBorder( in ), Intervals.translate( out, -1, 0 ) );
+	private final RandomAccessibleInterval< DoubleType > frontIn =
+			Views.interval( Views.extendBorder( in ), Intervals.translate( out, -1, 0 ) );
 
 	@Benchmark
 	public void gradient_niceAndSlow()

--- a/src/test/java/net/imglib2/loops/SyncedPositionablesBenchmark.java
+++ b/src/test/java/net/imglib2/loops/SyncedPositionablesBenchmark.java
@@ -56,41 +56,48 @@ public class SyncedPositionablesBenchmark
 {
 	private long[] dims = { 100, 100, 100 };
 
-	private List< Img< IntType > > array = sixTimes(() -> ArrayImgs.ints( dims ));
+	private List< Img< IntType > > array = sixTimes( () -> ArrayImgs.ints( dims ) );
 
 	private < T > List< T > sixTimes( Supplier< T > supplier )
 	{
-		return IntStream.range( 0, 6 ).mapToObj( ignore -> supplier.get() ).collect( Collectors.toList());
+		return IntStream.range( 0, 6 ).mapToObj( ignore -> supplier.get() ).collect( Collectors.toList() );
 	}
 
 	@Benchmark
-	public void benchmark2() {
+	public void benchmark2()
+	{
 		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ) )
-				.forEachPixel( (a, r) -> r.setReal( a.getRealDouble() ) );
+				.forEachPixel( ( a, r ) -> r.setReal( a.getRealDouble() ) );
 	}
 
 	@Benchmark
-	public void benchmark3() {
+	public void benchmark3()
+	{
 		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ) )
-				.forEachPixel( (a, b, r) -> r.setReal( a.getRealDouble() + b.getRealDouble() ) );
+				.forEachPixel( ( a, b, r ) -> r.setReal( a.getRealDouble() + b.getRealDouble() ) );
 	}
 
 	@Benchmark
-	public void benchmark4() {
+	public void benchmark4()
+	{
 		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ), array.get( 3 ) )
-				.forEachPixel( (a, b, c, r) -> r.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() ) );
+				.forEachPixel( ( a, b, c, r ) -> r.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() ) );
 	}
 
 	@Benchmark
-	public void benchmark5() {
-		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ), array.get( 3 ), array.get( 4) )
-				.forEachPixel( (a, b, c, d, r) -> r.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() + d.getRealDouble() ) );
+	public void benchmark5()
+	{
+		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ), array.get( 3 ), array.get( 4 ) )
+				.forEachPixel(
+						( a, b, c, d, r ) -> r.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() + d.getRealDouble() ) );
 	}
 
 	@Benchmark
-	public void benchmark6() {
-		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ), array.get( 3 ), array.get( 4 ), array.get( 5) )
-				.forEachPixel( (a, b, c, d, e, r) -> r.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() + d.getRealDouble() + e.getRealDouble() ) );
+	public void benchmark6()
+	{
+		LoopBuilder.setImages( array.get( 0 ), array.get( 1 ), array.get( 2 ), array.get( 3 ), array.get( 4 ), array.get( 5 ) )
+				.forEachPixel( ( a, b, c, d, e, r ) -> r
+						.setReal( a.getRealDouble() + b.getRealDouble() + c.getRealDouble() + d.getRealDouble() + e.getRealDouble() ) );
 	}
 
 	public static void main( final String... args ) throws RunnerException

--- a/src/test/java/net/imglib2/nearestneighbor/KDTreeTest.java
+++ b/src/test/java/net/imglib2/nearestneighbor/KDTreeTest.java
@@ -56,7 +56,8 @@ import org.junit.Test;
  */
 public class KDTreeTest
 {
-	protected static boolean testNearestNeighbor( final int numDimensions, final int numPoints, final int numTests, final float min, final float max )
+	protected static boolean testNearestNeighbor( final int numDimensions, final int numPoints, final int numTests, final float min,
+			final float max )
 	{
 		final ArrayList< RealPoint > points = new ArrayList< RealPoint >();
 		final Random rnd = new Random( 435435435 );
@@ -161,7 +162,8 @@ public class KDTreeTest
 		return nearest;
 	}
 
-	protected static boolean testKNearestNeighbor( final int neighbors, final int numDimensions, final int numPoints, final int numTests, final float min, final float max )
+	protected static boolean testKNearestNeighbor( final int neighbors, final int numDimensions, final int numPoints, final int numTests,
+			final float min, final float max )
 	{
 		final ArrayList< RealPoint > points = new ArrayList< RealPoint >();
 		final Random rnd = new Random( 435435435 );
@@ -285,7 +287,8 @@ public class KDTreeTest
 		return nearest;
 	}
 
-	protected static boolean testRadiusNeighbor( final int numDimensions, final int numPoints, final int numTests, final float min, final float max )
+	protected static boolean testRadiusNeighbor( final int numDimensions, final int numPoints, final int numTests, final float min,
+			final float max )
 	{
 		final ArrayList< RealPoint > points = new ArrayList< RealPoint >();
 		final Random rnd = new Random( 435435435 );
@@ -382,7 +385,8 @@ public class KDTreeTest
 		return true;
 	}
 
-	private static ArrayList< ValuePair< RealPoint, Double > > findNeighborsRadiusExhaustive( final ArrayList< RealPoint > points, final RealPoint t, final double radius, final boolean sortResults )
+	private static ArrayList< ValuePair< RealPoint, Double > > findNeighborsRadiusExhaustive( final ArrayList< RealPoint > points,
+			final RealPoint t, final double radius, final boolean sortResults )
 	{
 		final ArrayList< ValuePair< RealPoint, Double > > withinRadius = new ArrayList< ValuePair< RealPoint, Double > >();
 

--- a/src/test/java/net/imglib2/nearestneighbor/NearestNeighborSearchOnIterableRealIntervalTest.java
+++ b/src/test/java/net/imglib2/nearestneighbor/NearestNeighborSearchOnIterableRealIntervalTest.java
@@ -90,7 +90,8 @@ public class NearestNeighborSearchOnIterableRealIntervalTest
 	public void testKNearestNeighborSearch()
 	{
 		final RealCursor< DoubleType > cursor = realPointSampleList.cursor();
-		final KNearestNeighborSearchOnIterableRealInterval< DoubleType > search1 = new KNearestNeighborSearchOnIterableRealInterval< DoubleType >( realPointSampleList, 1 );
+		final KNearestNeighborSearchOnIterableRealInterval< DoubleType > search1 =
+				new KNearestNeighborSearchOnIterableRealInterval< DoubleType >( realPointSampleList, 1 );
 
 		search1.search( new RealPoint( new double[] { 0.1, 0.2 } ) );
 		assertTrue( "Position mismatch ", positionEquals( search1.getPosition( 0 ), new RealPoint( coordinates[ 0 ] ) ) );

--- a/src/test/java/net/imglib2/outofbounds/OutOfBoundsBorderBenchmark.java
+++ b/src/test/java/net/imglib2/outofbounds/OutOfBoundsBorderBenchmark.java
@@ -75,13 +75,13 @@ import java.util.concurrent.TimeUnit;
 public class OutOfBoundsBorderBenchmark
 {
 
-	private final RandomAccessibleInterval<IntType> arrayImg = createImg( new ArrayImgFactory<>( new IntType() ) );
+	private final RandomAccessibleInterval< IntType > arrayImg = createImg( new ArrayImgFactory<>( new IntType() ) );
 
-	private final RandomAccessibleInterval<IntType> planarImg = createImg( new PlanarImgFactory<>( new IntType() ) );
+	private final RandomAccessibleInterval< IntType > planarImg = createImg( new PlanarImgFactory<>( new IntType() ) );
 
-	private final RandomAccessibleInterval<IntType> cellImg = createImg( new CellImgFactory<>( new IntType(), 100, 100 ) );
+	private final RandomAccessibleInterval< IntType > cellImg = createImg( new CellImgFactory<>( new IntType(), 100, 100 ) );
 
-	private static RandomAccessibleInterval<IntType> createImg( final ImgFactory<IntType> factory )
+	private static RandomAccessibleInterval< IntType > createImg( final ImgFactory< IntType > factory )
 	{
 		return Views.interval( Views.extendBorder( factory.create( 900, 900 ) ), new long[] { 0, 0 }, new long[] { 999, 999 } );
 	}
@@ -119,10 +119,10 @@ public class OutOfBoundsBorderBenchmark
 		return sum[ 0 ];
 	}
 
-	public static double sum( final RandomAccessibleInterval<? extends RealType<?>> img )
+	public static double sum( final RandomAccessibleInterval< ? extends RealType< ? > > img )
 	{
 		double sum = 0;
-		final RandomAccess<? extends RealType<?>> ra = img.randomAccess();
+		final RandomAccess< ? extends RealType< ? > > ra = img.randomAccess();
 		ra.setPosition( img.min( 1 ), 1 );
 		for ( int y = 0; y < img.dimension( 1 ); y++ )
 		{
@@ -137,10 +137,10 @@ public class OutOfBoundsBorderBenchmark
 		return sum;
 	}
 
-	public static double sum2( final RandomAccessibleInterval<? extends RealType<?>> img )
+	public static double sum2( final RandomAccessibleInterval< ? extends RealType< ? > > img )
 	{
 		double sum = 0;
-		final RandomAccess<? extends RealType<?>> ra = img.randomAccess();
+		final RandomAccess< ? extends RealType< ? > > ra = img.randomAccess();
 		ra.setPosition( img.min( 1 ), 1 );
 		for ( int y = 0; y < img.dimension( 1 ); y++ )
 		{

--- a/src/test/java/net/imglib2/outofbounds/OutOfBoundsBorderTest.java
+++ b/src/test/java/net/imglib2/outofbounds/OutOfBoundsBorderTest.java
@@ -132,9 +132,12 @@ public class OutOfBoundsBorderTest
 		for ( final IntType t : listImage )
 			t.set( i++ );
 
-		cArray = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( arrayImage, new OutOfBoundsBorderFactory< IntType, Img< IntType > >() ).randomAccess();
-		cCell = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( cellImage, new OutOfBoundsBorderFactory< IntType, Img< IntType > >() ).randomAccess();
-		cList = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( listImage, new OutOfBoundsBorderFactory< IntType, Img< IntType > >() ).randomAccess();
+		cArray = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( arrayImage,
+				new OutOfBoundsBorderFactory< IntType, Img< IntType > >() ).randomAccess();
+		cCell = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( cellImage,
+				new OutOfBoundsBorderFactory< IntType, Img< IntType > >() ).randomAccess();
+		cList = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( listImage,
+				new OutOfBoundsBorderFactory< IntType, Img< IntType > >() ).randomAccess();
 	}
 
 	/**
@@ -168,7 +171,8 @@ public class OutOfBoundsBorderTest
 			assertEquals( "CellContainer x failed at iteration " + i + ".", expectedX[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer x failed at iteration " + i + ".", expectedX[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -190,7 +194,8 @@ public class OutOfBoundsBorderTest
 			assertEquals( "CellContainer y failed at iteration " + i + ".", expectedY[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer y failed at iteration " + i + ".", expectedY[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -212,7 +217,8 @@ public class OutOfBoundsBorderTest
 			assertEquals( "CellContainer z failed at iteration " + i + ".", expectedZ[ i ], cCell.get().getInteger() );
 			assertEquals( "LinkContainer z failed at iteration " + i + ".", expectedZ[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "LinkContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -238,7 +244,8 @@ public class OutOfBoundsBorderTest
 			assertEquals( "CellContainer x failed at iteration " + i + ".", expectedX[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer x failed at iteration " + i + ".", expectedX[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -260,7 +267,8 @@ public class OutOfBoundsBorderTest
 			assertEquals( "CellContainer y failed at iteration " + i + ".", expectedY[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer y failed at iteration " + i + ".", expectedY[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -282,7 +290,8 @@ public class OutOfBoundsBorderTest
 			assertEquals( "CellContainer z failed at iteration " + i + ".", expectedZ[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer z failed at iteration " + i + ".", expectedZ[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -315,7 +324,8 @@ public class OutOfBoundsBorderTest
 			assertEquals( "CellContainer move failed at iteration " + i + ".", v[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer move failed at iteration " + i + ".", v[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 		}

--- a/src/test/java/net/imglib2/outofbounds/OutOfBoundsMirrorDoubleBoundaryTest.java
+++ b/src/test/java/net/imglib2/outofbounds/OutOfBoundsMirrorDoubleBoundaryTest.java
@@ -132,9 +132,12 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 		for ( final IntType t : listImage )
 			t.set( i++ );
 
-		cArray = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( arrayImage, new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.DOUBLE ) ).randomAccess();
-		cCell = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( cellImage, new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.DOUBLE ) ).randomAccess();
-		cList = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( listImage, new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.DOUBLE ) ).randomAccess();
+		cArray = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( arrayImage,
+				new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.DOUBLE ) ).randomAccess();
+		cCell = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( cellImage,
+				new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.DOUBLE ) ).randomAccess();
+		cList = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( listImage,
+				new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.DOUBLE ) ).randomAccess();
 
 	}
 
@@ -158,7 +161,8 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 	{
 		final int[] expectedX = new int[] { 2, 3, 4, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 4, 3, 2, 1, 0, 0, 1, 2, 3 };
 		final int[] expectedY = new int[] { 10, 15, 15, 10, 5, 0, 0, 5, 10, 15, 15, 10, 5, 0, 0, 5, 10, 15, 15, 10, 5, 0, 0, 5 };
-		final int[] expectedZ = new int[] { 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20 };
+		final int[] expectedZ =
+				new int[] { 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20 };
 
 		cArray.setPosition( -8, 0 );
 		cCell.setPosition( -8, 0 );
@@ -169,7 +173,8 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 			assertEquals( "CellContainer x failed at iteration " + i + ".", expectedX[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer x failed at iteration " + i + ".", expectedX[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -191,7 +196,8 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 			assertEquals( "CellContainer y failed at iteration " + i + ".", expectedY[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer y failed at iteration " + i + ".", expectedY[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -213,7 +219,8 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 			assertEquals( "CellContainer z failed at iteration " + i + ".", expectedZ[ i ], cCell.get().getInteger() );
 			assertEquals( "LinkContainer z failed at iteration " + i + ".", expectedZ[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "LinkContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -228,7 +235,8 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 	{
 		final int[] expectedX = new int[] { 2, 3, 4, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 4, 3, 2, 1, 0, 0, 1, 2, 3 };
 		final int[] expectedY = new int[] { 10, 15, 15, 10, 5, 0, 0, 5, 10, 15, 15, 10, 5, 0, 0, 5, 10, 15, 15, 10, 5, 0, 0, 5 };
-		final int[] expectedZ = new int[] { 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20 };
+		final int[] expectedZ =
+				new int[] { 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20, 0, 0, 20, 40, 40, 20 };
 
 		cArray.setPosition( 7, 0 );
 		cCell.setPosition( 7, 0 );
@@ -239,7 +247,8 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 			assertEquals( "CellContainer x failed at iteration " + i + ".", expectedX[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer x failed at iteration " + i + ".", expectedX[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -261,7 +270,8 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 			assertEquals( "CellContainer y failed at iteration " + i + ".", expectedY[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer y failed at iteration " + i + ".", expectedY[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -283,8 +293,10 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 			assertEquals( "CellContainer z failed at iteration " + i + ".", expectedZ[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer z failed at iteration " + i + ".", expectedZ[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
-			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
+			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ),
+					cArray.isOutOfBounds() );
 			assertEquals( "ListContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
 			cArray.bck( 2 );
@@ -316,7 +328,8 @@ public class OutOfBoundsMirrorDoubleBoundaryTest
 			assertEquals( "CellContainer move failed at iteration " + i + ".", v[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer move failed at iteration " + i + ".", v[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 		}

--- a/src/test/java/net/imglib2/outofbounds/OutOfBoundsMirrorSingleBoundaryTest.java
+++ b/src/test/java/net/imglib2/outofbounds/OutOfBoundsMirrorSingleBoundaryTest.java
@@ -132,9 +132,12 @@ public class OutOfBoundsMirrorSingleBoundaryTest
 		for ( final IntType t : listImage )
 			t.set( i++ );
 
-		cArray = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( arrayImage, new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.SINGLE ) ).randomAccess();
-		cCell = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( cellImage, new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.SINGLE ) ).randomAccess();
-		cList = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( listImage, new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.SINGLE ) ).randomAccess();
+		cArray = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( arrayImage,
+				new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.SINGLE ) ).randomAccess();
+		cCell = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( cellImage,
+				new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.SINGLE ) ).randomAccess();
+		cList = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( listImage,
+				new OutOfBoundsMirrorFactory< IntType, Img< IntType > >( Boundary.SINGLE ) ).randomAccess();
 	}
 
 	/**
@@ -168,7 +171,8 @@ public class OutOfBoundsMirrorSingleBoundaryTest
 			assertEquals( "CellContainer x failed at iteration " + i + ".", expectedX[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer x failed at iteration " + i + ".", expectedX[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -190,7 +194,8 @@ public class OutOfBoundsMirrorSingleBoundaryTest
 			assertEquals( "CellContainer y failed at iteration " + i + ".", expectedY[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer y failed at iteration " + i + ".", expectedY[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -212,7 +217,8 @@ public class OutOfBoundsMirrorSingleBoundaryTest
 			assertEquals( "CellContainer z failed at iteration " + i + ".", expectedZ[ i ], cCell.get().getInteger() );
 			assertEquals( "LinkContainer z failed at iteration " + i + ".", expectedZ[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "LinkContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -238,7 +244,8 @@ public class OutOfBoundsMirrorSingleBoundaryTest
 			assertEquals( "CellContainer x failed at iteration " + i + ".", expectedX[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer x failed at iteration " + i + ".", expectedX[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -260,7 +267,8 @@ public class OutOfBoundsMirrorSingleBoundaryTest
 			assertEquals( "CellContainer y failed at iteration " + i + ".", expectedY[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer y failed at iteration " + i + ".", expectedY[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -282,7 +290,8 @@ public class OutOfBoundsMirrorSingleBoundaryTest
 			assertEquals( "CellContainer z failed at iteration " + i + ".", expectedZ[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer z failed at iteration " + i + ".", expectedZ[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -315,7 +324,8 @@ public class OutOfBoundsMirrorSingleBoundaryTest
 			assertEquals( "CellContainer move failed at iteration " + i + ".", v[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer move failed at iteration " + i + ".", v[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 		}

--- a/src/test/java/net/imglib2/outofbounds/OutOfBoundsPeriodicTest.java
+++ b/src/test/java/net/imglib2/outofbounds/OutOfBoundsPeriodicTest.java
@@ -131,9 +131,12 @@ public class OutOfBoundsPeriodicTest
 		for ( final IntType t : listImage )
 			t.set( i++ );
 
-		cArray = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( arrayImage, new OutOfBoundsPeriodicFactory< IntType, Img< IntType > >() ).randomAccess();
-		cCell = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( cellImage, new OutOfBoundsPeriodicFactory< IntType, Img< IntType > >() ).randomAccess();
-		cList = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( listImage, new OutOfBoundsPeriodicFactory< IntType, Img< IntType > >() ).randomAccess();
+		cArray = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( arrayImage,
+				new OutOfBoundsPeriodicFactory< IntType, Img< IntType > >() ).randomAccess();
+		cCell = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( cellImage,
+				new OutOfBoundsPeriodicFactory< IntType, Img< IntType > >() ).randomAccess();
+		cList = new ExtendedRandomAccessibleInterval< IntType, Img< IntType > >( listImage,
+				new OutOfBoundsPeriodicFactory< IntType, Img< IntType > >() ).randomAccess();
 	}
 
 	/**
@@ -167,7 +170,8 @@ public class OutOfBoundsPeriodicTest
 			assertEquals( "CellContainer x failed at iteration " + i + ".", expectedX[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer x failed at iteration " + i + ".", expectedX[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -189,7 +193,8 @@ public class OutOfBoundsPeriodicTest
 			assertEquals( "CellContainer y failed at iteration " + i + ".", expectedY[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer y failed at iteration " + i + ".", expectedY[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -211,7 +216,8 @@ public class OutOfBoundsPeriodicTest
 			assertEquals( "CellContainer z failed at iteration " + i + ".", expectedZ[ i ], cCell.get().getInteger() );
 			assertEquals( "LinkContainer z failed at iteration " + i + ".", expectedZ[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "LinkContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -237,7 +243,8 @@ public class OutOfBoundsPeriodicTest
 			assertEquals( "CellContainer x failed at iteration " + i + ".", expectedX[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer x failed at iteration " + i + ".", expectedX[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer x failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -259,7 +266,8 @@ public class OutOfBoundsPeriodicTest
 			assertEquals( "CellContainer y failed at iteration " + i + ".", expectedY[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer y failed at iteration " + i + ".", expectedY[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer y failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -281,7 +289,8 @@ public class OutOfBoundsPeriodicTest
 			assertEquals( "CellContainer z failed at iteration " + i + ".", expectedZ[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer z failed at iteration " + i + ".", expectedZ[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 
@@ -314,7 +323,8 @@ public class OutOfBoundsPeriodicTest
 			assertEquals( "CellContainer move failed at iteration " + i + ".", v[ i ], cCell.get().getInteger() );
 			assertEquals( "ListContainer move failed at iteration " + i + ".", v[ i ], cList.get().getInteger() );
 
-			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ), cArray.isOutOfBounds() );
+			assertEquals( "ArrayContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cArray ),
+					cArray.isOutOfBounds() );
 			assertEquals( "CellContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cCell ), cCell.isOutOfBounds() );
 			assertEquals( "ListContainer z failed isOutOfBounds() at iteration " + i + ".", isOutOfBounds( cList ), cList.isOutOfBounds() );
 		}

--- a/src/test/java/net/imglib2/parallel/DefaultTaskExecutorTest.java
+++ b/src/test/java/net/imglib2/parallel/DefaultTaskExecutorTest.java
@@ -108,9 +108,9 @@ public class DefaultTaskExecutorTest
 		assertEquals( 6, sum.get() );
 	}
 
-
 	@Test
-	public void testExceptionHandling() {
+	public void testExceptionHandling()
+	{
 		try
 		{
 			twoThreads.runAll( Collections.singletonList( () -> throwDummyException() ) );

--- a/src/test/java/net/imglib2/parallel/ParallelizationDemo.java
+++ b/src/test/java/net/imglib2/parallel/ParallelizationDemo.java
@@ -68,9 +68,9 @@ public class ParallelizationDemo
 		List< Integer > list = Arrays.asList( 1, 2, 3, 4 );
 
 		taskExecutor.forEach( list, index -> {
-			System.out.println( "task " + index + " start");
+			System.out.println( "task " + index + " start" );
 			waitOneSecond();
-			System.out.println( "task " + index + " finish");
+			System.out.println( "task " + index + " finish" );
 		} );
 	}
 

--- a/src/test/java/net/imglib2/position/FunctionRealRandomAccessibleTest.java
+++ b/src/test/java/net/imglib2/position/FunctionRealRandomAccessibleTest.java
@@ -44,20 +44,24 @@ import org.junit.Test;
 
 import net.imglib2.type.logic.BoolType;
 
-
-public class FunctionRealRandomAccessibleTest {
+public class FunctionRealRandomAccessibleTest
+{
 
 	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {}
+	public static void setUpBeforeClass() throws Exception
+	{}
 
 	@AfterClass
-	public static void tearDownAfterClass() throws Exception {}
+	public static void tearDownAfterClass() throws Exception
+	{}
 
 	@Before
-	public void setUp() throws Exception {}
+	public void setUp() throws Exception
+	{}
 
 	@After
-	public void tearDown() throws Exception {}
+	public void tearDown() throws Exception
+	{}
 
 	@Test
 	public void test()

--- a/src/test/java/net/imglib2/test/ImgLib2AssertTest.java
+++ b/src/test/java/net/imglib2/test/ImgLib2AssertTest.java
@@ -76,7 +76,7 @@ public class ImgLib2AssertTest
 	@Test
 	public void testAssertImageEqualsWithPredicate()
 	{
-		ImgLib2Assert.assertImageEquals( img( 3 ), img( 5 ), ( a, e ) -> (a.getInteger() == 3) && (e.getInteger() == 5) );
+		ImgLib2Assert.assertImageEquals( img( 3 ), img( 5 ), ( a, e ) -> ( a.getInteger() == 3 ) && ( e.getInteger() == 5 ) );
 	}
 
 	@Test( expected = AssertionError.class )

--- a/src/test/java/net/imglib2/test/RandomImgsTest.java
+++ b/src/test/java/net/imglib2/test/RandomImgsTest.java
@@ -101,7 +101,7 @@ public class RandomImgsTest
 	{
 		int expected = new Random( 42 ).nextInt();
 		Img< IntType > image = RandomImgs.seed( 42 ).randomize( ArrayImgs.ints( new int[ 1 ], 1 ) );
-		assertImageEquals( ArrayImgs.ints( new int[]{ expected }, 1 ), image );
+		assertImageEquals( ArrayImgs.ints( new int[] { expected }, 1 ), image );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/transform/integer/permutation/PermutationTransformTest.java
+++ b/src/test/java/net/imglib2/transform/integer/permutation/PermutationTransformTest.java
@@ -96,7 +96,8 @@ public class PermutationTransformTest
 	@Test
 	public void test()
 	{
-		final ArrayImg< LongType, LongArray > img = ArrayImgs.longs( PermutationTransformTest.values, PermutationTransformTest.width, PermutationTransformTest.width );
+		final ArrayImg< LongType, LongArray > img =
+				ArrayImgs.longs( PermutationTransformTest.values, PermutationTransformTest.width, PermutationTransformTest.width );
 		final PermutationTransform t = new PermutationTransform( PermutationTransformTest.lut, 2, 2 );
 		final TransformView< LongType > bijectivePermutation = new TransformView< LongType >( img, t );
 		final TransformView< LongType > inverseBijectivePermutation = new TransformView< LongType >( bijectivePermutation, t.inverse() );
@@ -108,7 +109,8 @@ public class PermutationTransformTest
 
 		for ( int i = 0; i < 1000; ++i )
 		{
-			final long[] x = new long[] { PermutationTransformTest.rnd.nextInt( PermutationTransformTest.width ), PermutationTransformTest.rnd.nextInt( PermutationTransformTest.width ) };
+			final long[] x = new long[] { PermutationTransformTest.rnd.nextInt( PermutationTransformTest.width ),
+					PermutationTransformTest.rnd.nextInt( PermutationTransformTest.width ) };
 			reference.setPosition( x );
 			result.setPosition( x );
 			Assert.assertEquals( reference.get().get(), result.get().get() );

--- a/src/test/java/net/imglib2/transform/integer/permutation/SingleDimensionPermutationTransformTest.java
+++ b/src/test/java/net/imglib2/transform/integer/permutation/SingleDimensionPermutationTransformTest.java
@@ -109,7 +109,8 @@ public class SingleDimensionPermutationTransformTest
 	@Test
 	public void test()
 	{
-		final SingleDimensionPermutationTransform transform = new SingleDimensionPermutationTransform( this.lut, this.nDim, this.nDim, this.d );
+		final SingleDimensionPermutationTransform transform =
+				new SingleDimensionPermutationTransform( this.lut, this.nDim, this.nDim, this.d );
 		final SingleDimensionPermutationTransform inverse = transform.inverse();
 
 		final TransformView< IntType > transformed = new TransformView< IntType >( this.img, transform );

--- a/src/test/java/net/imglib2/transform/integer/shear/ShearTransformTest.java
+++ b/src/test/java/net/imglib2/transform/integer/shear/ShearTransformTest.java
@@ -62,13 +62,16 @@ import org.junit.Test;
  */
 public class ShearTransformTest
 {
-	
+
 	final private long[] dim = new long[] { 5, 6, 7, 8 };
+
 	final private int numDimensions = dim.length;
+
 	final private ArrayImg< FloatType, FloatArray > img = ArrayImgs.floats( dim );
+
 	final private Random rng = new Random();
+
 	final private long[] zero = new long[ numDimensions ];
-	
 
 	/**
 	 * @throws java.lang.Exception
@@ -76,28 +79,29 @@ public class ShearTransformTest
 	@Before
 	public void setUp() throws Exception
 	{
-		for ( FloatType i : img ) i.set( rng.nextFloat() );
+		for ( FloatType i : img )
+			i.set( rng.nextFloat() );
 	}
 
-	
 	@Test
 	public void testIdentity()
 	{
 		for ( int source = 0; source < numDimensions; ++source )
 		{
-			for ( int target = 0; target < numDimensions; ++ target ) 
+			for ( int target = 0; target < numDimensions; ++target )
 			{
-				
-				if ( target == source ) continue;
-				
+
+				if ( target == source )
+					continue;
+
 				ShearTransform tf = new ShearTransform( numDimensions, target, source );
 				AbstractShearTransform iv = tf.inverse();
-				TransformView<FloatType> transformed = new TransformView< FloatType >( new TransformView< FloatType >( img, iv ), tf );
-				
-				ArrayCursor<FloatType> i = img.cursor();
-				Cursor<FloatType> t      = Views.flatIterable( Views.interval( transformed, img ) ).cursor();
-				
-				while( t.hasNext() ) 
+				TransformView< FloatType > transformed = new TransformView< FloatType >( new TransformView< FloatType >( img, iv ), tf );
+
+				ArrayCursor< FloatType > i = img.cursor();
+				Cursor< FloatType > t = Views.flatIterable( Views.interval( transformed, img ) ).cursor();
+
+				while ( t.hasNext() )
 				{
 					Assert.assertTrue( i.hasNext() );
 					Assert.assertEquals( i.next().get(), t.next().get(), 0.0f );
@@ -106,39 +110,40 @@ public class ShearTransformTest
 			}
 		}
 	}
-	
-	
+
 	@Test
-	public void testTransform() {
+	public void testTransform()
+	{
 		for ( int source = 0; source < numDimensions; ++source )
 		{
-			for ( int target = 0; target < numDimensions; ++ target )
+			for ( int target = 0; target < numDimensions; ++target )
 			{
-				if ( target == source ) continue;
-				
+				if ( target == source )
+					continue;
+
 				ShearTransform tf = new ShearTransform( numDimensions, target, source );
 				AbstractShearTransform iv = tf.inverse();
-				ExtendedRandomAccessibleInterval<FloatType, ArrayImg<FloatType, FloatArray>> extended = Views.extendValue( img, new FloatType( Float.NaN ) );
-				TransformView<FloatType> transformed = new TransformView< FloatType >( extended, iv );
+				ExtendedRandomAccessibleInterval< FloatType, ArrayImg< FloatType, FloatArray > > extended =
+						Views.extendValue( img, new FloatType( Float.NaN ) );
+				TransformView< FloatType > transformed = new TransformView< FloatType >( extended, iv );
 				BoundingBox boundingBox = new BoundingBox( img );
 				tf.transform( boundingBox );
-				
-				IntervalView<FloatType> viewTransformed = Views.shear( extended, img, target, source );
-				
+
+				IntervalView< FloatType > viewTransformed = Views.shear( extended, img, target, source );
+
 				// BoundingBox holds max, and not max + 1; need to account for that by adding 1+1;
 				Assert.assertEquals( dim[ target ] + dim[ source ], boundingBox.corner2[ target ] + 2 );
-				
-				
-				FinalInterval interval   = new FinalInterval( boundingBox.corner1, boundingBox.corner2 );
-				OutOfBounds<FloatType> i = extended.randomAccess();
-				Cursor<FloatType> t      = Views.flatIterable( Views.interval( transformed, interval ) ).cursor();
-				Cursor<FloatType> v      = Views.flatIterable( viewTransformed ).cursor();
-				
+
+				FinalInterval interval = new FinalInterval( boundingBox.corner1, boundingBox.corner2 );
+				OutOfBounds< FloatType > i = extended.randomAccess();
+				Cursor< FloatType > t = Views.flatIterable( Views.interval( transformed, interval ) ).cursor();
+				Cursor< FloatType > v = Views.flatIterable( viewTransformed ).cursor();
+
 				Assert.assertEquals( interval.numDimensions(), viewTransformed.numDimensions() );
 				for ( int d = 0; d < interval.numDimensions(); ++d )
 					Assert.assertEquals( interval.dimension( d ), viewTransformed.dimension( d ) );
-				
-				while( t.hasNext() )
+
+				while ( t.hasNext() )
 				{
 					t.fwd();
 					v.fwd();
@@ -147,44 +152,44 @@ public class ShearTransformTest
 					Assert.assertEquals( i.get().get(), t.get().get(), 0.0f );
 					Assert.assertEquals( t.get().get(), v.get().get(), 0.0f );
 				}
-				
+
 			}
 		}
 	}
-	
-	
+
 	@Test
-	public void testInverseTransform() 
+	public void testInverseTransform()
 	{
 		for ( int source = 0; source < numDimensions; ++source )
 		{
-			for ( int target = 0; target < numDimensions; ++ target )
+			for ( int target = 0; target < numDimensions; ++target )
 			{
-				if ( target == source ) continue;
-				
+				if ( target == source )
+					continue;
+
 				ShearTransform tf = new ShearTransform( numDimensions, target, source );
 				AbstractShearTransform iv = tf.inverse();
-				ExtendedRandomAccessibleInterval<FloatType, ArrayImg<FloatType, FloatArray>> extended = Views.extendValue( img, new FloatType( Float.NaN ) );
-				TransformView<FloatType> transformed = new TransformView< FloatType >( extended, tf );
+				ExtendedRandomAccessibleInterval< FloatType, ArrayImg< FloatType, FloatArray > > extended =
+						Views.extendValue( img, new FloatType( Float.NaN ) );
+				TransformView< FloatType > transformed = new TransformView< FloatType >( extended, tf );
 				BoundingBox boundingBox = new BoundingBox( img );
 				iv.transform( boundingBox );
-				
-				IntervalView<FloatType> viewTransformed = Views.unshear( extended, img, target, source );
-				
+
+				IntervalView< FloatType > viewTransformed = Views.unshear( extended, img, target, source );
+
 				// BoundingBox holds max, and not max + 1; need to account for that by subtracting 1 (zero stays the same);
 				Assert.assertEquals( zero[ target ] - dim[ source ], boundingBox.corner1[ target ] - 1 );
-				
-				
-				FinalInterval interval   = new FinalInterval( boundingBox.corner1, boundingBox.corner2 );
-				OutOfBounds<FloatType> i = extended.randomAccess();
-				Cursor<FloatType> t      = Views.flatIterable( Views.interval( transformed, interval ) ).cursor();
-				Cursor<FloatType> v      = Views.flatIterable( viewTransformed ).cursor();
-				
+
+				FinalInterval interval = new FinalInterval( boundingBox.corner1, boundingBox.corner2 );
+				OutOfBounds< FloatType > i = extended.randomAccess();
+				Cursor< FloatType > t = Views.flatIterable( Views.interval( transformed, interval ) ).cursor();
+				Cursor< FloatType > v = Views.flatIterable( viewTransformed ).cursor();
+
 				Assert.assertEquals( interval.numDimensions(), viewTransformed.numDimensions() );
 				for ( int d = 0; d < interval.numDimensions(); ++d )
 					Assert.assertEquals( interval.dimension( d ), viewTransformed.dimension( d ) );
-				
-				while( t.hasNext() )
+
+				while ( t.hasNext() )
 				{
 					t.fwd();
 					v.fwd();
@@ -193,7 +198,7 @@ public class ShearTransformTest
 					Assert.assertEquals( i.get().get(), t.get().get(), 0.0f );
 					Assert.assertEquals( t.get().get(), v.get().get(), 0.0f );
 				}
-				
+
 			}
 		}
 	}

--- a/src/test/java/net/imglib2/type/logic/BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/logic/BitTypeTest.java
@@ -55,10 +55,11 @@ import org.junit.Test;
  * @author Stephan Preibisch
  * @author Tobias Pietzsch
  */
-public class BitTypeTest {
+public class BitTypeTest
+{
 
 	static ArrayImg< BitType, LongArray > img;
-	
+
 	/**
 	 * @throws java.lang.Exception
 	 */
@@ -91,7 +92,7 @@ public class BitTypeTest {
 		for ( final BitType t : img )
 			assertTrue( !t.get() );
 	}
-	
+
 	/**
 	 * Test method for {@link net.imglib2.type.logic.BitType#setOne()}.
 	 */
@@ -113,9 +114,10 @@ public class BitTypeTest {
 	 * representation of a BitType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
-		final BitType l = new BitType(false);
+		final BitType l = new BitType( false );
 
 		assertEquals( BigInteger.ZERO, l.getBigInteger() );
 	}
@@ -125,7 +127,8 @@ public class BitTypeTest {
 	 * returned is within BitType range.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final BitType ul = new BitType( false );
 
@@ -137,308 +140,308 @@ public class BitTypeTest {
 		assertEquals( ul.get(), true );
 	}
 
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#toString()}.
-//	 */
-//	@Test
-//	public void testToString() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#inc()}.
-//	 */
-//	@Test
-//	public void testInc() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#dec()}.
-//	 */
-//	@Test
-//	public void testDec() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#BitType(net.imglib2.img.NativeImg)}.
-//	 */
-//	@Test
-//	public void testBitTypeNativeImgOfBitTypeQextendsLongAccess() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#BitType(boolean)}.
-//	 */
-//	@Test
-//	public void testBitTypeBoolean() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#BitType(net.imglib2.img.basictypeaccess.LongAccess)}.
-//	 */
-//	@Test
-//	public void testBitTypeLongAccess() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#BitType()}.
-//	 */
-//	@Test
-//	public void testBitType() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#createSuitableNativeImg(net.imglib2.img.NativeImgFactory, long[])}.
-//	 */
-//	@Test
-//	public void testCreateSuitableNativeImg() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#updateContainer(java.lang.Object)}.
-//	 */
-//	@Test
-//	public void testUpdateContainer() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#duplicateTypeOnSameNativeImg()}.
-//	 */
-//	@Test
-//	public void testDuplicateTypeOnSameNativeImg() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#get()}.
-//	 */
-//	@Test
-//	public void testGet() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#set(boolean)}.
-//	 */
-//	@Test
-//	public void testSetBoolean() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#getInteger()}.
-//	 */
-//	@Test
-//	public void testGetInteger() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#getIntegerLong()}.
-//	 */
-//	@Test
-//	public void testGetIntegerLong() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#setInteger(int)}.
-//	 */
-//	@Test
-//	public void testSetIntegerInt() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#setInteger(long)}.
-//	 */
-//	@Test
-//	public void testSetIntegerLong() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#getMaxValue()}.
-//	 */
-//	@Test
-//	public void testGetMaxValue() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#getMinValue()}.
-//	 */
-//	@Test
-//	public void testGetMinValue() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#set(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testSetBitType() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#and(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testAnd() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#or(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testOr() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#xor(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testXor() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#not()}.
-//	 */
-//	@Test
-//	public void testNot() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#add(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testAddBitType() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#div(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testDivBitType() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#mul(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testMulBitType() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#sub(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testSubBitType() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#compareTo(net.imglib2.type.logic.BitType)}.
-//	 */
-//	@Test
-//	public void testCompareToBitType() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#createVariable()}.
-//	 */
-//	@Test
-//	public void testCreateVariable() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#copy()}.
-//	 */
-//	@Test
-//	public void testCopy() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#getEntitiesPerPixel()}.
-//	 */
-//	@Test
-//	public void testGetEntitiesPerPixel() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#updateIndex(int)}.
-//	 */
-//	@Test
-//	public void testUpdateIndex() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#getIndex()}.
-//	 */
-//	@Test
-//	public void testGetIndex() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#incIndex()}.
-//	 */
-//	@Test
-//	public void testIncIndex() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#incIndex(int)}.
-//	 */
-//	@Test
-//	public void testIncIndexInt() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#decIndex()}.
-//	 */
-//	@Test
-//	public void testDecIndex() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#decIndex(int)}.
-//	 */
-//	@Test
-//	public void testDecIndexInt() {
-//		fail("Not yet implemented");
-//	}
-//
-//	/**
-//	 * Test method for {@link net.imglib2.type.logic.BitType#getBitsPerPixel()}.
-//	 */
-//	@Test
-//	public void testGetBitsPerPixel() {
-//		fail("Not yet implemented");
-//	}
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#toString()}.
+	//	 */
+	//	@Test
+	//	public void testToString() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#inc()}.
+	//	 */
+	//	@Test
+	//	public void testInc() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#dec()}.
+	//	 */
+	//	@Test
+	//	public void testDec() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#BitType(net.imglib2.img.NativeImg)}.
+	//	 */
+	//	@Test
+	//	public void testBitTypeNativeImgOfBitTypeQextendsLongAccess() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#BitType(boolean)}.
+	//	 */
+	//	@Test
+	//	public void testBitTypeBoolean() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#BitType(net.imglib2.img.basictypeaccess.LongAccess)}.
+	//	 */
+	//	@Test
+	//	public void testBitTypeLongAccess() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#BitType()}.
+	//	 */
+	//	@Test
+	//	public void testBitType() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#createSuitableNativeImg(net.imglib2.img.NativeImgFactory, long[])}.
+	//	 */
+	//	@Test
+	//	public void testCreateSuitableNativeImg() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#updateContainer(java.lang.Object)}.
+	//	 */
+	//	@Test
+	//	public void testUpdateContainer() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#duplicateTypeOnSameNativeImg()}.
+	//	 */
+	//	@Test
+	//	public void testDuplicateTypeOnSameNativeImg() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#get()}.
+	//	 */
+	//	@Test
+	//	public void testGet() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#set(boolean)}.
+	//	 */
+	//	@Test
+	//	public void testSetBoolean() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#getInteger()}.
+	//	 */
+	//	@Test
+	//	public void testGetInteger() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#getIntegerLong()}.
+	//	 */
+	//	@Test
+	//	public void testGetIntegerLong() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#setInteger(int)}.
+	//	 */
+	//	@Test
+	//	public void testSetIntegerInt() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#setInteger(long)}.
+	//	 */
+	//	@Test
+	//	public void testSetIntegerLong() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#getMaxValue()}.
+	//	 */
+	//	@Test
+	//	public void testGetMaxValue() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#getMinValue()}.
+	//	 */
+	//	@Test
+	//	public void testGetMinValue() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#set(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testSetBitType() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#and(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testAnd() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#or(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testOr() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#xor(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testXor() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#not()}.
+	//	 */
+	//	@Test
+	//	public void testNot() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#add(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testAddBitType() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#div(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testDivBitType() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#mul(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testMulBitType() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#sub(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testSubBitType() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#compareTo(net.imglib2.type.logic.BitType)}.
+	//	 */
+	//	@Test
+	//	public void testCompareToBitType() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#createVariable()}.
+	//	 */
+	//	@Test
+	//	public void testCreateVariable() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#copy()}.
+	//	 */
+	//	@Test
+	//	public void testCopy() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#getEntitiesPerPixel()}.
+	//	 */
+	//	@Test
+	//	public void testGetEntitiesPerPixel() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#updateIndex(int)}.
+	//	 */
+	//	@Test
+	//	public void testUpdateIndex() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#getIndex()}.
+	//	 */
+	//	@Test
+	//	public void testGetIndex() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#incIndex()}.
+	//	 */
+	//	@Test
+	//	public void testIncIndex() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#incIndex(int)}.
+	//	 */
+	//	@Test
+	//	public void testIncIndexInt() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#decIndex()}.
+	//	 */
+	//	@Test
+	//	public void testDecIndex() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#decIndex(int)}.
+	//	 */
+	//	@Test
+	//	public void testDecIndexInt() {
+	//		fail("Not yet implemented");
+	//	}
+	//
+	//	/**
+	//	 * Test method for {@link net.imglib2.type.logic.BitType#getBitsPerPixel()}.
+	//	 */
+	//	@Test
+	//	public void testGetBitsPerPixel() {
+	//		fail("Not yet implemented");
+	//	}
 
 }

--- a/src/test/java/net/imglib2/type/logic/NativeBoolTypeTest.java
+++ b/src/test/java/net/imglib2/type/logic/NativeBoolTypeTest.java
@@ -54,7 +54,8 @@ import org.junit.Test;
  * 
  * @author Curtis Rueden
  */
-public class NativeBoolTypeTest {
+public class NativeBoolTypeTest
+{
 
 	static ArrayImg< NativeBoolType, BooleanArray > img;
 

--- a/src/test/java/net/imglib2/type/numeric/integer/ByteTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/ByteTypeTest.java
@@ -39,21 +39,22 @@ import java.math.BigInteger;
 
 import org.junit.Test;
 
-
-public class ByteTypeTest {
+public class ByteTypeTest
+{
 
 	/**
 	 * Test which verifies {@link ByteType#getBigInteger()} returns the
 	 * {@code BigInteger} representation of a ByteType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
-		final ByteType l = new ByteType( (byte) 124 );
+		final ByteType l = new ByteType( ( byte ) 124 );
 		assertEquals( BigInteger.valueOf( 124l ), l.getBigInteger() );
 
-		final ByteType l2 = new ByteType( (byte) -18 );
-		assertEquals( BigInteger.valueOf( -18l ) , l2.getBigInteger() );
+		final ByteType l2 = new ByteType( ( byte ) -18 );
+		assertEquals( BigInteger.valueOf( -18l ), l2.getBigInteger() );
 	}
 
 	/**
@@ -61,15 +62,16 @@ public class ByteTypeTest {
 	 * ByteTypes with a {@code BigInteger} and still return a {@code byte} value.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
-		final ByteType l = new ByteType( (byte) 93 );
+		final ByteType l = new ByteType( ( byte ) 93 );
 
-		assertEquals( l.get(), (byte) 93 );
+		assertEquals( l.get(), ( byte ) 93 );
 
 		final BigInteger bi = BigInteger.valueOf( -71l );
 		l.setBigInteger( bi );
-		assertEquals( l.get(), (byte) -71 );
+		assertEquals( l.get(), ( byte ) -71 );
 	}
 
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/IntTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/IntTypeTest.java
@@ -39,21 +39,22 @@ import java.math.BigInteger;
 
 import org.junit.Test;
 
-
-public class IntTypeTest {
+public class IntTypeTest
+{
 
 	/**
 	 * Test which verifies {@link IntType#getBigInteger()} returns the
 	 * {@code BigInteger} representation of an IntType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final IntType l = new IntType( 10948 );
 		assertEquals( BigInteger.valueOf( 10948l ), l.getBigInteger() );
 
 		final IntType l2 = new IntType( -40913824 );
-		assertEquals( BigInteger.valueOf( -40913824l ) , l2.getBigInteger() );
+		assertEquals( BigInteger.valueOf( -40913824l ), l2.getBigInteger() );
 	}
 
 	/**
@@ -62,7 +63,8 @@ public class IntTypeTest {
 	 * {@code int} value.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final IntType l = new IntType( 0 );
 

--- a/src/test/java/net/imglib2/type/numeric/integer/IntegerTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/IntegerTypeTest.java
@@ -112,33 +112,34 @@ public class IntegerTypeTest< T extends IntegerType< T > >
 	{
 		final List< BigInteger > values = new ArrayList<>();
 		final boolean isSigned = type.getMinValue() < 0;
-		final int bits = type.getBitsPerPixel() - (isSigned ? 1 : 0);
+		final int bits = type.getBitsPerPixel() - ( isSigned ? 1 : 0 );
 
 		values.addAll( powersOfTwo( bits ) );
-		if(isSigned)
+		if ( isSigned )
 			values.addAll( negate( powersOfTwo( bits ) ) );
 
 		return values;
 	}
 
 	/** Returns a list: 1, 2, 4, 8, ... , 2^(count - 1). */
-	private List< BigInteger > powersOfTwo( int count ) {
-		BigInteger value  = BigInteger.ONE;
-		List<BigInteger> results = new ArrayList<>( count );
+	private List< BigInteger > powersOfTwo( int count )
+	{
+		BigInteger value = BigInteger.ONE;
+		List< BigInteger > results = new ArrayList<>( count );
 		for ( int i = 0; i < count; i++, value.multiply( BigInteger.valueOf( 2 ) ) )
 			results.add( value );
 		return results;
 	}
 
 	/** Return a list that contains the negated values of the given list. */
-	private List< BigInteger > negate( List<BigInteger> input )
+	private List< BigInteger > negate( List< BigInteger > input )
 	{
-		return input.stream().map( BigInteger::negate ).collect(Collectors.toList());
+		return input.stream().map( BigInteger::negate ).collect( Collectors.toList() );
 	}
 
-
 	@Test
-	public void testGetAndSetBigInteger() {
+	public void testGetAndSetBigInteger()
+	{
 		T type = zero();
 		BigInteger value = toBigInteger( type.getMaxValue() * 0.9 );
 		type.setBigInteger( value );
@@ -146,7 +147,8 @@ public class IntegerTypeTest< T extends IntegerType< T > >
 	}
 
 	@Test
-	public void testToString() {
+	public void testToString()
+	{
 		for ( BigInteger value : values )
 		{
 			final T variable = zero();
@@ -155,20 +157,21 @@ public class IntegerTypeTest< T extends IntegerType< T > >
 		}
 	}
 
-
 	@Test
-	public void testGetReal() {
+	public void testGetReal()
+	{
 		for ( BigInteger value : values )
 		{
 			final T variable = zero();
 			variable.setBigInteger( value );
-			assertEquals( value.doubleValue(), variable.getRealDouble(), 0);
-			assertEquals( value.floatValue(), variable.getRealFloat(), 0);
+			assertEquals( value.doubleValue(), variable.getRealDouble(), 0 );
+			assertEquals( value.floatValue(), variable.getRealFloat(), 0 );
 		}
 	}
 
 	@Test
-	public void testSetRealDouble() {
+	public void testSetRealDouble()
+	{
 		for ( BigInteger value : values )
 		{
 			final T variable = zero();
@@ -178,7 +181,8 @@ public class IntegerTypeTest< T extends IntegerType< T > >
 	}
 
 	@Test
-	public void testSetRealFloat() {
+	public void testSetRealFloat()
+	{
 		for ( BigInteger value : values )
 		{
 			final T variable = zero();

--- a/src/test/java/net/imglib2/type/numeric/integer/IntegerTypesTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/IntegerTypesTest.java
@@ -54,7 +54,8 @@ public class IntegerTypesTest
 		assertEquals( UnsignedShortType.class, IntegerTypes.smallestType( 0, 65535 ).getClass() );
 		assertEquals( UnsignedIntType.class, IntegerTypes.smallestType( 0, 65536 ).getClass() );
 		assertEquals( UnsignedIntType.class, IntegerTypes.smallestType( 0, ( long ) Integer.MAX_VALUE - Integer.MIN_VALUE ).getClass() );
-		assertEquals( UnsignedLongType.class, IntegerTypes.smallestType( 0, ( long ) Integer.MAX_VALUE - Integer.MIN_VALUE + 1 ).getClass() );
+		assertEquals( UnsignedLongType.class,
+				IntegerTypes.smallestType( 0, ( long ) Integer.MAX_VALUE - Integer.MIN_VALUE + 1 ).getClass() );
 
 		assertEquals( ByteType.class, IntegerTypes.smallestType( -128, 0 ).getClass() );
 		assertEquals( ShortType.class, IntegerTypes.smallestType( -129, 0 ).getClass() );

--- a/src/test/java/net/imglib2/type/numeric/integer/LongTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/LongTypeTest.java
@@ -39,21 +39,22 @@ import java.math.BigInteger;
 
 import org.junit.Test;
 
-
-public class LongTypeTest {
+public class LongTypeTest
+{
 
 	/**
 	 * Test which verifies {@link LongType#getBigInteger()} returns the
 	 * {@code BigInteger} representation of an LongType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final LongType l = new LongType( 901374907l );
 		assertEquals( BigInteger.valueOf( 901374907l ), l.getBigInteger() );
 
 		final LongType l2 = new LongType( -98174938174l );
-		assertEquals( BigInteger.valueOf( -98174938174l ) , l2.getBigInteger() );
+		assertEquals( BigInteger.valueOf( -98174938174l ), l2.getBigInteger() );
 	}
 
 	/**
@@ -61,7 +62,8 @@ public class LongTypeTest {
 	 * LongTypes with a {@code BigInteger} and still return a {@code long} value.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final LongType l = new LongType( 72l );
 
@@ -73,7 +75,8 @@ public class LongTypeTest {
 	}
 
 	@Test
-	public void testSetRealFloat() {
+	public void testSetRealFloat()
+	{
 		testSetRealFloat( 0.4f, 0 );
 		testSetRealFloat( 0.6f, 1 );
 		testSetRealFloat( -0.6f, -1 );
@@ -89,7 +92,8 @@ public class LongTypeTest {
 	}
 
 	@Test
-	public void testSetMinMaxValue() {
+	public void testSetMinMaxValue()
+	{
 		testSetRealDouble( new LongType().getMaxValue(), Long.MAX_VALUE );
 		testSetRealDouble( new LongType().getMinValue(), Long.MIN_VALUE );
 	}

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned128BitTypeTest.java
@@ -135,9 +135,10 @@ public class Unsigned128BitTypeTest
 	 * {@code BigInteger} representation of an Unsigned128BitType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
-		final BigInteger bi = new BigInteger("CAFE123498230498CAFE", 16);
+		final BigInteger bi = new BigInteger( "CAFE123498230498CAFE", 16 );
 		final Unsigned128BitType l = new Unsigned128BitType( bi );
 		assertEquals( bi, l.getBigInteger() );
 
@@ -152,9 +153,10 @@ public class Unsigned128BitTypeTest
 	 * {@code int} value.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
-		final BigInteger b = new BigInteger("BABE09481BEEF", 16);
+		final BigInteger b = new BigInteger( "BABE09481BEEF", 16 );
 		final Unsigned128BitType l = new Unsigned128BitType( b );
 		assertEquals( l.get(), b );
 
@@ -164,15 +166,17 @@ public class Unsigned128BitTypeTest
 	}
 
 	@Test
-	public void testGetRealDouble() {
+	public void testGetRealDouble()
+	{
 		assertEquals( 0.0, new Unsigned128BitType( 0, 0 ).getRealDouble(), 0.0 );
 		assertEquals( Math.pow( 2, 128 ), new Unsigned128BitType( -1, -1 ).getRealDouble(), 0.0 );
 	}
 
 	@Test
-	public void testGetRealFloat() {
+	public void testGetRealFloat()
+	{
 		assertEquals( 0.0, new Unsigned128BitType( 0, 0 ).getRealFloat(), 0.0 );
-		assertEquals( Math.pow( 2, 127 ), (float) Math.pow( 2, 127 ), 0.0 );
-		assertEquals( Math.pow( 2, 127 ), new Unsigned128BitType(0, 1l << 63 ).getRealFloat(), 0.0 );
+		assertEquals( Math.pow( 2, 127 ), ( float ) Math.pow( 2, 127 ), 0.0 );
+		assertEquals( Math.pow( 2, 127 ), new Unsigned128BitType( 0, 1l << 63 ).getRealFloat(), 0.0 );
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned12BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned12BitTypeTest.java
@@ -81,13 +81,14 @@ public class Unsigned12BitTypeTest
 	 * {@code BigInteger} representation of an Unsigned12BitType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final Unsigned12BitType l = new Unsigned12BitType( 300l );
 		assertEquals( BigInteger.valueOf( 300l ), l.getBigInteger() );
 
 		final Unsigned12BitType l2 = new Unsigned12BitType( 5700l );
-		assertEquals( BigInteger.valueOf( 1604l ) , l2.getBigInteger() );
+		assertEquals( BigInteger.valueOf( 1604l ), l2.getBigInteger() );
 	}
 
 	/**
@@ -96,7 +97,8 @@ public class Unsigned12BitTypeTest
 	 * {@code int} value that is in the proper range.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final Unsigned12BitType l = new Unsigned12BitType( 1029l );
 
@@ -135,7 +137,6 @@ public class Unsigned12BitTypeTest
 		assertTrue( b.equals( i4 ) );
 		assertTrue( i4.equals( b ) );
 	}
-
 
 	/** Tests {@link Unsigned12BitType#hashCode()}. */
 	@Test

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned2BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned2BitTypeTest.java
@@ -81,13 +81,14 @@ public class Unsigned2BitTypeTest
 	 * {@code BigInteger} representation of an Unsigned2BitType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final Unsigned2BitType l = new Unsigned2BitType( 2 );
 		assertEquals( BigInteger.valueOf( 2l ), l.getBigInteger() );
 
 		final Unsigned2BitType l2 = new Unsigned2BitType( 0l );
-		assertEquals( BigInteger.ZERO , l2.getBigInteger() );
+		assertEquals( BigInteger.ZERO, l2.getBigInteger() );
 	}
 
 	/**
@@ -96,7 +97,8 @@ public class Unsigned2BitTypeTest
 	 * {@code int} value that is in the proper range.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final Unsigned2BitType l = new Unsigned2BitType( 10l );
 
@@ -136,12 +138,12 @@ public class Unsigned2BitTypeTest
 		assertTrue( i4.equals( b ) );
 	}
 
-
 	/** Tests {@link Unsigned2BitType#hashCode()}. */
 	@Test
 	public void testHashCode()
 	{
-		for (int i = 0; i < 4; i++) {
+		for ( int i = 0; i < 4; i++ )
+		{
 			final Unsigned2BitType b = new Unsigned2BitType( i );
 			assertEquals( i, b.hashCode() );
 		}

--- a/src/test/java/net/imglib2/type/numeric/integer/Unsigned4BitTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/Unsigned4BitTypeTest.java
@@ -57,7 +57,7 @@ public class Unsigned4BitTypeTest
 	public static void setUpBeforeClass() throws Exception
 	{
 
-		img = new ArrayImgFactory<> ( new Unsigned4BitType() ).create( 10, 20, 30 );
+		img = new ArrayImgFactory<>( new Unsigned4BitType() ).create( 10, 20, 30 );
 	}
 
 	/**
@@ -81,13 +81,14 @@ public class Unsigned4BitTypeTest
 	 * {@code BigInteger} representation of an Unsigned4BitType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final Unsigned4BitType l = new Unsigned4BitType( 14l );
 		assertEquals( BigInteger.valueOf( 14l ), l.getBigInteger() );
 
 		final Unsigned4BitType l2 = new Unsigned4BitType( -7l );
-		assertEquals( BigInteger.valueOf( 9l ) , l2.getBigInteger() );
+		assertEquals( BigInteger.valueOf( 9l ), l2.getBigInteger() );
 	}
 
 	/**
@@ -96,7 +97,8 @@ public class Unsigned4BitTypeTest
 	 * {@code int} value that is in the proper range.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final Unsigned4BitType l = new Unsigned4BitType( 4l );
 
@@ -136,12 +138,12 @@ public class Unsigned4BitTypeTest
 		assertTrue( i4.equals( b ) );
 	}
 
-
 	/** Tests {@link Unsigned4BitType#hashCode()}. */
 	@Test
 	public void testHashCode()
 	{
-		for (int i = 0; i < 16; i++) {
+		for ( int i = 0; i < 16; i++ )
+		{
 			final Unsigned4BitType b = new Unsigned4BitType( i );
 			assertEquals( i, b.hashCode() );
 		}

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedByteTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedByteTypeTest.java
@@ -91,13 +91,14 @@ public class UnsignedByteTypeTest
 	 * {@code BigInteger} representation of an UnsignedByteType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final UnsignedByteType l = new UnsignedByteType( 255 );
 		assertEquals( BigInteger.valueOf( 255l ), l.getBigInteger() );
 
 		final UnsignedByteType l2 = new UnsignedByteType( -127 );
-		assertEquals( BigInteger.valueOf( 129l ) , l2.getBigInteger() );
+		assertEquals( BigInteger.valueOf( 129l ), l2.getBigInteger() );
 	}
 
 	/**
@@ -106,7 +107,8 @@ public class UnsignedByteTypeTest
 	 * proper {@code int} value.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final UnsignedByteType l = new UnsignedByteType( 255 );
 

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedIntTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedIntTypeTest.java
@@ -92,13 +92,14 @@ public class UnsignedIntTypeTest
 	 * {@code BigInteger} representation of an UnsignedIntType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final UnsignedIntType l = new UnsignedIntType( 120345l );
 		assertEquals( BigInteger.valueOf( 120345l ), l.getBigInteger() );
 
 		final UnsignedIntType l2 = new UnsignedIntType( -1209843l );
-		assertEquals( BigInteger.valueOf( 4293757453l ) , l2.getBigInteger() );
+		assertEquals( BigInteger.valueOf( 4293757453l ), l2.getBigInteger() );
 	}
 
 	/**
@@ -107,7 +108,8 @@ public class UnsignedIntTypeTest
 	 * {@code long} value within the proper range.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final UnsignedIntType l = new UnsignedIntType( 6943 );
 

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedLongTypeTest.java
@@ -41,17 +41,19 @@ import java.math.BigInteger;
 
 import org.junit.Test;
 
-
-public class UnsignedLongTypeTest {
+public class UnsignedLongTypeTest
+{
 
 	private UnsignedLongType u = new UnsignedLongType();
+
 	private UnsignedLongType t = new UnsignedLongType();
 
 	/** Tests that {@link UnsignedLongType#compareTo(UnsignedLongType)} works for
 	 * comparing a positive number to a negative number and vice versa.
 	 */
 	@Test
-	public void testComparePosNeg(){
+	public void testComparePosNeg()
+	{
 
 		u.set( -1L );
 		t.set( 1L );
@@ -71,7 +73,8 @@ public class UnsignedLongTypeTest {
 	 * comparing two negative numbers.
 	 */
 	@Test
-	public void testCompareNegatives(){
+	public void testCompareNegatives()
+	{
 
 		u.set( -9000L );
 		t.set( -9000L );
@@ -91,11 +94,12 @@ public class UnsignedLongTypeTest {
 	 * comparing two positive numbers.
 	 */
 	@Test
-	public void testComparePositives(){
+	public void testComparePositives()
+	{
 
 		u.set( 100L );
 		t.set( 100L );
-		assertEquals( u.compareTo( t ), 0);
+		assertEquals( u.compareTo( t ), 0 );
 
 		u.set( 3098080948019L );
 		t.set( 1L );
@@ -111,7 +115,8 @@ public class UnsignedLongTypeTest {
 	 * when comparing values to zero.
 	 */
 	@Test
-	public void testCompareZero() {
+	public void testCompareZero()
+	{
 
 		u.set( 0L );
 		t.set( 0L );
@@ -132,7 +137,8 @@ public class UnsignedLongTypeTest {
 	 * of range values.
 	 */
 	@Test
-	public void testBIConstructor() {
+	public void testBIConstructor()
+	{
 
 		final BigInteger bi = new BigInteger( "ABCD14984904EFEFEFE4324904294D17A", 16 );
 		final UnsignedLongType l = new UnsignedLongType( bi );
@@ -146,7 +152,8 @@ public class UnsignedLongTypeTest {
 	 * constructed with a {@code long} or a {@code BigInteger}.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final BigInteger mask = new BigInteger( "FFFFFFFFFFFFFFFF", 16 );
 		final BigInteger bi = new BigInteger( "DEAD12345678BEEF", 16 );
@@ -156,8 +163,8 @@ public class UnsignedLongTypeTest {
 
 		final UnsignedLongType l2 = new UnsignedLongType( -473194873871904l );
 
-		assertEquals(BigInteger.valueOf( -473194873871904l ).and( mask ),
-			l2.getBigInteger() );
+		assertEquals( BigInteger.valueOf( -473194873871904l ).and( mask ),
+				l2.getBigInteger() );
 	}
 
 	/**
@@ -165,7 +172,8 @@ public class UnsignedLongTypeTest {
 	 * can still return the proper long value.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final long l = -184713894790123847l;
 		final UnsignedLongType ul = new UnsignedLongType( l );
@@ -179,26 +187,30 @@ public class UnsignedLongTypeTest {
 	}
 
 	@Test
-	public void testGetMaxValue() {
-		assertEquals( (double) Long.MAX_VALUE - (double) Long.MIN_VALUE, new UnsignedLongType().getMaxValue(), 0.0 );
+	public void testGetMaxValue()
+	{
+		assertEquals( ( double ) Long.MAX_VALUE - ( double ) Long.MIN_VALUE, new UnsignedLongType().getMaxValue(), 0.0 );
 	}
 
 	@Test
-	public void testGetRealDouble() {
+	public void testGetRealDouble()
+	{
 
 		final UnsignedLongType ul = new UnsignedLongType( -1 );
 		assertEquals( ul.getMaxValue(), ul.getRealDouble(), 0.0 );
 	}
 
 	@Test
-	public void testGetRealFloat() {
+	public void testGetRealFloat()
+	{
 
 		final UnsignedLongType ul = new UnsignedLongType( -1 );
-		assertEquals( (float) ul.getMaxValue(), ul.getRealFloat(), 0.0f );
+		assertEquals( ( float ) ul.getMaxValue(), ul.getRealFloat(), 0.0f );
 	}
 
 	@Test
-	public void testSetRealDouble() {
+	public void testSetRealDouble()
+	{
 		// simple values
 		testSetRealDouble( 0, 0 );
 		testSetRealDouble( 42, 42 );
@@ -209,7 +221,7 @@ public class UnsignedLongTypeTest {
 		// max long + 1
 		testSetRealDouble( Math.pow( 2, 63 ), 1l << 63 );
 		// value smaller than "max long + 1", that can be represented by double
-		testSetRealDouble( Math.pow( 2, 63 ) - Math.pow( 2, 10 ), (1l << 63) - (1l << 10) );
+		testSetRealDouble( Math.pow( 2, 63 ) - Math.pow( 2, 10 ), ( 1l << 63 ) - ( 1l << 10 ) );
 		// max unsigned long + 1
 		testSetRealDouble( Math.pow( 2, 64 ) + 1, ( long ) -1 );
 	}
@@ -222,13 +234,15 @@ public class UnsignedLongTypeTest {
 	}
 
 	@Test
-	public void testSetMinMax() {
+	public void testSetMinMax()
+	{
 		testSetRealDouble( new UnsignedLongType().getMaxValue(), -1l );
 		testSetRealDouble( new UnsignedLongType().getMinValue(), 0 );
 	}
 
 	@Test
-	public void testSetRealFloat() {
+	public void testSetRealFloat()
+	{
 		// simple values
 		testSetRealFloat( 0, 0 );
 		testSetRealFloat( 42, 42 );
@@ -239,7 +253,7 @@ public class UnsignedLongTypeTest {
 		// max long + 1
 		testSetRealFloat( Math.pow( 2, 63 ), 1l << 63 );
 		// value smaller than "max long + 1", that can be represented by float
-		testSetRealFloat( Math.pow( 2, 63 ) - Math.pow( 2, 39 ), (1l << 63) - (1l << 39) );
+		testSetRealFloat( Math.pow( 2, 63 ) - Math.pow( 2, 39 ), ( 1l << 63 ) - ( 1l << 39 ) );
 		// max unsigned long + 1
 		testSetRealFloat( Math.pow( 2, 64 ) + 1, ( long ) -1 );
 	}
@@ -247,7 +261,7 @@ public class UnsignedLongTypeTest {
 	private void testSetRealFloat( double realValue, long longValue )
 	{
 		UnsignedLongType type = new UnsignedLongType();
-		type.setReal((float) realValue );
+		type.setReal( ( float ) realValue );
 		assertEquals( longValue, type.getLong() );
 	}
 }

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedShortTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedShortTypeTest.java
@@ -91,13 +91,14 @@ public class UnsignedShortTypeTest
 	 * {@code BigInteger} representation of an UnsignedShortType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
 		final UnsignedShortType l = new UnsignedShortType( 1000 );
 		assertEquals( BigInteger.valueOf( 1000l ), l.getBigInteger() );
 
 		final UnsignedShortType l2 = new UnsignedShortType( 32001 );
-		assertEquals( BigInteger.valueOf( 32001l ) , l2.getBigInteger() );
+		assertEquals( BigInteger.valueOf( 32001l ), l2.getBigInteger() );
 	}
 
 	/**
@@ -106,7 +107,8 @@ public class UnsignedShortTypeTest
 	 * {@code int} value within range.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
 		final UnsignedShortType l = new UnsignedShortType( 93 );
 

--- a/src/test/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthTypeTest.java
@@ -39,8 +39,8 @@ import java.math.BigInteger;
 
 import org.junit.Test;
 
-
-public class UnsignedVariableBitLengthTypeTest {
+public class UnsignedVariableBitLengthTypeTest
+{
 
 	/**
 	 * Test which verifies {@link UnsignedVariableBitLengthType#getBigInteger()}
@@ -48,20 +48,18 @@ public class UnsignedVariableBitLengthTypeTest {
 	 * UnsignedVariableBitLengthType.
 	 */
 	@Test
-	public void testGetBigInteger() {
+	public void testGetBigInteger()
+	{
 
-		final UnsignedVariableBitLengthType l = new
-				UnsignedVariableBitLengthType( 1234l, 16 );
+		final UnsignedVariableBitLengthType l = new UnsignedVariableBitLengthType( 1234l, 16 );
 		assertEquals( BigInteger.valueOf( 1234l ), l.getBigInteger() );
 
-		final UnsignedVariableBitLengthType l2 = new
-				UnsignedVariableBitLengthType( -196, 8);
+		final UnsignedVariableBitLengthType l2 = new UnsignedVariableBitLengthType( -196, 8 );
 		assertEquals( BigInteger.valueOf( 60l ), l2.getBigInteger() );
 
-		final UnsignedVariableBitLengthType l3 = new
-				UnsignedVariableBitLengthType( -9223372036854775807l, 64 );
-		assertEquals( BigInteger.valueOf( -9223372036854775807l ).and( 
-			new BigInteger("FFFFFFFFFFFFFFFF", 16) ), l3.getBigInteger() );
+		final UnsignedVariableBitLengthType l3 = new UnsignedVariableBitLengthType( -9223372036854775807l, 64 );
+		assertEquals( BigInteger.valueOf( -9223372036854775807l ).and(
+				new BigInteger( "FFFFFFFFFFFFFFFF", 16 ) ), l3.getBigInteger() );
 	}
 
 	/**
@@ -71,10 +69,10 @@ public class UnsignedVariableBitLengthTypeTest {
 	 * a {@code long} value that is in the correct range.
 	 */
 	@Test
-	public void testSetBigInteger() {
+	public void testSetBigInteger()
+	{
 
-		final UnsignedVariableBitLengthType ul = new
-				UnsignedVariableBitLengthType( 6347, 14 );
+		final UnsignedVariableBitLengthType ul = new UnsignedVariableBitLengthType( 6347, 14 );
 		assertEquals( ul.get(), 6347 );
 
 		ul.setBigInteger( BigInteger.valueOf( 15004l ) );

--- a/src/test/java/net/imglib2/util/ConstantUtilsTest.java
+++ b/src/test/java/net/imglib2/util/ConstantUtilsTest.java
@@ -77,7 +77,8 @@ public class ConstantUtilsTest
 		final Random rng = new Random( 100 );
 		final long[] dims = LongStream.generate( () -> rng.nextInt( 5 ) + 1 ).limit( nDim ).toArray();
 		final IntType constVal = new IntType( 123 );
-		final RandomAccessibleInterval< IntType > randomAccessibleInterval = ConstantUtils.constantRandomAccessibleInterval( constVal, new FinalInterval( dims ) );
+		final RandomAccessibleInterval< IntType > randomAccessibleInterval =
+				ConstantUtils.constantRandomAccessibleInterval( constVal, new FinalInterval( dims ) );
 
 		Assert.assertArrayEquals( dims, Intervals.dimensionsAsLongArray( randomAccessibleInterval ) );
 		Assert.assertArrayEquals( new long[ nDim ], randomAccessibleInterval.minAsLongArray() );

--- a/src/test/java/net/imglib2/util/FlatCollectionsBenchmark.java
+++ b/src/test/java/net/imglib2/util/FlatCollectionsBenchmark.java
@@ -59,22 +59,24 @@ import java.util.Collection;
 @State( Scope.Benchmark )
 public class FlatCollectionsBenchmark
 {
-	Img< IntType > image = RandomImgs.seed( 42 ).nextImage( new IntType(), 100, 100, 100);
+	Img< IntType > image = RandomImgs.seed( 42 ).nextImage( new IntType(), 100, 100, 100 );
 
 	Collection< Integer > list = FlatCollections.integerCollection( image );
 
 	@Benchmark
-	public double benchmarkSumList() {
+	public double benchmarkSumList()
+	{
 		double sum = 0;
-		for( Integer pixel : list )
+		for ( Integer pixel : list )
 			sum += pixel;
 		return sum;
 	}
 
 	@Benchmark
-	public double benchmarkSumImg() {
+	public double benchmarkSumImg()
+	{
 		double sum = 0;
-		for( RealType<?> pixel : image )
+		for ( RealType< ? > pixel : image )
 			sum += pixel.getRealDouble();
 		return sum;
 	}

--- a/src/test/java/net/imglib2/util/FlatCollectionsTest.java
+++ b/src/test/java/net/imglib2/util/FlatCollectionsTest.java
@@ -69,21 +69,28 @@ import org.junit.Test;
 public final class FlatCollectionsTest
 {
 
-	private final Img< String > imgString = new ListImg<>( Arrays.asList( "A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3", "D1", "D2", "D3" ), 3, 4 );
+	private final Img< String > imgString =
+			new ListImg<>( Arrays.asList( "A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3", "D1", "D2", "D3" ), 3, 4 );
 
-	private final Img< NativeBoolType > imgBoolean = ArrayImgs.booleans( new boolean[] { true, true, false, false, false, true, true, false }, 2, 4 );
+	private final Img< NativeBoolType > imgBoolean =
+			ArrayImgs.booleans( new boolean[] { true, true, false, false, false, true, true, false }, 2, 4 );
 
 	private final Img< ByteType > imgByte = ArrayImgs.bytes( new byte[] { 7, 3, 0, 56, -66, -1, 33, 127, 1, 99, 42, -128 }, 3, 4 );
 
-	private final Img< DoubleType > imgDouble = ArrayImgs.doubles( new double[] { 0.1, 0.02, 0.003, 0.0004, 0.00005, 0.000006, 0.0000007, 0.00000008, 0.000000009, 0, -0.9, -0.08 }, 3, 4 );
+	private final Img< DoubleType > imgDouble = ArrayImgs.doubles(
+			new double[] { 0.1, 0.02, 0.003, 0.0004, 0.00005, 0.000006, 0.0000007, 0.00000008, 0.000000009, 0, -0.9, -0.08 }, 3, 4 );
 
-	private final Img< IntType > imgInt = ArrayImgs.ints( new int[] { 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000, -1_000_000_000, -100_000_000 }, 3, 4 );
+	private final Img< IntType > imgInt = ArrayImgs.ints( new int[] { 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000,
+			100_000_000, 1_000_000_000, -1_000_000_000, -100_000_000 }, 3, 4 );
 
-	private final Img< LongType > imgLong = ArrayImgs.longs( new long[] { 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000, 10_000_000_000L, 100_000_000_000L }, 3, 4 );
+	private final Img< LongType > imgLong = ArrayImgs.longs( new long[] { 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000,
+			100_000_000, 1_000_000_000, 10_000_000_000L, 100_000_000_000L }, 3, 4 );
 
-	private final Img< ShortType > imgShort = ArrayImgs.shorts( new short[] { 32767, 32766, 32765, 32764, 32763, 10000, 10001, 10002, 10003, -32768, -32767, -32766 }, 2, 3, 2 );
+	private final Img< ShortType > imgShort = ArrayImgs
+			.shorts( new short[] { 32767, 32766, 32765, 32764, 32763, 10000, 10001, 10002, 10003, -32768, -32767, -32766 }, 2, 3, 2 );
 
-	private final Img< UnsignedLongType > imgUnsignedLong = ArrayImgs.unsignedLongs( new long[] { Long.MAX_VALUE, Long.MAX_VALUE / 2, -1, Long.MIN_VALUE, Long.MIN_VALUE / 2, Long.MIN_VALUE / 3 }, 3, 2 );
+	private final Img< UnsignedLongType > imgUnsignedLong = ArrayImgs.unsignedLongs(
+			new long[] { Long.MAX_VALUE, Long.MAX_VALUE / 2, -1, Long.MIN_VALUE, Long.MIN_VALUE / 2, Long.MIN_VALUE / 3 }, 3, 2 );
 
 	@Test
 	public void testCollection()
@@ -120,7 +127,8 @@ public final class FlatCollectionsTest
 		assertImageEqualsCollection( imgInt, FlatCollections.integerCollection( imgInt ), ( e, a ) -> e.get() == a );
 		assertImageEqualsCollection( imgLong, FlatCollections.integerCollection( imgLong ), ( e, a ) -> e.getInteger() == a ); // lossy
 		assertImageEqualsCollection( imgShort, FlatCollections.integerCollection( imgShort ), ( e, a ) -> e.getInteger() == a );
-		assertImageEqualsCollection( imgUnsignedLong, FlatCollections.integerCollection( imgUnsignedLong ), ( e, a ) -> e.getInteger() == a ); // lossy
+		assertImageEqualsCollection( imgUnsignedLong, FlatCollections.integerCollection( imgUnsignedLong ),
+				( e, a ) -> e.getInteger() == a ); // lossy
 	}
 
 	@Test
@@ -129,13 +137,15 @@ public final class FlatCollectionsTest
 		assertImageEqualsCollection( imgByte, FlatCollections.longCollection( imgByte ), ( e, a ) -> e.getIntegerLong() == a );
 		assertImageEqualsCollection( imgLong, FlatCollections.longCollection( imgLong ), ( e, a ) -> e.get() == a );
 		assertImageEqualsCollection( imgShort, FlatCollections.longCollection( imgShort ), ( e, a ) -> e.getIntegerLong() == a );
-		assertImageEqualsCollection( imgUnsignedLong, FlatCollections.longCollection( imgUnsignedLong ), ( e, a ) -> e.getIntegerLong() == a ); // lossy
+		assertImageEqualsCollection( imgUnsignedLong, FlatCollections.longCollection( imgUnsignedLong ),
+				( e, a ) -> e.getIntegerLong() == a ); // lossy
 	}
 
 	@Test
 	public void testBigIntegerCollection()
 	{
-		assertImageEqualsCollection( imgUnsignedLong, FlatCollections.bigIntegerCollection( imgUnsignedLong ), ( e, a ) -> Objects.equals( e.getBigInteger(), a ) );
+		assertImageEqualsCollection( imgUnsignedLong, FlatCollections.bigIntegerCollection( imgUnsignedLong ),
+				( e, a ) -> Objects.equals( e.getBigInteger(), a ) );
 	}
 
 	@Test
@@ -188,10 +198,12 @@ public final class FlatCollectionsTest
 	@Test
 	public void testBigIntegerList()
 	{
-		assertImageEqualsCollection( imgUnsignedLong, FlatCollections.bigIntegerList( imgUnsignedLong ), ( e, a ) -> Objects.equals( e.getBigInteger(), a ) );
+		assertImageEqualsCollection( imgUnsignedLong, FlatCollections.bigIntegerList( imgUnsignedLong ),
+				( e, a ) -> Objects.equals( e.getBigInteger(), a ) );
 	}
 
-	private < T, E > void assertImageEqualsCollection( final Img< T > image, final Collection< E > collection, final BiPredicate< T, E > equality )
+	private < T, E > void assertImageEqualsCollection( final Img< T > image, final Collection< E > collection,
+			final BiPredicate< T, E > equality )
 	{
 		assertEquals( Intervals.numElements( image ), collection.size() );
 		assertIterationEquals( image, collection, equality );
@@ -203,7 +215,8 @@ public final class FlatCollectionsTest
 		assertRandomAccessibleIntervalEqualsList( image, list, equality );
 	}
 
-	private < E, A > void assertIterationEquals( final Iterable< E > expected, final Iterable< A > actual, final BiPredicate< E, A > equality )
+	private < E, A > void assertIterationEquals( final Iterable< E > expected, final Iterable< A > actual,
+			final BiPredicate< E, A > equality )
 	{
 		final Iterator< E > e = expected.iterator();
 		final Iterator< A > a = actual.iterator();
@@ -217,9 +230,10 @@ public final class FlatCollectionsTest
 		assertFalse( "More elements than expected", a.hasNext() );
 	}
 
-	private < T, E > void assertRandomAccessibleIntervalEqualsList( final RandomAccessibleInterval< T > image, final List< E > list, final BiPredicate< T, E > equality )
+	private < T, E > void assertRandomAccessibleIntervalEqualsList( final RandomAccessibleInterval< T > image, final List< E > list,
+			final BiPredicate< T, E > equality )
 	{
-		final Cursor< T > cursor = Views.flatIterable(image).cursor();
+		final Cursor< T > cursor = Views.flatIterable( image ).cursor();
 		for ( int index = 0; index < list.size(); index++ )
 		{
 			final T iv = cursor.next();

--- a/src/test/java/net/imglib2/util/ImgTestHelper.java
+++ b/src/test/java/net/imglib2/util/ImgTestHelper.java
@@ -182,15 +182,17 @@ public class ImgTestHelper
 
 			final FloatType t2 = positionable2.get();
 			final FloatType t1 = localizableCursor1.get();
-//			float f1 = t1.getRealFloat();
-//			float f2 = t2.getRealFloat();
+			//			float f1 = t1.getRealFloat();
+			//			float f2 = t2.getRealFloat();
 			t2.set( t1 );
-//			positionable2.get().set( localizableCursor1.get() );
+			//			positionable2.get().set( localizableCursor1.get() );
 		}
 
 		// copy again to the first image using a LocalizableByDimOutsideCursor
 		// and a LocalizableByDimCursor
-		final ExtendedRandomAccessibleInterval< FloatType, Img< FloatType > > extendedImg2 = new ExtendedRandomAccessibleInterval< FloatType, Img< FloatType > >( img2, new OutOfBoundsPeriodicFactory< FloatType, Img< FloatType > >() );
+		final ExtendedRandomAccessibleInterval< FloatType, Img< FloatType > > extendedImg2 =
+				new ExtendedRandomAccessibleInterval< FloatType, Img< FloatType > >( img2,
+						new OutOfBoundsPeriodicFactory< FloatType, Img< FloatType > >() );
 		final RandomAccess< FloatType > outsideCursor2 = extendedImg2.randomAccess();
 		localizableCursor1.reset();
 
@@ -221,8 +223,8 @@ public class ImgTestHelper
 				final FloatType t1 = localizableCursor1.get();
 				final FloatType t2 = outsideCursor2.get();
 
-//				final float f1 = t1.getRealFloat();
-//				final float f2 = t2.getRealFloat();
+				//				final float f1 = t1.getRealFloat();
+				//				final float f2 = t2.getRealFloat();
 
 				t1.set( t2 );
 

--- a/src/test/java/net/imglib2/util/ImgUtilTest.java
+++ b/src/test/java/net/imglib2/util/ImgUtilTest.java
@@ -60,34 +60,35 @@ import org.junit.Test;
  */
 public class ImgUtilTest
 {
-	
+
 	@Test
 	public void testPercentile()
 	{
-		final double[] data = new double[42];
-		for(int i = 0; i < data.length; i++) {
-		    data[i] = Math.random()*42;
+		final double[] data = new double[ 42 ];
+		for ( int i = 0; i < data.length; i++ )
+		{
+			data[ i ] = Math.random() * 42;
 		}
 		final double[] sortedData = data.clone();
 		final double[] quicksortedData = data.clone();
 		Arrays.sort( sortedData );
 		quicksort( quicksortedData );
-		
-		for(int i = 0; i < 3; i++){
-		
+
+		for ( int i = 0; i < 3; i++ )
+		{
+
 			double percentile = Math.random();
-			
+
 			int pos = Math.min( data.length - 1,
-								Math.max( 0, ( int ) Math.round( ( data.length - 1 ) * percentile ) ) );
-			
+					Math.max( 0, ( int ) Math.round( ( data.length - 1 ) * percentile ) ) );
+
 			final double percentileRes = percentile( data, percentile );
-			
-			assertEquals(quicksortedData[pos], sortedData[pos], 0.001);
-			assertEquals(quicksortedData[pos], percentileRes, 0.001);
-			
+
+			assertEquals( quicksortedData[ pos ], sortedData[ pos ], 0.001 );
+			assertEquals( quicksortedData[ pos ], percentileRes, 0.001 );
+
 		}
-		
-		
+
 	}
 
 	@Test
@@ -98,18 +99,20 @@ public class ImgUtilTest
 		final int[][] strides = { { 1, 3 }, { 3, 1 }, { -1, -3 } };
 		final double[][][] expected = {
 				{
-				{ 0, 1, 2 },
-				{ 3, 4, 5 },
-				{ 6, 7, 8 }
-		}, {
-		{ 0, 3, 6 },
-		{ 1, 4, 7 },
-		{ 2, 5, 8 }
-		}, {
-		{ 8, 7, 6 },
-		{ 5, 4, 3 },
-		{ 2, 1, 0 }
-		} };
+						{ 0, 1, 2 },
+						{ 3, 4, 5 },
+						{ 6, 7, 8 }
+				},
+				{
+						{ 0, 3, 6 },
+						{ 1, 4, 7 },
+						{ 2, 5, 8 }
+				},
+				{
+						{ 8, 7, 6 },
+						{ 5, 4, 3 },
+						{ 2, 1, 0 }
+				} };
 		for ( int i = 0; i < offsets.length; i++ )
 		{
 			final Img< DoubleType > img = new ArrayImgFactory<>( new DoubleType() ).create( 3, 3 );
@@ -137,18 +140,20 @@ public class ImgUtilTest
 		final int[][] strides = { { 1, 3 }, { 3, 1 }, { -1, -3 } };
 		final float[][][] expected = {
 				{
-				{ 0, 1, 2 },
-				{ 3, 4, 5 },
-				{ 6, 7, 8 }
-		}, {
-		{ 0, 3, 6 },
-		{ 1, 4, 7 },
-		{ 2, 5, 8 }
-		}, {
-		{ 8, 7, 6 },
-		{ 5, 4, 3 },
-		{ 2, 1, 0 }
-		} };
+						{ 0, 1, 2 },
+						{ 3, 4, 5 },
+						{ 6, 7, 8 }
+				},
+				{
+						{ 0, 3, 6 },
+						{ 1, 4, 7 },
+						{ 2, 5, 8 }
+				},
+				{
+						{ 8, 7, 6 },
+						{ 5, 4, 3 },
+						{ 2, 1, 0 }
+				} };
 		for ( int i = 0; i < offsets.length; i++ )
 		{
 			final Img< FloatType > img = new ArrayImgFactory<>( new FloatType() ).create( 3, 3 );
@@ -176,18 +181,20 @@ public class ImgUtilTest
 		final int[][] strides = { { 1, 3 }, { 3, 1 }, { -1, -3 } };
 		final long[][][] expected = {
 				{
-				{ 0, 1, 2 },
-				{ 3, 4, 5 },
-				{ 6, 7, 8 }
-		}, {
-		{ 0, 3, 6 },
-		{ 1, 4, 7 },
-		{ 2, 5, 8 }
-		}, {
-		{ 8, 7, 6 },
-		{ 5, 4, 3 },
-		{ 2, 1, 0 }
-		} };
+						{ 0, 1, 2 },
+						{ 3, 4, 5 },
+						{ 6, 7, 8 }
+				},
+				{
+						{ 0, 3, 6 },
+						{ 1, 4, 7 },
+						{ 2, 5, 8 }
+				},
+				{
+						{ 8, 7, 6 },
+						{ 5, 4, 3 },
+						{ 2, 1, 0 }
+				} };
 		for ( int i = 0; i < offsets.length; i++ )
 		{
 			final Img< LongType > img = new ArrayImgFactory<>( new LongType() ).create( 3, 3 );
@@ -215,18 +222,20 @@ public class ImgUtilTest
 		final int[][] strides = { { 1, 3 }, { 3, 1 }, { -1, -3 } };
 		final int[][][] expected = {
 				{
-				{ 0, 1, 2 },
-				{ 3, 4, 5 },
-				{ 6, 7, 8 }
-		}, {
-		{ 0, 3, 6 },
-		{ 1, 4, 7 },
-		{ 2, 5, 8 }
-		}, {
-		{ 8, 7, 6 },
-		{ 5, 4, 3 },
-		{ 2, 1, 0 }
-		} };
+						{ 0, 1, 2 },
+						{ 3, 4, 5 },
+						{ 6, 7, 8 }
+				},
+				{
+						{ 0, 3, 6 },
+						{ 1, 4, 7 },
+						{ 2, 5, 8 }
+				},
+				{
+						{ 8, 7, 6 },
+						{ 5, 4, 3 },
+						{ 2, 1, 0 }
+				} };
 		for ( int i = 0; i < offsets.length; i++ )
 		{
 			final Img< IntType > img = new ArrayImgFactory<>( new IntType() ).create( 3, 3 );
@@ -369,12 +378,12 @@ public class ImgUtilTest
 			assertArrayEquals( expected[ i ], output );
 		}
 	}
-	
+
 	@Test
 	public void testCopyRAItoRAI()
 	{
-		RandomAccessibleInterval<IntType> source = ArrayImgs.ints(new int[]{1, 2, 3, 4, 5, 6}, 2, 3);
-		RandomAccessibleInterval<IntType> destination = ArrayImgs.ints(2, 3);
+		RandomAccessibleInterval< IntType > source = ArrayImgs.ints( new int[] { 1, 2, 3, 4, 5, 6 }, 2, 3 );
+		RandomAccessibleInterval< IntType > destination = ArrayImgs.ints( 2, 3 );
 		ImgUtil.copy( source, destination );
 		ImgLib2Assert.assertImageEquals( source, destination );
 	}

--- a/src/test/java/net/imglib2/util/IntervalIndexerTest.java
+++ b/src/test/java/net/imglib2/util/IntervalIndexerTest.java
@@ -109,7 +109,8 @@ public class IntervalIndexerTest
 		{
 			cursor.fwd();
 			cursor.localize( pos );
-			Assert.assertEquals( IntervalIndexer.positionWithOffsetToIndex( pos, dim, min ), IntervalIndexer.positionToIndexForInterval( cursor, interval ) );
+			Assert.assertEquals( IntervalIndexer.positionWithOffsetToIndex( pos, dim, min ),
+					IntervalIndexer.positionToIndexForInterval( cursor, interval ) );
 		}
 	}
 

--- a/src/test/java/net/imglib2/util/IntervalsTest.java
+++ b/src/test/java/net/imglib2/util/IntervalsTest.java
@@ -223,12 +223,12 @@ public class IntervalsTest
 		final Interval bIa = Intervals.intersect( b, a );
 		final Interval aIc = Intervals.intersect( a, c );
 
-		assertTrue( "self-intersection", Intervals.equals( a, aIa ));
-		assertTrue( "intersection order", Intervals.equals( bIa, aIb ));
-		assertEquals( "non-intersecting", 0, Intervals.numElements( aIc ));
+		assertTrue( "self-intersection", Intervals.equals( a, aIa ) );
+		assertTrue( "intersection order", Intervals.equals( bIa, aIb ) );
+		assertEquals( "non-intersecting", 0, Intervals.numElements( aIc ) );
 
-		assertFalse( "intersecting not empty", Intervals.isEmpty( aIb ));
-		assertTrue( "non-intersecting is empty", Intervals.isEmpty( aIc ));
+		assertFalse( "intersecting not empty", Intervals.isEmpty( aIb ) );
+		assertTrue( "non-intersecting is empty", Intervals.isEmpty( aIc ) );
 	}
 
 	@Test
@@ -239,7 +239,7 @@ public class IntervalsTest
 		final FinalInterval aUbTrue = FinalInterval.createMinMax( 1, 2, 4, 5 );
 
 		final FinalInterval aUa = Intervals.union( a, a );
-		assertTrue( "self-union", Intervals.equals( a, aUa ));
+		assertTrue( "self-union", Intervals.equals( a, aUa ) );
 
 		final FinalInterval aUb = Intervals.union( a, b );
 		final FinalInterval bUa = Intervals.union( a, b );
@@ -263,18 +263,18 @@ public class IntervalsTest
 		final FinalRealInterval aUbTrue = FinalRealInterval.createMinMax( 1.1, 2.2, 4.4, 5.5 );
 
 		final FinalRealInterval aUa = Intervals.union( a, a );
-		assertTrue( "self-union", Intervals.equals( a, aUa ));
+		assertTrue( "self-union", Intervals.equals( a, aUa ) );
 
 		final FinalRealInterval aUb = Intervals.union( a, b );
 		final FinalRealInterval bUa = Intervals.union( a, b );
-		assertTrue( "union", Intervals.equals( aUbTrue, aUb, eps) );
-		assertTrue( "union commutes", Intervals.equals( aUbTrue, bUa, eps) );
+		assertTrue( "union", Intervals.equals( aUbTrue, aUb, eps ) );
+		assertTrue( "union commutes", Intervals.equals( aUbTrue, bUa, eps ) );
 
 		final FinalRealInterval empty = FinalRealInterval.createMinMax( 0, 0, -1, -1 );
 		final FinalRealInterval aUempty = Intervals.union( a, empty );
-		assertTrue( "union with empty", Intervals.equals( a, aUempty, eps ));
+		assertTrue( "union with empty", Intervals.equals( a, aUempty, eps ) );
 
 		final FinalRealInterval emptyUempty = Intervals.union( empty, empty );
-		assertTrue( "empty union empty", Intervals.equals( empty, emptyUempty, eps ));
+		assertTrue( "empty union empty", Intervals.equals( empty, emptyUempty, eps ) );
 	}
 }

--- a/src/test/java/net/imglib2/util/IterablePairTest.java
+++ b/src/test/java/net/imglib2/util/IterablePairTest.java
@@ -64,7 +64,7 @@ public class IterablePairTest
 	{
 		final List< Integer > iter1 = Arrays.asList( 3, 5, 6, 1, 2, 3 );
 		final List< String > iter2 = Arrays.asList( "dog", "cat", "mouse", "fox" );
-		final IterablePair< Integer, String > pair = new IterablePair< >( iter1, iter2 );
+		final IterablePair< Integer, String > pair = new IterablePair<>( iter1, iter2 );
 		final Iterator< Pair< Integer, String > > iterPair = pair.iterator();
 		assertNotNull( iterPair );
 		assertNextItems( iterPair, 3, "dog" );
@@ -89,7 +89,7 @@ public class IterablePairTest
 	@Test( expected = NullPointerException.class )
 	public void testNulls()
 	{
-		final IterablePair< Integer, Integer > pair = new IterablePair< >( null, null );
+		final IterablePair< Integer, Integer > pair = new IterablePair<>( null, null );
 		pair.iterator().next();
 	}
 
@@ -101,7 +101,7 @@ public class IterablePairTest
 	{
 		final List< Integer > iter1 = Collections.emptyList();
 		final List< Integer > iter2 = Collections.emptyList();
-		final IterablePair< Integer, Integer > pair = new IterablePair< >( iter1, iter2 );
+		final IterablePair< Integer, Integer > pair = new IterablePair<>( iter1, iter2 );
 		pair.iterator().next();
 	}
 
@@ -112,7 +112,7 @@ public class IterablePairTest
 	public void testSameIterable()
 	{
 		final List< Integer > iter = Arrays.asList( 3, 5, 6, 1, 2, 3 );
-		final IterablePair< Integer, Integer > pair = new IterablePair< >( iter, iter );
+		final IterablePair< Integer, Integer > pair = new IterablePair<>( iter, iter );
 		final Iterator< Pair< Integer, Integer > > iterPair = pair.iterator();
 		assertNotNull( iterPair );
 		int count = 0;

--- a/src/test/java/net/imglib2/util/LocalizablesTest.java
+++ b/src/test/java/net/imglib2/util/LocalizablesTest.java
@@ -46,14 +46,16 @@ import static org.junit.Assert.assertEquals;
 public class LocalizablesTest
 {
 	@Test
-	public void testAsLongArray() {
-		Localizable input = new Point( 5,7 );
+	public void testAsLongArray()
+	{
+		Localizable input = new Point( 5, 7 );
 		long[] result = input.positionAsLongArray();
 		assertArrayEquals( new long[] { 5, 7 }, result );
 	}
 
 	@Test
-	public void testRandomAccessible() {
+	public void testRandomAccessible()
+	{
 		long[] position = { 4, 2 };
 		int n = position.length;
 		RandomAccessible< Localizable > randomAccessible = Localizables.randomAccessible( n );

--- a/src/test/java/net/imglib2/util/StopWatchTest.java
+++ b/src/test/java/net/imglib2/util/StopWatchTest.java
@@ -56,7 +56,7 @@ public class StopWatchTest
 		StopWatch sw = StopWatch.createAndStart();
 		Thread.sleep( 42 );
 		long nanoTime = sw.nanoTime();
-		assertEquals( 42e6, nanoTime, 1e6);
+		assertEquals( 42e6, nanoTime, 1e6 );
 	}
 
 	@Ignore // NB: Time measurement depends on side effects. The test might sometimes fail. Better ignore it to avoid confusion.
@@ -70,7 +70,7 @@ public class StopWatchTest
 		sw.stop();
 		Thread.sleep( 10 );
 		long nanoTime = sw.nanoTime();
-		assertEquals( 10e6, nanoTime, 1e6);
+		assertEquals( 10e6, nanoTime, 1e6 );
 	}
 
 	@Ignore // NB: Time measurement depends on side effects. The test might sometimes fail. Better ignore it to avoid confusion.
@@ -80,16 +80,17 @@ public class StopWatchTest
 		StopWatch sw = StopWatch.createAndStart();
 		Thread.sleep( 42 );
 		double time = sw.seconds();
-		assertEquals( 0.042, time, 0.010);
+		assertEquals( 0.042, time, 0.010 );
 	}
 
 	// TODO: Fix or remove this test. It may fail depending on locale, e.g., secondsToString(42) will give "42,000 s" for de.
-	public void testSecondsToString() {
-		assertEquals("42.000 s", StopWatch.secondsToString(42));
-		assertEquals("42.000 ms", StopWatch.secondsToString(42e-3));
-		assertEquals("42.000 \u00b5s", StopWatch.secondsToString(42e-6));
-		assertEquals("42.000 ns", StopWatch.secondsToString(42e-9));
-		assertEquals("-42.000 ms", StopWatch.secondsToString(-42e-3));
-		assertEquals("42.000 s", StopWatch.secondsToString(42.00000000001));
+	public void testSecondsToString()
+	{
+		assertEquals( "42.000 s", StopWatch.secondsToString( 42 ) );
+		assertEquals( "42.000 ms", StopWatch.secondsToString( 42e-3 ) );
+		assertEquals( "42.000 \u00b5s", StopWatch.secondsToString( 42e-6 ) );
+		assertEquals( "42.000 ns", StopWatch.secondsToString( 42e-9 ) );
+		assertEquals( "-42.000 ms", StopWatch.secondsToString( -42e-3 ) );
+		assertEquals( "42.000 s", StopWatch.secondsToString( 42.00000000001 ) );
 	}
 }

--- a/src/test/java/net/imglib2/util/UtilTest.java
+++ b/src/test/java/net/imglib2/util/UtilTest.java
@@ -71,89 +71,91 @@ public class UtilTest
 	@Test
 	public void testPrintCoordinatesEmpty()
 	{
-	    final double[] doubleCoordinates = {};
-	    final int[] intCoordinates = {};
-	    final long[] longCoordinates = {};
-	    final float[] floatCoordinates = {};
-	    final boolean[] booleanCoordinates = {};
-	    final RealLocalizable rl = new RealPoint();
-	    String expected  = "(Array empty)";
-	    String rlExpected = "(RealLocalizable empty)";
+		final double[] doubleCoordinates = {};
+		final int[] intCoordinates = {};
+		final long[] longCoordinates = {};
+		final float[] floatCoordinates = {};
+		final boolean[] booleanCoordinates = {};
+		final RealLocalizable rl = new RealPoint();
+		String expected = "(Array empty)";
+		String rlExpected = "(RealLocalizable empty)";
 
-	    assertEquals(expected, Util.printCoordinates(doubleCoordinates));
-	    assertEquals(expected, Util.printCoordinates(intCoordinates));
-	    assertEquals(expected, Util.printCoordinates(longCoordinates));
-	    assertEquals(expected, Util.printCoordinates(floatCoordinates));
-	    assertEquals(expected, Util.printCoordinates(booleanCoordinates));
-	    assertEquals(rlExpected, Util.printCoordinates(rl));
+		assertEquals( expected, Util.printCoordinates( doubleCoordinates ) );
+		assertEquals( expected, Util.printCoordinates( intCoordinates ) );
+		assertEquals( expected, Util.printCoordinates( longCoordinates ) );
+		assertEquals( expected, Util.printCoordinates( floatCoordinates ) );
+		assertEquals( expected, Util.printCoordinates( booleanCoordinates ) );
+		assertEquals( rlExpected, Util.printCoordinates( rl ) );
 	}
 
 	@Test
 	public void testPrintCoordinatesNull()
 	{
-	    final double[] nullDouble = null;
-	    final int[] nullInt = null;
-	    final long[] nullLong = null;
-	    final float[] nullFloat = null;
-	    final boolean[] nullBoolean = null;
-	    final RealLocalizable nullRl = null;
-	    String expected  = "(Array empty)";
-	    String rlExpected = "(RealLocalizable empty)";
+		final double[] nullDouble = null;
+		final int[] nullInt = null;
+		final long[] nullLong = null;
+		final float[] nullFloat = null;
+		final boolean[] nullBoolean = null;
+		final RealLocalizable nullRl = null;
+		String expected = "(Array empty)";
+		String rlExpected = "(RealLocalizable empty)";
 
-	    assertEquals(expected, Util.printCoordinates(nullDouble));
-	    assertEquals(expected, Util.printCoordinates(nullInt));
-	    assertEquals(expected, Util.printCoordinates(nullLong));
-	    assertEquals(expected, Util.printCoordinates(nullFloat));
-	    assertEquals(expected, Util.printCoordinates(nullBoolean));
-	    assertEquals(rlExpected, Util.printCoordinates(nullRl));
+		assertEquals( expected, Util.printCoordinates( nullDouble ) );
+		assertEquals( expected, Util.printCoordinates( nullInt ) );
+		assertEquals( expected, Util.printCoordinates( nullLong ) );
+		assertEquals( expected, Util.printCoordinates( nullFloat ) );
+		assertEquals( expected, Util.printCoordinates( nullBoolean ) );
+		assertEquals( rlExpected, Util.printCoordinates( nullRl ) );
 
 	}
 
 	@Test
 	public void testPrintCoordinatesOneElem()
 	{
-	    final double[] oneElemDouble = {1};
-	    final int[] oneElemInt = {1};
-	    final long[] oneElemLong = {1};
-	    final boolean[] oneElemBoolean = {true};
-	    final RealLocalizable oneElemRl = new RealPoint(oneElemDouble);
-	    String expected  = "(1)";
-	    String expectedDouble  = "(1.0)";
+		final double[] oneElemDouble = { 1 };
+		final int[] oneElemInt = { 1 };
+		final long[] oneElemLong = { 1 };
+		final boolean[] oneElemBoolean = { true };
+		final RealLocalizable oneElemRl = new RealPoint( oneElemDouble );
+		String expected = "(1)";
+		String expectedDouble = "(1.0)";
 
-	    assertEquals(expectedDouble, Util.printCoordinates(oneElemDouble));
-	    assertEquals(expected, Util.printCoordinates(oneElemInt));
-	    assertEquals(expected, Util.printCoordinates(oneElemLong));
-	    assertEquals(expected, Util.printCoordinates(oneElemBoolean));
-	    assertEquals(expectedDouble, Util.printCoordinates(oneElemRl));
+		assertEquals( expectedDouble, Util.printCoordinates( oneElemDouble ) );
+		assertEquals( expected, Util.printCoordinates( oneElemInt ) );
+		assertEquals( expected, Util.printCoordinates( oneElemLong ) );
+		assertEquals( expected, Util.printCoordinates( oneElemBoolean ) );
+		assertEquals( expectedDouble, Util.printCoordinates( oneElemRl ) );
 
 	}
 
 	@Test
 	public void testPrintCoordinatesManyElems()
 	{
-	    final double[] doubleData = {1,5,7};
-	    final int[] intData = {1,5,7};
-	    final long[] longData = {1,5,7};
-	    final boolean[] booleanData = {true, false, true};
-	    final RealLocalizable rlData = new RealPoint(doubleData);
-	    String expected  = "(1, 5, 7)";
-	    String expectedDouble  = "(1.0, 5.0, 7.0)";
-	    String expectedBoolean  = "(1, 0, 1)";
+		final double[] doubleData = { 1, 5, 7 };
+		final int[] intData = { 1, 5, 7 };
+		final long[] longData = { 1, 5, 7 };
+		final boolean[] booleanData = { true, false, true };
+		final RealLocalizable rlData = new RealPoint( doubleData );
+		String expected = "(1, 5, 7)";
+		String expectedDouble = "(1.0, 5.0, 7.0)";
+		String expectedBoolean = "(1, 0, 1)";
 
-	    assertEquals(expectedDouble, Util.printCoordinates(doubleData));
-	    assertEquals(expected, Util.printCoordinates(intData));
-	    assertEquals(expected, Util.printCoordinates(longData));
-	    assertEquals(expectedBoolean, Util.printCoordinates(booleanData));
-	    assertEquals(expectedDouble, Util.printCoordinates(rlData));
+		assertEquals( expectedDouble, Util.printCoordinates( doubleData ) );
+		assertEquals( expected, Util.printCoordinates( intData ) );
+		assertEquals( expected, Util.printCoordinates( longData ) );
+		assertEquals( expectedBoolean, Util.printCoordinates( booleanData ) );
+		assertEquals( expectedDouble, Util.printCoordinates( rlData ) );
 
 	}
 
 	@Test
-	public void testGetSuitableImgFactory() {
+	public void testGetSuitableImgFactory()
+	{
 		final ImgFactory< BitType > smallBitFactory = Util.getSuitableImgFactory( new FinalInterval( 10, 10 ), new BitType() );
 		assertTrue( smallBitFactory instanceof ArrayImgFactory );
 
-		final ImgFactory< BitType > largeBitFactory = Util.getSuitableImgFactory( new FinalInterval( 1_000_000_000, 1_000_000_000 ), new BitType() );
+		final ImgFactory< BitType > largeBitFactory =
+				Util.getSuitableImgFactory( new FinalInterval( 1_000_000_000, 1_000_000_000 ), new BitType() );
 		assertTrue( largeBitFactory instanceof CellImgFactory );
 
 		final ImgFactory< BoolType > boolFactory = Util.getSuitableImgFactory( new FinalInterval( 10, 10 ), new BoolType() );
@@ -161,20 +163,22 @@ public class UtilTest
 	}
 
 	@Test
-	public void testImagesEqual() {
-		assertTrue( Util.imagesEqual( intsImage(1,2,3), intsImage(1,2,3) ) );
-		assertFalse( Util.imagesEqual( intsImage(1), intsImage(1,2,3) ) );
-		assertFalse( Util.imagesEqual( intsImage(1,2,3), intsImage(1,4,3) ) );
-		assertTrue( Util.imagesEqual( doublesImage(1,2,3), doublesImage(1,2,3) ) );
-		assertFalse( Util.imagesEqual( doublesImage(1,2,3), doublesImage(1,4,3) ) );
+	public void testImagesEqual()
+	{
+		assertTrue( Util.imagesEqual( intsImage( 1, 2, 3 ), intsImage( 1, 2, 3 ) ) );
+		assertFalse( Util.imagesEqual( intsImage( 1 ), intsImage( 1, 2, 3 ) ) );
+		assertFalse( Util.imagesEqual( intsImage( 1, 2, 3 ), intsImage( 1, 4, 3 ) ) );
+		assertTrue( Util.imagesEqual( doublesImage( 1, 2, 3 ), doublesImage( 1, 2, 3 ) ) );
+		assertFalse( Util.imagesEqual( doublesImage( 1, 2, 3 ), doublesImage( 1, 4, 3 ) ) );
 	}
 
 	@Test
-	public void testImagesEqualWithPredicate() {
-		BiPredicate< RealType<?>, RealType<?> > predicate = ( a, b ) -> a.getRealDouble() == b.getRealDouble();
-		assertTrue( Util.imagesEqual( intsImage(1,2,3), doublesImage(1,2,3), predicate ) );
-		assertFalse( Util.imagesEqual( intsImage(1), doublesImage(1,2,3), predicate ) );
-		assertFalse( Util.imagesEqual( intsImage(1,2,3), doublesImage(1,4,3), predicate ) );
+	public void testImagesEqualWithPredicate()
+	{
+		BiPredicate< RealType< ? >, RealType< ? > > predicate = ( a, b ) -> a.getRealDouble() == b.getRealDouble();
+		assertTrue( Util.imagesEqual( intsImage( 1, 2, 3 ), doublesImage( 1, 2, 3 ), predicate ) );
+		assertFalse( Util.imagesEqual( intsImage( 1 ), doublesImage( 1, 2, 3 ), predicate ) );
+		assertFalse( Util.imagesEqual( intsImage( 1, 2, 3 ), doublesImage( 1, 4, 3 ), predicate ) );
 	}
 
 	private Img< IntType > intsImage( int... pixels )
@@ -182,7 +186,7 @@ public class UtilTest
 		return ArrayImgs.ints( pixels, pixels.length );
 	}
 
-	private Img<DoubleType > doublesImage( double... pixels )
+	private Img< DoubleType > doublesImage( double... pixels )
 	{
 		return ArrayImgs.doubles( pixels, pixels.length );
 	}
@@ -259,7 +263,8 @@ public class UtilTest
 	}
 
 	@Test
-	public void testGetArrayOrCellImgFactoryWithEntitiesPerPixelLessThanOne() {
+	public void testGetArrayOrCellImgFactoryWithEntitiesPerPixelLessThanOne()
+	{
 		// NB: An ArrayImg internally uses a LongAccess to store the image content.
 		// The JVM allows to create a LongAccess of a required size. But an ArrayImg
 		// must not be used with a size greater than Integer.MAX_VALUE, as some

--- a/src/test/java/net/imglib2/view/BundleViewTest.java
+++ b/src/test/java/net/imglib2/view/BundleViewTest.java
@@ -58,11 +58,11 @@ public class BundleViewTest
 		final Random rnd = new Random();
 		final long[] dimensions = new long[] { 10, 6, 5 };
 		final int[] data = new int[ 10 * 6 * 5 ];
-		Arrays.setAll( data, i -> rnd.nextInt());
-		img = ArrayImgs.ints(data, dimensions);
+		Arrays.setAll( data, i -> rnd.nextInt() );
+		img = ArrayImgs.ints( data, dimensions );
 
 		positions = new long[ 100 ][];
-		Arrays.setAll( positions, i -> new long[]{ rnd.nextInt( 11 ), rnd.nextInt( 7 ), rnd.nextInt( 6 ) } );
+		Arrays.setAll( positions, i -> new long[] { rnd.nextInt( 11 ), rnd.nextInt( 7 ), rnd.nextInt( 6 ) } );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/view/ConcatenateViewTest.java
+++ b/src/test/java/net/imglib2/view/ConcatenateViewTest.java
@@ -63,11 +63,12 @@ public class ConcatenateViewTest
 {
 
 	@Test
-	public void testConcatenateSimple() {
+	public void testConcatenateSimple()
+	{
 		// setup
-		Img<ByteType> a = ArrayImgs.bytes( new byte[]{ 1, 2, 3, 4 }, 2, 2 );
-		Img<ByteType> b = ArrayImgs.bytes( new byte[]{ 7, 8 }, 1, 2 );
-		Img<ByteType> expected = ArrayImgs.bytes( new byte[]{ 1, 2, 7, 3, 4, 8 }, 3, 2 );
+		Img< ByteType > a = ArrayImgs.bytes( new byte[] { 1, 2, 3, 4 }, 2, 2 );
+		Img< ByteType > b = ArrayImgs.bytes( new byte[] { 7, 8 }, 1, 2 );
+		Img< ByteType > expected = ArrayImgs.bytes( new byte[] { 1, 2, 7, 3, 4, 8 }, 3, 2 );
 		// process
 		RandomAccessibleInterval< ByteType > result = Views.concatenate( 0, a, b );
 		// test

--- a/src/test/java/net/imglib2/view/HyperSlicesViewTest.java
+++ b/src/test/java/net/imglib2/view/HyperSlicesViewTest.java
@@ -45,9 +45,10 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.LongType;
 
-public class HyperSlicesViewTest {
+public class HyperSlicesViewTest
+{
 
-	final static long[] sizes = new long[]{ 2, 3, 4, 5, 6 };
+	final static long[] sizes = new long[] { 2, 3, 4, 5, 6 };
 
 	final static private long[] hyperSlice2Array(
 			final RandomAccess< HyperSlice< LongType > > hyperSlicesAccess,
@@ -66,7 +67,7 @@ public class HyperSlicesViewTest {
 		for ( final long s : max )
 			n *= s + 1;
 
-		final long[] list = new long[ ( int )n ];
+		final long[] list = new long[ ( int ) n ];
 
 		int i = 0;
 		for ( final LongType t : Views.iterable( hyperSlice ) )
@@ -92,7 +93,7 @@ public class HyperSlicesViewTest {
 		for ( final long s : max )
 			n *= s + 1;
 
-		final long[] list = new long[ ( int )n ];
+		final long[] list = new long[ ( int ) n ];
 
 		int i = 0;
 		for ( final LongType t : Views.iterable( hyperSlice ) )
@@ -106,8 +107,8 @@ public class HyperSlicesViewTest {
 	{
 		final long n = LongStream.of( sizes ).reduce( 1, ( x, y ) -> x * y );
 
-		final long[] data = new long[ ( int )n ];
-		for ( int d = 0; d < n ; ++d )
+		final long[] data = new long[ ( int ) n ];
+		for ( int d = 0; d < n; ++d )
 			data[ d ] = d;
 
 		final RandomAccessibleInterval< LongType > source = ArrayImgs.longs( data, sizes );
@@ -118,16 +119,16 @@ public class HyperSlicesViewTest {
 		final HyperSlicesView< LongType > hyperSlices = new HyperSlicesView< LongType >( source, 2, 3 );
 		final RandomAccess< HyperSlice< LongType > > hyperSlicesAccess = hyperSlices.randomAccess();
 
-		final long[][] expecteds = new long[][]{
-			{0, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114},
-			{1, 7, 13, 19, 25, 31, 37, 43, 49, 55, 61, 67, 73, 79, 85, 91, 97, 103, 109, 115},
-			{2, 8, 14, 20, 26, 32, 38, 44, 50, 56, 62, 68, 74, 80, 86, 92, 98, 104, 110, 116},
-			{3, 9, 15, 21, 27, 33, 39, 45, 51, 57, 63, 69, 75, 81, 87, 93, 99, 105, 111, 117}
+		final long[][] expecteds = new long[][] {
+				{ 0, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114 },
+				{ 1, 7, 13, 19, 25, 31, 37, 43, 49, 55, 61, 67, 73, 79, 85, 91, 97, 103, 109, 115 },
+				{ 2, 8, 14, 20, 26, 32, 38, 44, 50, 56, 62, 68, 74, 80, 86, 92, 98, 104, 110, 116 },
+				{ 3, 9, 15, 21, 27, 33, 39, 45, 51, 57, 63, 69, 75, 81, 87, 93, 99, 105, 111, 117 }
 		};
 
 		for ( int d = 0; hyperSlicesAccess.getLongPosition( 0 ) < sizes[ 2 ]; hyperSlicesAccess.fwd( 0 ), ++d )
 		{
-			Assert.assertArrayEquals( expecteds[ d ], hyperSlice2Array(hyperSlicesAccess, 2, 3 ) );
+			Assert.assertArrayEquals( expecteds[ d ], hyperSlice2Array( hyperSlicesAccess, 2, 3 ) );
 		}
 	}
 

--- a/src/test/java/net/imglib2/view/RandomAccessTest.java
+++ b/src/test/java/net/imglib2/view/RandomAccessTest.java
@@ -79,7 +79,8 @@ public class RandomAccessTest
 	{
 		final long[] offset = new long[] { 1, 10, 0, -5 };
 		final long[] dim = new long[] { 10, 10, 10, 10 };
-		final RandomAccess< UnsignedByteType > a = Views.offsetInterval( Views.invertAxis( Views.hyperSlice( img, 2, 2 ), 3 ), offset, dim ).randomAccess();
+		final RandomAccess< UnsignedByteType > a =
+				Views.offsetInterval( Views.invertAxis( Views.hyperSlice( img, 2, 2 ), 3 ), offset, dim ).randomAccess();
 
 		assertTrue( FullSourceMapMixedRandomAccess.class.isInstance( a ) );
 

--- a/src/test/java/net/imglib2/view/StackRandomAccessibleIntervalsTest.java
+++ b/src/test/java/net/imglib2/view/StackRandomAccessibleIntervalsTest.java
@@ -81,11 +81,14 @@ public class StackRandomAccessibleIntervalsTest
 	{
 		// lets create a stack with every second plane of the input image,
 		// works!
-		final List< RandomAccessibleInterval< UnsignedByteType >> intervals = new ArrayList< RandomAccessibleInterval< UnsignedByteType > >();
+		final List< RandomAccessibleInterval< UnsignedByteType > > intervals =
+				new ArrayList< RandomAccessibleInterval< UnsignedByteType > >();
 		for ( int d = 0; d < img.dimension( 2 ); d++ )
 		{
 			if ( d % 2 == 0 )
-				intervals.add( Views.dropSingletonDimensions( Views.interval( img, new FinalInterval( new long[] { img.min( 0 ), img.min( 1 ), d }, new long[] { img.max( 0 ), img.max( 1 ), d } ) ) ) );
+				intervals.add(
+						Views.dropSingletonDimensions( Views.interval( img, new FinalInterval( new long[] { img.min( 0 ), img.min( 1 ), d },
+								new long[] { img.max( 0 ), img.max( 1 ), d } ) ) ) );
 		}
 
 		// stack it!

--- a/src/test/java/net/imglib2/view/ViewsTest.java
+++ b/src/test/java/net/imglib2/view/ViewsTest.java
@@ -56,39 +56,44 @@ import static org.junit.Assert.assertTrue;
 public class ViewsTest
 {
 	@Test
-	public void testMoveAxisUp() {
+	public void testMoveAxisUp()
+	{
 		RandomAccessible< Localizable > input = Localizables.randomAccessible( 4 );
 		RandomAccessible< Localizable > view = Views.moveAxis( input, 1, 3 );
 		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {1, 3, 4, 2} );
-		assertArrayEquals( new long[] {1, 2, 3, 4}, ra.get().positionAsLongArray() );
+		ra.setPosition( new long[] { 1, 3, 4, 2 } );
+		assertArrayEquals( new long[] { 1, 2, 3, 4 }, ra.get().positionAsLongArray() );
 	}
 
 	@Test
-	public void testMoveAxisDown() {
+	public void testMoveAxisDown()
+	{
 		RandomAccessible< Localizable > input = Localizables.randomAccessible( 4 );
 		RandomAccessible< Localizable > view = Views.moveAxis( input, 3, 1 );
 		RandomAccess< Localizable > ra = view.randomAccess();
-		ra.setPosition( new long[] {1, 4, 2, 3} );
-		assertArrayEquals( new long[] {1, 2, 3, 4}, ra.get().positionAsLongArray() );
+		ra.setPosition( new long[] { 1, 4, 2, 3 } );
+		assertArrayEquals( new long[] { 1, 2, 3, 4 }, ra.get().positionAsLongArray() );
 	}
 
 	@Test
-	public void testMoveAxisUpForInteval() {
-		Img<?> img = ArrayImgs.bytes( 1, 2, 3, 4 );
+	public void testMoveAxisUpForInteval()
+	{
+		Img< ? > img = ArrayImgs.bytes( 1, 2, 3, 4 );
 		RandomAccessibleInterval< ? > view = Views.moveAxis( img, 1, 3 );
-		assertArrayEquals( new long[]{ 1, 3, 4, 2 }, Intervals.dimensionsAsLongArray( view ) );
+		assertArrayEquals( new long[] { 1, 3, 4, 2 }, Intervals.dimensionsAsLongArray( view ) );
 	}
 
 	@Test
-	public void testMoveAxisDownForInteval() {
-		Img<?> img = ArrayImgs.bytes( 1, 2, 3, 4 );
+	public void testMoveAxisDownForInteval()
+	{
+		Img< ? > img = ArrayImgs.bytes( 1, 2, 3, 4 );
 		RandomAccessibleInterval< ? > view = Views.moveAxis( img, 3, 1 );
-		assertArrayEquals( new long[]{ 1, 4, 2, 3 }, Intervals.dimensionsAsLongArray( view ) );
+		assertArrayEquals( new long[] { 1, 4, 2, 3 }, Intervals.dimensionsAsLongArray( view ) );
 	}
 
 	@Test
-	public void testExtendValue() {
+	public void testExtendValue()
+	{
 		final long[] dims = { 2, 3, 4 };
 		final long[] border = { 1, 1, 1 };
 
@@ -106,7 +111,8 @@ public class ViewsTest
 			final long[] dims,
 			final double insideValue,
 			final double doubleExtension,
-			final float floatExtension ) {
+			final float floatExtension )
+	{
 		final RandomAccessibleInterval< DoubleType > rai = ArrayImgs.doubles( dims );
 		Views.iterable( rai ).forEach( px -> px.setReal( insideValue ) );
 		testValueExtended(
@@ -128,7 +134,8 @@ public class ViewsTest
 			final double insideValue,
 			final double doubleExtension,
 			final float floatExtension,
-			final long... border) {
+			final long... border )
+	{
 		final RandomAccessibleInterval< DoubleType > rai = ArrayImgs.doubles( dims );
 		Views.iterable( rai ).forEach( px -> px.setReal( insideValue ) );
 		testValueExtended(
@@ -149,7 +156,8 @@ public class ViewsTest
 			final long[] dims,
 			final long insideValue,
 			final long longExtension,
-			final int intExtension ) {
+			final int intExtension )
+	{
 		final RandomAccessibleInterval< LongType > rai = ArrayImgs.longs( dims );
 		Views.iterable( rai ).forEach( px -> px.setInteger( insideValue ) );
 		testValueExtended(
@@ -171,7 +179,8 @@ public class ViewsTest
 			final long insideValue,
 			final long longExtension,
 			final int intExtension,
-			final long... border) {
+			final long... border )
+	{
 		final RandomAccessibleInterval< LongType > rai = ArrayImgs.longs( dims );
 		Views.iterable( rai ).forEach( px -> px.setInteger( insideValue ) );
 		testValueExtended(
@@ -191,7 +200,8 @@ public class ViewsTest
 	private static void testExtendBoolean(
 			final long[] dims,
 			final boolean insideValue,
-			final boolean extension ) {
+			final boolean extension )
+	{
 		final RandomAccessibleInterval< BitType > rai = ArrayImgs.bits( dims );
 		Views.iterable( rai ).forEach( px -> px.set( insideValue ) );
 		testValueExtended(
@@ -206,8 +216,9 @@ public class ViewsTest
 			final long[] dims,
 			final boolean insideValue,
 			final boolean extension,
-			final long... border) {
-		final RandomAccessibleInterval<BitType> rai = ArrayImgs.bits( dims );
+			final long... border )
+	{
+		final RandomAccessibleInterval< BitType > rai = ArrayImgs.bits( dims );
 		Views.iterable( rai ).forEach( px -> px.set( insideValue ) );
 		testValueExtended(
 				Views.expandValue( rai, extension, border ),
@@ -218,13 +229,15 @@ public class ViewsTest
 	}
 
 	private static < T extends Type< T > > void testValueExtended(
-			final RandomAccessible<T> accessible,
+			final RandomAccessible< T > accessible,
 			final Interval inside,
 			final Interval total,
 			final T insideValue,
-			final T outsideValue ) {
+			final T outsideValue )
+	{
 		final Cursor< T > cursor = Views.interval( accessible, total ).cursor();
-		while ( cursor.hasNext() ) {
+		while ( cursor.hasNext() )
+		{
 			final T value = cursor.next();
 			assertTrue( value.valueEquals( Intervals.contains( inside, cursor ) ? insideValue : outsideValue ) );
 		}

--- a/src/test/java/net/imglib2/view/ViewsTranslateBenchmark.java
+++ b/src/test/java/net/imglib2/view/ViewsTranslateBenchmark.java
@@ -74,13 +74,13 @@ import java.util.concurrent.TimeUnit;
 public class ViewsTranslateBenchmark
 {
 
-	private final RandomAccessibleInterval<IntType> arrayImg = createImg( new ArrayImgFactory<>( new IntType() ) );
+	private final RandomAccessibleInterval< IntType > arrayImg = createImg( new ArrayImgFactory<>( new IntType() ) );
 
-	private final RandomAccessibleInterval<IntType> planarImg = createImg( new PlanarImgFactory<>( new IntType() ) );
+	private final RandomAccessibleInterval< IntType > planarImg = createImg( new PlanarImgFactory<>( new IntType() ) );
 
-	private final RandomAccessibleInterval<IntType> cellImg = createImg( new CellImgFactory<>( new IntType(), 100, 100 ) );
+	private final RandomAccessibleInterval< IntType > cellImg = createImg( new CellImgFactory<>( new IntType(), 100, 100 ) );
 
-	private RandomAccessibleInterval<IntType> createImg( final ImgFactory<IntType> factory )
+	private RandomAccessibleInterval< IntType > createImg( final ImgFactory< IntType > factory )
 	{
 		return Views.translate( factory.create( 1000, 1000 ), 40, 40 );
 	}
@@ -118,10 +118,10 @@ public class ViewsTranslateBenchmark
 		return sum[ 0 ];
 	}
 
-	public static double sum( final RandomAccessibleInterval<? extends RealType<?>> img )
+	public static double sum( final RandomAccessibleInterval< ? extends RealType< ? > > img )
 	{
 		double sum = 0;
-		final RandomAccess<? extends RealType<?>> ra = img.randomAccess();
+		final RandomAccess< ? extends RealType< ? > > ra = img.randomAccess();
 		ra.setPosition( img.min( 1 ), 1 );
 		for ( int y = 0; y < img.dimension( 1 ); y++ )
 		{
@@ -136,10 +136,10 @@ public class ViewsTranslateBenchmark
 		return sum;
 	}
 
-	public static double sum2( final RandomAccessibleInterval<? extends RealType<?>> img )
+	public static double sum2( final RandomAccessibleInterval< ? extends RealType< ? > > img )
 	{
 		double sum = 0;
-		final RandomAccess<? extends RealType<?>> ra = img.randomAccess();
+		final RandomAccess< ? extends RealType< ? > > ra = img.randomAccess();
 		ra.setPosition( img.min( 1 ), 1 );
 		for ( int y = 0; y < img.dimension( 1 ); y++ )
 		{

--- a/src/test/java/tests/JUnitTestBase.java
+++ b/src/test/java/tests/JUnitTestBase.java
@@ -76,7 +76,7 @@ public class JUnitTestBase
 	/**
 	 * Check whether an image is identical to a generated image
 	 */
-	protected < T extends RealType< T >> boolean match( final Img< T > image, final Function function )
+	protected < T extends RealType< T > > boolean match( final Img< T > image, final Function function )
 	{
 		final Cursor< T > cursor = image.localizingCursor();
 		final long[] pos = new long[ cursor.numDimensions() ];
@@ -93,7 +93,7 @@ public class JUnitTestBase
 	/**
 	 * Check whether an image is identical to a generated image, with fuzz
 	 */
-	protected < T extends RealType< T >> boolean match( final Img< T > image, final Function function, final float tolerance )
+	protected < T extends RealType< T > > boolean match( final Img< T > image, final Function function, final float tolerance )
 	{
 		final Cursor< T > cursor = image.localizingCursor();
 		final long[] pos = new long[ cursor.numDimensions() ];
@@ -113,7 +113,7 @@ public class JUnitTestBase
 	 * The image signature are 1st and 2nd order moments of the intensity and
 	 * the coordinates.
 	 */
-	protected < T extends RealType< T >> float[] signature( final Img< T > image )
+	protected < T extends RealType< T > > float[] signature( final Img< T > image )
 	{
 		final float[] result = new float[ ( image.numDimensions() + 1 ) * 2 ];
 		signature( image, result );
@@ -126,7 +126,7 @@ public class JUnitTestBase
 	 * The image signature are 1st and 2nd order moments of the intensity and
 	 * the coordinates.
 	 */
-	protected < T extends RealType< T >> void signature( final Img< T > image, final float[] result )
+	protected < T extends RealType< T > > void signature( final Img< T > image, final float[] result )
 	{
 		Arrays.fill( result, 0 );
 		final Cursor< T > cursor = image.localizingCursor();
@@ -167,7 +167,7 @@ public class JUnitTestBase
 	 * When it is hard/computationally expensive to calculate the values of the
 	 * expected image, we need a quick test like this one.
 	 */
-	protected < T extends RealType< T >> boolean matchSignature( final Img< T > image, final float[] signature )
+	protected < T extends RealType< T > > boolean matchSignature( final Img< T > image, final float[] signature )
 	{
 		final float[] result = signature( image );
 		return Arrays.equals( result, signature );
@@ -179,7 +179,7 @@ public class JUnitTestBase
 	 * When it is hard/computationally expensive to calculate the values of the
 	 * expected image, we need a quick test like this one.
 	 */
-	protected < T extends RealType< T >> boolean matchSignature( final Img< T > image, final float[] signature, final float tolerance )
+	protected < T extends RealType< T > > boolean matchSignature( final Img< T > image, final float[] signature, final float tolerance )
 	{
 		final float[] result = signature( image );
 		for ( int i = 0; i < signature.length; i++ )
@@ -191,7 +191,7 @@ public class JUnitTestBase
 	/**
 	 * Convenience helper to access single pixels
 	 */
-	protected < T extends RealType< T >> float get( final Img< T > image, final int[] pos )
+	protected < T extends RealType< T > > float get( final Img< T > image, final int[] pos )
 	{
 		final RandomAccess< T > cursor = image.randomAccess();
 		cursor.setPosition( pos );
@@ -202,7 +202,7 @@ public class JUnitTestBase
 	/**
 	 * Convenience helper to access single pixels
 	 */
-	protected < T extends RealType< T >> float get3D( final Img< T > image, final int x, final int y, final int z )
+	protected < T extends RealType< T > > float get3D( final Img< T > image, final int x, final int y, final int z )
 	{
 		return get( image, new int[] { x, y, z } );
 	}
@@ -210,7 +210,7 @@ public class JUnitTestBase
 	/**
 	 * Generate an image
 	 */
-	protected < T extends RealType< T > & NativeType< T >> Img< T > makeImage( final T type, final Function function, final long[] dims )
+	protected < T extends RealType< T > & NativeType< T > > Img< T > makeImage( final T type, final Function function, final long[] dims )
 	{
 		final ImgFactory< T > factory = new ArrayImgFactory<>( type );
 		final Img< T > result = factory.create( dims );


### PR DESCRIPTION
There are some problems with the imglib2 coding style.
1. It generates very long lines, because many intentionally set line breaks are removed.
2. Comments at the end of a line are wrapped in a ugly manner.
...
See https://github.com/scijava/scijava-coding-style/pull/7 for detials.

We (@stefanhahmann and I) tried to solve these problems to get an "imglib2" like coding style, that could be used in practice without causing to much trouble. The main change is that the "modified imglib2 coding style" is more relaxed in terms of line breaks. It allows developers to more freely decide when there should be a new line.

**This PR shows the changes the "modified imglib2 coding style" would do on the imglib2 source code.**
It is not meant to be merged. It's for you @tpietzsch @StephanPreibisch @axtimwalde to get an opinion. If the "modified imglib2 coding style" is ok for you or do we need to keep the original coding style.

NB: The "modified imglib2 coding style", does less changes to the source code. Applying the old imglib2 coding style the the imglib2 source code changes 362 files. The "modified imglib2 coding style" changes 289 files.

Please comment here: https://github.com/scijava/scijava-coding-style/pull/7 

For comparison: [Here are the changes](https://github.com/imglib/imglib2/commit/85d7d64c8d57d9724714431e72c0d4d8146982db) that the original imglib2 coding style would apply on the imglib2 source code.