### PR TITLE
Postpone Cell linking to CellRandomAccess.get()

### DIFF
--- a/src/main/java/net/imglib2/img/cell/Cell.java
+++ b/src/main/java/net/imglib2/img/cell/Cell.java
@@ -81,7 +81,7 @@ public class Cell< A > implements Interval, Serializable
 	}
 
 	/**
-	 * Get the basic type array that stores this cells pixels.
+	 * Get the basic type array that stores this cell's pixels.
 	 *
 	 * @return underlying basic type array.
 	 */

--- a/src/main/java/net/imglib2/img/cell/CellGrid.java
+++ b/src/main/java/net/imglib2/img/cell/CellGrid.java
@@ -34,13 +34,13 @@
 package net.imglib2.img.cell;
 
 import java.util.Arrays;
-import java.util.Iterator;
 
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
+import net.imglib2.Localizable;
 import net.imglib2.Point;
 import net.imglib2.Positionable;
 import net.imglib2.RandomAccess;
@@ -335,6 +335,36 @@ public class CellGrid
 	{
 		for ( int d = 0; d < n; ++d )
 			cellPos.setPosition( position[ d ] / cellDimensions[ d ], d );
+	}
+
+	/**
+	 * Compute all cell-related coordinates/sizes required by CellRandomAccess.
+	 *
+	 * @param position
+	 * 			  current image position
+	 * @param cellSteps
+	 * 			  allocation steps for cell are written here.
+	 * @param cellMin
+	 *            offset of the cell in image coordinates are written here.
+	 * @param cellMax is set to the
+	 *            max of the cell in image coordinates are written here.
+	 * @return index within the cell.
+	 */
+	int getCellCoordinates( final long[] position, final int[] cellSteps, final long[] cellMin, final long[] cellMax )
+	{
+		int steps = 1;
+		int i = 0;
+		for ( int d = 0; d < n; ++d )
+		{
+			final long gridPos = position[ d ] / cellDimensions[ d ];
+			final int cellDim = ( gridPos + 1 == numCells[ d ] ) ? borderSize[ d ] : cellDimensions[ d ];
+			cellMin[ d ] = gridPos * cellDimensions[ d ];
+			cellMax[ d ] = cellMin[ d ] + cellDim - 1;
+			cellSteps[ d ] = steps;
+			i += steps * ( position[ d ] - cellMin[ d ] );
+			steps *= cellDim;
+		}
+		return i;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/CellRandomAccess.java
+++ b/src/main/java/net/imglib2/img/cell/CellRandomAccess.java
@@ -73,14 +73,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 
 	protected boolean isOutOfBounds;
 
-	private boolean typeNeedsUpdate = true;
-
-
-	/**
-	 * The current index of the type. It is faster to duplicate this here than
-	 * to access it through type.getIndex().
-	 */
-	protected int index;
+	private boolean typeNeedsUpdate;
 
 	protected CellRandomAccess( final CellRandomAccess< T, C > randomAccess )
 	{
@@ -101,10 +94,8 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 
 		isOutOfBounds = randomAccess.isOutOfBounds;
 
-		index = randomAccess.index;
-		if ( !isOutOfBounds )
-			type.updateContainer( this );
-		typeIndex.set( index );
+		typeIndex.set( randomAccess.typeIndex.get() );
+		typeNeedsUpdate = true;
 	}
 
 	public CellRandomAccess( final AbstractCellImg< T, ?, C, ? > img )
@@ -157,51 +148,47 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 	@Override
 	public void fwd( final int d )
 	{
-		index += currentCellSteps[ d ];
+		typeIndex.inc( currentCellSteps[ d ] );
 		if ( ++position[ d ] > currentCellMax[ d ] )
 		{
 			randomAccessOnCells.fwd( d );
 			updatePosition( position[ d ] >= dimensions[ d ] );
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
 	public void bck( final int d )
 	{
-		index -= currentCellSteps[ d ];
+		typeIndex.dec( currentCellSteps[ d ] );
 		if ( --position[ d ] < currentCellMin[ d ] )
 		{
 			randomAccessOnCells.bck( d );
 			updatePosition( position[ d ] < 0 );
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
 	public void move( final int distance, final int d )
 	{
-		index += distance * currentCellSteps[ d ];
+		typeIndex.inc( distance * currentCellSteps[ d ] );
 		position[ d ] += distance;
 		if ( position[ d ] < currentCellMin[ d ] || position[ d ] > currentCellMax[ d ] )
 		{
 			randomAccessOnCells.setPosition( position[ d ] / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
 	public void move( final long distance, final int d )
 	{
-		index += ( int ) distance * currentCellSteps[ d ];
+		typeIndex.inc( ( int ) distance * currentCellSteps[ d ] );
 		position[ d ] += distance;
 		if ( position[ d ] < currentCellMin[ d ] || position[ d ] > currentCellMax[ d ] )
 		{
 			randomAccessOnCells.setPosition( position[ d ] / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
@@ -212,7 +199,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			final long pos = localizable.getLongPosition( d );
 			if ( pos != 0 )
 			{
-				index += ( int ) pos * currentCellSteps[ d ];
+				typeIndex.inc( ( int ) pos * currentCellSteps[ d ] );
 				position[ d ] += pos;
 				if ( position[ d ] < currentCellMin[ d ] || position[ d ] > currentCellMax[ d ] )
 				{
@@ -237,7 +224,6 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
@@ -247,7 +233,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		{
 			if ( distance[ d ] != 0 )
 			{
-				index += distance[ d ] * currentCellSteps[ d ];
+				typeIndex.inc( distance[ d ] * currentCellSteps[ d ] );
 				position[ d ] += distance[ d ];
 				if ( position[ d ] < currentCellMin[ d ] || position[ d ] > currentCellMax[ d ] )
 				{
@@ -271,7 +257,6 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
@@ -281,7 +266,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		{
 			if ( distance[ d ] != 0 )
 			{
-				index += ( int ) distance[ d ] * currentCellSteps[ d ];
+				typeIndex.inc( ( int ) distance[ d ] * currentCellSteps[ d ] );
 				position[ d ] += distance[ d ];
 				if ( position[ d ] < currentCellMin[ d ] || position[ d ] > currentCellMax[ d ] )
 				{
@@ -305,33 +290,30 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
 	public void setPosition( final int pos, final int d )
 	{
-		index += ( int ) ( pos - position[ d ] ) * currentCellSteps[ d ];
+		typeIndex.inc( ( int ) ( pos - position[ d ] ) * currentCellSteps[ d ] );
 		position[ d ] = pos;
 		if ( pos < currentCellMin[ d ] || pos > currentCellMax[ d ] )
 		{
 			randomAccessOnCells.setPosition( pos / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
 	public void setPosition( final long pos, final int d )
 	{
-		index += ( int ) ( pos - position[ d ] ) * currentCellSteps[ d ];
+		typeIndex.inc( ( int ) ( pos - position[ d ] ) * currentCellSteps[ d ] );
 		position[ d ] = pos;
 		if ( position[ d ] < currentCellMin[ d ] || position[ d ] > currentCellMax[ d ] )
 		{
 			randomAccessOnCells.setPosition( pos / cellDims[ d ], d );
 			updatePosition( position[ d ] < 0 || position[ d ] >= dimensions[ d ] );
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
@@ -342,7 +324,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 			final long pos = localizable.getLongPosition( d );
 			if ( pos != position[ d ] )
 			{
-				index += ( int ) ( pos - position[ d ] ) * currentCellSteps[ d ];
+				typeIndex.inc( ( int ) ( pos - position[ d ] ) * currentCellSteps[ d ] );
 				position[ d ] = pos;
 				if ( position[ d ] < currentCellMin[ d ] || position[ d ] > currentCellMax[ d ] )
 				{
@@ -367,7 +349,6 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		typeIndex.set( index );
 	}
 
 	@Override
@@ -377,7 +358,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		{
 			if ( pos[ d ] != position[ d ] )
 			{
-				index += ( int ) ( pos[ d ] - position[ d ] ) * currentCellSteps[ d ];
+				typeIndex.inc( ( int ) ( pos[ d ] - position[ d ] ) * currentCellSteps[ d ] );
 				if ( pos[ d ] < currentCellMin[ d ] || pos[ d ] > currentCellMax[ d ] )
 				{
 					setPos2( pos, d );
@@ -386,7 +367,6 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				position[ d ] = pos[ d ];
 			}
 		}
-		typeIndex.set( index );
 	}
 
 	private void setPos2( final int[] pos, final int d0 )
@@ -414,7 +394,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		{
 			if ( pos[ d ] != position[ d ] )
 			{
-				index += ( int ) ( pos[ d ] - position[ d ] ) * currentCellSteps[ d ];
+				typeIndex.inc( ( int ) ( pos[ d ] - position[ d ] ) * currentCellSteps[ d ] );
 				position[ d ] = pos[ d ];
 				if ( position[ d ] < currentCellMin[ d ] || position[ d ] > currentCellMax[ d ] )
 				{
@@ -438,7 +418,6 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				}
 			}
 		}
-		typeIndex.set( index );
 	}
 
 	/**
@@ -470,7 +449,7 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 				isOutOfBounds = false;
 				grid.getCellPosition( position, randomAccessOnCells );
 			}
-			index = grid.getCellCoordinates( position, currentCellSteps, currentCellMin, currentCellMax );
+			typeIndex.set( grid.getCellCoordinates( position, currentCellSteps, currentCellMin, currentCellMax ) );
 			typeNeedsUpdate = true;
 		}
 	}

--- a/src/main/java/net/imglib2/img/cell/LazyCellImg.java
+++ b/src/main/java/net/imglib2/img/cell/LazyCellImg.java
@@ -45,7 +45,7 @@ import net.imglib2.util.Fraction;
 /**
  * A {@link AbstractCellImg} that obtains its Cells lazily when they are
  * accessed. Cells are obtained by a {@link Get} method that is provided by the
- * user. Typically this is some kind of cache.
+ * user. Typically, this is some kind of cache.
  *
  * @param <T>
  *            the pixel type


### PR DESCRIPTION
Previously the `CellRandomAccess` would link `Cell` data to it's `Type` proxy as soon as it enters a new `Cell`.
Specifically, for `LazyCellImg`s this would trigger loading of the `Cell` (potentially unnecessary).
This PR changes this mechanics to link only when the first `get()` in a new `Cell` happens.

This addresses https://github.com/imglib/imglib2/issues/252.