### PR TITLE
PrimitiveBlocks copies RandomAccessible blocks to primitive arrays

### DIFF
--- a/src/main/java/net/imglib2/blocks/ArrayImgRangeCopier.java
+++ b/src/main/java/net/imglib2/blocks/ArrayImgRangeCopier.java
@@ -1,0 +1,235 @@
+package net.imglib2.blocks;
+
+import java.util.List;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+
+import static net.imglib2.blocks.Ranges.Direction.CONSTANT;
+
+/**
+ * Does the actual copying work from an {@code ArrayImg} into a primitive array.
+ *
+ * @param <T> a primitive array type, e.g., {@code byte[]}.
+ */
+class ArrayImgRangeCopier< T > implements RangeCopier< T >
+{
+	private final int n;
+	private final int[] srcDims;
+	private final Ranges findRanges;
+	private final MemCopy< T > memCopy;
+	private final T oob;
+
+	private final List< Ranges.Range >[] rangesPerDimension;
+	private final Ranges.Range[] ranges;
+
+	private final int[] dsteps;
+	private final int[] doffsets;
+	private final int[] csteps;
+	private final int[] lengths;
+
+	private final T src;
+
+	public ArrayImgRangeCopier(
+			final ArrayImg< ?, ? > arrayImg,
+			final Ranges findRanges,
+			final MemCopy< T > memCopy,
+			final T oob )
+	{
+		n = arrayImg.numDimensions();
+
+		srcDims = new int[ n ];
+		for ( int d = 0; d < n; d++ )
+			srcDims[ d ] = ( int ) arrayImg.dimension( d );
+
+		this.findRanges = findRanges;
+		this.memCopy = memCopy;
+		this.oob = oob;
+
+		rangesPerDimension = new List[ n ];
+		ranges = new Ranges.Range[ n ];
+
+		dsteps = new int[ n ];
+		doffsets = new int[ n + 1 ];
+		csteps = new int[ n ];
+		lengths = new int[ n ];
+
+		src = ( T ) ( ( ( ArrayDataAccess< ? > ) arrayImg.update( null ) ).getCurrentStorageArray() );
+	}
+
+	// creates an independent copy of {@code other}
+	private ArrayImgRangeCopier( ArrayImgRangeCopier< T > copier )
+	{
+		n = copier.n;
+		srcDims = copier.srcDims.clone();
+		findRanges = copier.findRanges;
+		memCopy = copier.memCopy;
+		oob = copier.oob;
+		src = copier.src;
+
+		rangesPerDimension = new List[ n ];
+		ranges = new Ranges.Range[ n ];
+		dsteps = new int[ n ];
+		doffsets = new int[ n + 1 ];
+		csteps = new int[ n ];
+		lengths = new int[ n ];
+	}
+
+	@Override
+	public ArrayImgRangeCopier< T > newInstance()
+	{
+		return new ArrayImgRangeCopier<>( this );
+	}
+
+	/**
+	 * Copy the block starting at {@code srcPos} with the given {@code size}
+	 * into the (appropriately sized) {@code dest} array.
+	 * <p>
+	 * This finds the src range lists for all dimensions and then calls
+	 * {@link #copy(Object, int)} to iterate all range combinations.
+	 *
+	 * @param srcPos
+	 * 		min coordinates of block to copy from src Img.
+	 * @param dest
+	 * 		destination array. Type is {@code byte[]}, {@code float[]},
+	 * 		etc, corresponding to the src Img's native type.
+	 * @param size
+	 * 		dimensions of block to copy from src Img.
+	 */
+	@Override
+	public void copy( final long[] srcPos, final T dest, final int[] size )
+	{
+		// find ranges
+		for ( int d = 0; d < n; ++d )
+			rangesPerDimension[ d ] = findRanges.findRanges( srcPos[ d ], size[ d ], srcDims[ d ], srcDims[ d ] );
+
+		// copy data
+		setupDestSize( size );
+		copy( dest, n - 1 );
+	}
+
+	/**
+	 * Iterate the {@code rangesPerDimension} list for the given dimension {@code d}
+	 * and recursively call itself for iterating dimension {@code d-1}.
+	 *
+	 * @param dest
+	 * 		destination array. Type is {@code byte[]}, {@code float[]},
+	 * 		etc, corresponding to the src Img's native type.
+	 * @param d
+	 * 		current dimension. This method calls itself recursively with
+	 * 		        {@code d-1} until {@code d==0} is reached.
+     */
+	private void copy( final T dest, final int d )
+	{
+		for ( Ranges.Range range : rangesPerDimension[ d ] )
+		{
+			ranges[ d ] = range;
+			updateRange( d );
+			if ( range.dir == CONSTANT )
+				fillRanges( dest, d );
+			else if ( d > 0 )
+				copy( dest, d - 1 );
+			else
+				copyRanges( dest );
+		}
+	}
+
+	private void setupDestSize( final int[] size )
+	{
+		dsteps[ 0 ] = 1;
+		for ( int d = 0; d < n - 1; ++d )
+			dsteps[ d + 1 ] = dsteps[ d ] * size[ d ];
+	}
+
+	private void updateRange( final int d )
+	{
+		final Ranges.Range r = ranges[ d ];
+		lengths[ d ] = r.w;
+		doffsets[ d ] = doffsets[ d + 1 ] + dsteps[ d ] * r.x; // doffsets[ n ] == 0
+	}
+
+	/**
+     * Once we get here, {@link #setupDestSize} and {@link #updateRange} for
+     * all dimensions have been called, so the {@code dsteps}, {@code
+     * doffsets}, {@code cdims}, and {@code lengths} fields have been
+     * appropriately set up for the current Range combination.
+     */
+	private void copyRanges( final T dest )
+	{
+		csteps[ 0 ] = 1;
+		for ( int d = 0; d < n - 1; ++d )
+			csteps[ d + 1 ] = csteps[ d ] * srcDims[ d ];
+
+		int sOffset = 0;
+		for ( int d = 0; d < n; ++d )
+		{
+			final Ranges.Range r = ranges[ d ];
+			sOffset += csteps[ d ] * r.cellx;
+			switch( r.dir )
+			{
+			case BACKWARD:
+				csteps[ d ] = -csteps[ d ];
+				break;
+			case STAY:
+				csteps[ d ] = 0;
+				break;
+			}
+		}
+
+		final int dOffset = doffsets[ 0 ];
+
+		if ( n > 1 )
+			copyRangesRecursively( src, sOffset, dest, dOffset, n - 1 );
+		else
+		{
+			final int l0 = lengths[ 0 ];
+			final int cstep0 = csteps[ 0 ];
+			memCopy.copyLines( cstep0, l0, 1, src, sOffset, 0, dest, dOffset, 0 );
+		}
+	}
+
+	private void copyRangesRecursively( final T src, final int srcPos, final T dest, final int destPos, final int d )
+	{
+		final int length = lengths[ d ];
+		final int cstep = csteps[ d ];
+		final int dstep = dsteps[ d ];
+		if ( d > 1 )
+			for ( int i = 0; i < length; ++i )
+				copyRangesRecursively( src, srcPos + i * cstep, dest, destPos + i * dstep, d - 1 );
+		else
+		{
+			final int l0 = lengths[ 0 ];
+			final int cstep0 = csteps[ 0 ];
+			memCopy.copyLines( cstep0, l0, length, src, srcPos, cstep, dest, destPos, dstep );
+		}
+	}
+
+	/**
+     * Once we get here, {@link #setupDestSize} and {@link #updateRange} for
+     * all dimensions have been called, so the {@code dsteps}, {@code
+     * doffsets}, {@code cdims}, and {@code lengths} fields have been
+     * appropriately set up for the current Range combination. Also {@code
+     * cellAccess} is positioned on the corresponding cell.
+     */
+	void fillRanges( final T dest, final int dConst )
+	{
+		final int dOffset = doffsets[ dConst ];
+		lengths[ dConst ] *= dsteps[ dConst ];
+
+		if ( n - 1 > dConst )
+			fillRangesRecursively( dest, dOffset, n - 1, dConst );
+		else
+			memCopy.copyValue( oob, 0, dest, dOffset, lengths[ dConst ] );
+	}
+
+	private void fillRangesRecursively( final T dest, final int destPos, final int d, final int dConst )
+	{
+		final int length = lengths[ d ];
+		final int dstep = dsteps[ d ];
+		if ( d > dConst + 1 )
+			for ( int i = 0; i < length; ++i )
+				fillRangesRecursively( dest, destPos + i * dstep, d - 1, dConst );
+		else
+			for ( int i = 0; i < length; ++i )
+				memCopy.copyValue( oob, 0, dest, destPos + i * dstep, lengths[ dConst ] );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/CellImgRangeCopier.java
+++ b/src/main/java/net/imglib2/blocks/CellImgRangeCopier.java
@@ -1,0 +1,244 @@
+package net.imglib2.blocks;
+
+import java.util.List;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.cell.AbstractCellImg;
+import net.imglib2.img.cell.Cell;
+import net.imglib2.img.cell.CellGrid;
+
+import static net.imglib2.blocks.Ranges.Direction.CONSTANT;
+
+/**
+ * Does the actual copying work from an {@code AbstractCellImg} into a primitive
+ * array.
+ *
+ * @param <T> a primitive array type, e.g., {@code byte[]}.
+ */
+class CellImgRangeCopier< T > implements RangeCopier< T >
+{
+	private final int n;
+	private final CellGrid cellGrid;
+	private final RandomAccess< ? extends Cell< ? > > cellAccess;
+	private final long[] srcDims;
+	private final Ranges findRanges;
+	private final MemCopy< T > memCopy;
+	private final T oob;
+
+	private final List< Ranges.Range >[] rangesPerDimension;
+	private final Ranges.Range[] ranges;
+
+	private final int[] dsteps;
+	private final int[] doffsets;
+	private final int[] cdims;
+	private final int[] csteps;
+	private final int[] lengths;
+
+	public CellImgRangeCopier(
+			final AbstractCellImg< ?, ?, ?, ? > cellImg,
+			final Ranges findRanges,
+			final MemCopy< T > memCopy,
+			final T oob )
+	{
+		n = cellImg.numDimensions();
+		cellGrid = cellImg.getCellGrid();
+		cellAccess = cellImg.getCells().randomAccess();
+		srcDims = cellImg.dimensionsAsLongArray();
+
+		this.findRanges = findRanges;
+		this.memCopy = memCopy;
+		this.oob = oob;
+
+		rangesPerDimension = new List[ n ];
+		ranges = new Ranges.Range[ n ];
+
+		dsteps = new int[ n ];
+		doffsets = new int[ n + 1 ];
+		cdims = new int[ n ];
+		csteps = new int[ n ];
+		lengths = new int[ n ];
+	}
+
+	// creates an independent copy of {@code other}
+	private CellImgRangeCopier( CellImgRangeCopier< T > copier )
+	{
+		n = copier.n;
+		cellGrid = copier.cellGrid;
+		cellAccess = copier.cellAccess.copy();
+		srcDims = copier.srcDims.clone();
+		findRanges = copier.findRanges;
+		memCopy = copier.memCopy;
+		oob = copier.oob;
+
+		rangesPerDimension = new List[ n ];
+		ranges = new Ranges.Range[ n ];
+		dsteps = new int[ n ];
+		doffsets = new int[ n + 1 ];
+		cdims = new int[ n ];
+		csteps = new int[ n ];
+		lengths = new int[ n ];
+	}
+
+	@Override
+	public CellImgRangeCopier< T > newInstance()
+	{
+		return new CellImgRangeCopier<>( this );
+	}
+
+	/**
+	 * Copy the block starting at {@code srcPos} with the given {@code size}
+	 * into the (appropriately sized) {@code dest} array.
+	 * <p>
+	 * This finds the src range lists for all dimensions and then calls
+	 * {@link #copy(Object, int)} to iterate all range combinations.
+	 *
+	 * @param srcPos
+	 * 		min coordinates of block to copy from src Img.
+	 * @param dest
+	 * 		destination array. Type is {@code byte[]}, {@code float[]},
+	 * 		etc, corresponding to the src Img's native type.
+	 * @param size
+	 * 		dimensions of block to copy from src Img.
+	 */
+	@Override
+	public void copy( final long[] srcPos, final T dest, final int[] size )
+	{
+		// find ranges
+		for ( int d = 0; d < n; ++d )
+			rangesPerDimension[ d ] = findRanges.findRanges( srcPos[ d ], size[ d ], srcDims[ d ], cellGrid.cellDimension( d ) );
+
+		// copy data
+		setupDestSize( size );
+		copy( dest, n - 1 );
+	}
+
+	/**
+	 * Iterates the {@code rangesPerDimension} list for the given dimension {@code d}
+	 * and recursively calls itself for iterating dimension {@code d-1}.
+	 *
+	 * @param dest
+	 * 		destination array. Type is {@code byte[]}, {@code float[]},
+	 * 		etc, corresponding to the src Img's native type.
+	 * @param d
+	 * 		current dimension. This method calls itself recursively with
+	 * 		        {@code d-1} until {@code d==0} is reached.
+     */
+	private void copy( final T dest, final int d )
+	{
+		for ( Ranges.Range range : rangesPerDimension[ d ] )
+		{
+			ranges[ d ] = range;
+			updateRange( d );
+			if ( range.dir == CONSTANT )
+				fillRanges( dest, d );
+			else if ( d > 0 )
+				copy( dest, d - 1 );
+			else
+				copyRanges( dest );
+		}
+	}
+
+	private void setupDestSize( final int[] size )
+	{
+		dsteps[ 0 ] = 1;
+		for ( int d = 0; d < n - 1; ++d )
+			dsteps[ d + 1 ] = dsteps[ d ] * size[ d ];
+	}
+
+	private void updateRange( final int d )
+	{
+		final Ranges.Range r = ranges[ d ];
+		cellAccess.setPosition( r.gridx, d );
+		lengths[ d ] = r.w;
+		doffsets[ d ] = doffsets[ d + 1 ] + dsteps[ d ] * r.x; // doffsets[ n ] == 0
+		cdims[ d ] = cellGrid.getCellDimension( d, r.gridx );
+	}
+
+	/**
+     * Once we get here, {@link #setupDestSize} and {@link #updateRange} for
+     * all dimensions have been called, so the {@code dsteps}, {@code
+     * doffsets}, {@code cdims}, and {@code lengths} fields have been
+     * appropriately set up for the current Range combination. Also {@code
+     * cellAccess} is positioned on the corresponding cell.
+     */
+	private void copyRanges( final T dest )
+	{
+		csteps[ 0 ] = 1;
+		for ( int d = 0; d < n - 1; ++d )
+			csteps[ d + 1 ] = csteps[ d ] * cdims[ d ];
+
+		int sOffset = 0;
+		for ( int d = 0; d < n; ++d )
+		{
+			final Ranges.Range r = ranges[ d ];
+			sOffset += csteps[ d ] * r.cellx;
+			switch( r.dir )
+			{
+			case BACKWARD:
+				csteps[ d ] = -csteps[ d ];
+				break;
+			case STAY:
+				csteps[ d ] = 0;
+				break;
+			}
+		}
+
+		final int dOffset = doffsets[ 0 ];
+
+		final T src = ( T ) ( ( ( ArrayDataAccess< ? > ) cellAccess.get().getData() ).getCurrentStorageArray() );
+		if ( n > 1 )
+			copyRangesRecursively( src, sOffset, dest, dOffset, n - 1 );
+		else
+		{
+			final int l0 = lengths[ 0 ];
+			final int cstep0 = csteps[ 0 ];
+			memCopy.copyLines( cstep0, l0, 1, src, sOffset, 0, dest, dOffset, 0 );
+		}
+	}
+
+	private void copyRangesRecursively( final T src, final int srcPos, final T dest, final int destPos, final int d )
+	{
+		final int length = lengths[ d ];
+		final int cstep = csteps[ d ];
+		final int dstep = dsteps[ d ];
+		if ( d > 1 )
+			for ( int i = 0; i < length; ++i )
+				copyRangesRecursively( src, srcPos + i * cstep, dest, destPos + i * dstep, d - 1 );
+		else
+		{
+			final int l0 = lengths[ 0 ];
+			final int cstep0 = csteps[ 0 ];
+			memCopy.copyLines( cstep0, l0, length, src, srcPos, cstep, dest, destPos, dstep );
+		}
+	}
+
+	/**
+     * Once we get here, {@link #setupDestSize} and {@link #updateRange} for
+     * all dimensions have been called, so the {@code dsteps}, {@code
+     * doffsets}, {@code cdims}, and {@code lengths} fields have been
+     * appropriately set up for the current Range combination. Also {@code
+     * cellAccess} is positioned on the corresponding cell.
+     */
+	void fillRanges( final T dest, final int dConst )
+	{
+		final int dOffset = doffsets[ dConst ];
+		lengths[ dConst ] *= dsteps[ dConst ];
+
+		if ( n - 1 > dConst )
+			fillRangesRecursively( dest, dOffset, n - 1, dConst );
+		else
+			memCopy.copyValue( oob, 0, dest, dOffset, lengths[ dConst ] );
+	}
+
+	private void fillRangesRecursively( final T dest, final int destPos, final int d, final int dConst )
+	{
+		final int length = lengths[ d ];
+		final int dstep = dsteps[ d ];
+		if ( d > dConst + 1 )
+			for ( int i = 0; i < length; ++i )
+				fillRangesRecursively( dest, destPos + i * dstep, d - 1, dConst );
+		else
+			for ( int i = 0; i < length; ++i )
+				memCopy.copyValue( oob, 0, dest, destPos + i * dstep, lengths[ dConst ] );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/Convert.java
+++ b/src/main/java/net/imglib2/blocks/Convert.java
@@ -1,0 +1,50 @@
+package net.imglib2.blocks;
+
+import java.util.function.Supplier;
+import net.imglib2.converter.Converter;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+
+/*
+TODO: Performance of Convert is very unstable.
+      Different Java versions can optimize ConvertGeneric (and modified versions) to different degrees.
+      Although actual type in the convert loop are identical, specialized versions (e.g.,
+      ConvertImpl.Convert_UnsignedByteType_FloatType) are often twice as fast.
+      Also, the only experiments I have run so far are isolated instances with a single converter.
+      For real work loads, probably it is required to additionally use ClassCopyProvider, switching on the Converter (supplier) type.
+      More experiments are needed.
+      See ConvertBenchmark.
+
+TODO: Implement more special case converters.
+*/
+interface Convert
+{
+	void convert( Object src, Object dest, final int length );
+
+	Convert newInstance();
+
+	static < A extends NativeType< A >, B extends NativeType< B > > Convert create(
+			final A srcType,
+			final B destType,
+			final Supplier< Converter< A, B > > converterSupplier )
+	{
+		if ( srcType instanceof UnsignedByteType )
+		{
+			if ( destType instanceof FloatType )
+			{
+				return new ConvertImpl.Convert_UnsignedByteType_FloatType( ( Supplier ) converterSupplier );
+			}
+		}
+		else if ( srcType instanceof UnsignedShortType )
+		{
+			if ( destType instanceof FloatType )
+			{
+				return new ConvertImpl.Convert_UnsignedShortType_FloatType( ( Supplier ) converterSupplier );
+			}
+		}
+
+		return new ConvertImpl.ConvertGeneric<>( srcType, destType, converterSupplier );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/ConvertImpl.java
+++ b/src/main/java/net/imglib2/blocks/ConvertImpl.java
@@ -1,0 +1,155 @@
+package net.imglib2.blocks;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+import net.imglib2.converter.Converter;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.NativeTypeFactory;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+
+class ConvertImpl
+{
+	static class Convert_UnsignedShortType_FloatType implements Convert
+	{
+		private final Supplier< Converter< UnsignedShortType, FloatType > > converterSupplier;
+
+		private final Converter< UnsignedShortType, FloatType > converter;
+
+		public Convert_UnsignedShortType_FloatType(final Supplier< Converter< UnsignedShortType, FloatType > > converterSupplier)
+		{
+			this.converterSupplier = converterSupplier;
+			converter = converterSupplier.get();
+		}
+
+		@Override
+		public void convert( final Object src, final Object dest, final int length )
+		{
+			final UnsignedShortType in = new UnsignedShortType( new ShortArray( ( short[] ) src ) );
+			final FloatType out = new FloatType( new FloatArray( ( float[] ) dest ) );
+			for ( int i = 0; i < length; i++ )
+			{
+				in.index().set( i );
+				out.index().set( i );
+				converter.convert( in, out );
+			}
+		}
+
+		// creates an independent copy of {@code convert}
+		private Convert_UnsignedShortType_FloatType( Convert_UnsignedShortType_FloatType convert )
+		{
+			converterSupplier = convert.converterSupplier;
+			converter = converterSupplier.get();
+		}
+
+		@Override
+		public Convert newInstance()
+		{
+			return new Convert_UnsignedShortType_FloatType( this );
+		}
+	}
+
+	static class Convert_UnsignedByteType_FloatType implements Convert
+	{
+		private final Supplier< Converter< UnsignedByteType, FloatType > > converterSupplier;
+
+		private final Converter< UnsignedByteType, FloatType > converter;
+
+		public Convert_UnsignedByteType_FloatType(final Supplier< Converter< UnsignedByteType, FloatType > > converterSupplier)
+		{
+			this.converterSupplier = converterSupplier;
+			converter = converterSupplier.get();
+		}
+
+		@Override
+		public void convert( final Object src, final Object dest, final int length )
+		{
+			final UnsignedByteType in = new UnsignedByteType( new ByteArray( ( byte[] ) src ) );
+			final FloatType out = new FloatType( new FloatArray( ( float[] ) dest ) );
+			for ( int i = 0; i < length; i++ )
+			{
+				in.index().set( i );
+				out.index().set( i );
+				converter.convert( in, out );
+			}
+		}
+
+		// creates an independent copy of {@code convert}
+		private Convert_UnsignedByteType_FloatType( Convert_UnsignedByteType_FloatType convert )
+		{
+			converterSupplier = convert.converterSupplier;
+			converter = converterSupplier.get();
+		}
+
+		@Override
+		public Convert newInstance()
+		{
+			return new Convert_UnsignedByteType_FloatType( this );
+		}
+	}
+
+	static class ConvertGeneric< A extends NativeType< A >, B extends NativeType< B > > implements Convert
+	{
+		private final Supplier< Converter< A, B > > converterSupplier;
+
+		private final Converter< A, B > converter;
+
+		private final Function< Object, A > srcWrapper;
+
+		private final Function< Object, B > destWrapper;
+
+		public ConvertGeneric( final A srcType, final B destType, final Supplier< Converter< A, B > > converterSupplier )
+		{
+			this.converterSupplier = converterSupplier;
+			converter = converterSupplier.get();
+			srcWrapper = wrapperForType( srcType );
+			destWrapper = wrapperForType( destType );
+		}
+
+		@Override
+		public void convert( Object src, Object dest, final int length )
+		{
+			A in = srcWrapper.apply( src );
+			B out = destWrapper.apply( dest );
+			for ( int i = 0; i < length; i++ )
+			{
+				in.index().set( i );
+				out.index().set( i );
+				converter.convert( in, out );
+			}
+		}
+
+		// creates an independent copy of {@code convert}
+		private ConvertGeneric( ConvertGeneric< A, B > convert )
+		{
+			converterSupplier = convert.converterSupplier;
+			converter = converterSupplier.get();
+			srcWrapper = convert.srcWrapper;
+			destWrapper = convert.destWrapper;
+		}
+
+		@Override
+		public Convert newInstance()
+		{
+			return new ConvertGeneric<>( this );
+		}
+
+		static < T extends NativeType< T >, A extends ArrayDataAccess< A > > Function< Object, T > wrapperForType( T type )
+		{
+			final NativeTypeFactory< T, A > nativeTypeFactory = ( NativeTypeFactory< T, A > ) type.getNativeTypeFactory();
+			final PrimitiveTypeProperties< ?, A > props = ( PrimitiveTypeProperties< ?, A > ) PrimitiveTypeProperties.get( nativeTypeFactory.getPrimitiveType() );
+			return array -> {
+				final ArrayImg< T, A > img = new ArrayImg<>( props.wrap( array ), new long[] { 1 }, type.getEntitiesPerPixel() );
+				final T t = nativeTypeFactory.createLinkedType( img );
+				t.updateContainer( null );
+				return t;
+			};
+		}
+	}
+}

--- a/src/main/java/net/imglib2/blocks/Extension.java
+++ b/src/main/java/net/imglib2/blocks/Extension.java
@@ -1,0 +1,82 @@
+package net.imglib2.blocks;
+
+import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
+import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
+
+import static net.imglib2.outofbounds.OutOfBoundsMirrorFactory.Boundary.SINGLE;
+
+interface Extension
+{
+	enum Type
+	{
+		CONSTANT(true),
+		BORDER(false),
+		MIRROR_SINGLE(false),
+		MIRROR_DOUBLE(false),
+		UNKNOWN( true );
+
+		private final boolean isValueDependent;
+
+		Type( final boolean isValueDependent )
+		{
+			this.isValueDependent = isValueDependent;
+		}
+
+		/**
+		 * Whether this extension depends on the pixel value. E.g., {@code
+		 * BORDER}, {@code MIRROR_SINGLE}, {@code MIRROR_DOUBLE} are only
+		 * dependent on position ({@code isValueDependent()==false}), while
+		 * {@code CONSTANT} is dependent on the out-of-bounds value ({@code
+		 * isValueDependent()==true}).
+		 */
+		public boolean isValueDependent()
+		{
+			return isValueDependent;
+		}
+	}
+
+	Type type();
+
+	static Extension border()
+	{
+		return ExtensionImpl.border;
+	}
+
+	static Extension mirrorSingle()
+	{
+		return ExtensionImpl.mirrorSingle;
+	}
+
+	static Extension mirrorDouble()
+	{
+		return ExtensionImpl.mirrorDouble;
+	}
+
+	static < T > Extension constant( T oobValue )
+	{
+		return new ExtensionImpl.ConstantExtension<>( oobValue );
+	}
+
+	static Extension of( OutOfBoundsFactory< ?, ? > oobFactory )
+	{
+		if ( oobFactory instanceof OutOfBoundsBorderFactory )
+		{
+			return border();
+		}
+		else if ( oobFactory instanceof OutOfBoundsMirrorFactory )
+		{
+			final OutOfBoundsMirrorFactory.Boundary boundary = ( ( OutOfBoundsMirrorFactory< ?, ? > ) oobFactory ).getBoundary();
+			return boundary == SINGLE ? mirrorSingle() : mirrorDouble();
+		}
+		else if ( oobFactory instanceof OutOfBoundsConstantValueFactory )
+		{
+			return constant( ( ( OutOfBoundsConstantValueFactory ) oobFactory ).getValue() );
+		}
+		else
+		{
+			return new ExtensionImpl.UnknownExtension<>( oobFactory );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/blocks/ExtensionImpl.java
+++ b/src/main/java/net/imglib2/blocks/ExtensionImpl.java
@@ -1,0 +1,79 @@
+package net.imglib2.blocks;
+
+import net.imglib2.blocks.Extension.Type;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+
+class ExtensionImpl
+{
+	static final Extension border = new DefaultExtension( Type.BORDER );
+
+	static final Extension mirrorSingle = new DefaultExtension( Type.MIRROR_SINGLE );
+
+	static final Extension mirrorDouble = new DefaultExtension( Type.MIRROR_DOUBLE );
+
+	static class DefaultExtension implements Extension
+	{
+		private final Type type;
+
+		DefaultExtension( final Type type )
+		{
+			this.type = type;
+		}
+
+		@Override
+		public Type type()
+		{
+			return type;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Extension{" + type + '}';
+		}
+	}
+
+	static class UnknownExtension< T, F > extends DefaultExtension
+	{
+		private final OutOfBoundsFactory< T, F > oobFactory;
+
+		UnknownExtension( final OutOfBoundsFactory< T, F > oobFactory )
+		{
+			super( Type.UNKNOWN );
+			this.oobFactory = oobFactory;
+		}
+
+		public OutOfBoundsFactory< T, F > getOobFactory()
+		{
+			return oobFactory;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Extension{" + type() + ", oobFactory=" + oobFactory.getClass().getSimpleName() + '}';
+		}
+	}
+
+	static class ConstantExtension< T > extends DefaultExtension
+	{
+		private final T value;
+
+		ConstantExtension( T value )
+		{
+			super( Type.CONSTANT );
+			this.value = value;
+		}
+
+		public T getValue()
+		{
+			return value;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Extension{" + type() + ", value=" + value.getClass().getSimpleName() + "(" + value + ")}";
+		}
+	}
+}

--- a/src/main/java/net/imglib2/blocks/FallbackPrimitiveBlocks.java
+++ b/src/main/java/net/imglib2/blocks/FallbackPrimitiveBlocks.java
@@ -1,0 +1,60 @@
+package net.imglib2.blocks;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.NativeTypeFactory;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+class FallbackPrimitiveBlocks< T extends NativeType< T >, A extends ArrayDataAccess< A > > implements PrimitiveBlocks< T >
+{
+	private final RandomAccessible< T > source;
+
+	private final T type;
+
+	private final PrimitiveTypeProperties< ?, A > primitiveTypeProperties;
+
+	private final NativeTypeFactory< T, A > nativeTypeFactory;
+
+	public FallbackPrimitiveBlocks( final FallbackProperties< T > props )
+	{
+		this( props.getView(), props.getViewType() );
+	}
+
+	public FallbackPrimitiveBlocks( final RandomAccessible< T > source, final T type )
+	{
+		this.source = source;
+		this.type = type;
+
+		if ( type.getEntitiesPerPixel().getRatio() != 1 )
+			throw new IllegalArgumentException( "Types with entitiesPerPixel != 1 are not supported" );
+
+		nativeTypeFactory = ( NativeTypeFactory< T, A > ) type.getNativeTypeFactory();
+		primitiveTypeProperties = ( PrimitiveTypeProperties< ?, A > ) PrimitiveTypeProperties.get( nativeTypeFactory.getPrimitiveType() );
+	}
+
+	@Override
+	public T getType()
+	{
+		return type;
+	}
+
+	@Override
+	public void copy( final long[] srcPos, final Object dest, final int[] size )
+	{
+		final ArrayImg< T, A > img = new ArrayImg<>( primitiveTypeProperties.wrap( dest ), Util.int2long( size ), type.getEntitiesPerPixel() );
+		img.setLinkedType( nativeTypeFactory.createLinkedType( img ) );
+		final FinalInterval interval = FinalInterval.createMinSize( srcPos, Util.int2long( size ) );
+		LoopBuilder.setImages( Views.interval( source, interval ), img ).forEachPixel( ( a, b ) -> b.set( a ) );
+	}
+
+	@Override
+	public PrimitiveBlocks< T > threadSafe()
+	{
+		return this;
+	}
+}

--- a/src/main/java/net/imglib2/blocks/FallbackProperties.java
+++ b/src/main/java/net/imglib2/blocks/FallbackProperties.java
@@ -1,0 +1,43 @@
+package net.imglib2.blocks;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.type.NativeType;
+
+class FallbackProperties< T extends NativeType< T > >
+{
+	private final T viewType;
+
+	private final RandomAccessible< T > view;
+
+	/**
+	 * TODO: javadoc
+	 *
+	 * @param viewType
+	 * 		pixel type of the View to copy from
+	 * @param view
+	 */
+	FallbackProperties( final T viewType, final RandomAccessible< T > view )
+	{
+		this.viewType = viewType;
+		this.view = view;
+	}
+
+	@Override
+	public String toString()
+	{
+		return "FallbackProperties{" +
+				"viewType=" + viewType.getClass().getSimpleName() +
+				", view=" + view +
+				'}';
+	}
+
+	public T getViewType()
+	{
+		return viewType;
+	}
+
+	public RandomAccessible< T > getView()
+	{
+		return view;
+	}
+}

--- a/src/main/java/net/imglib2/blocks/MemCopy.java
+++ b/src/main/java/net/imglib2/blocks/MemCopy.java
@@ -1,0 +1,485 @@
+package net.imglib2.blocks;
+
+import java.util.Arrays;
+import net.imglib2.type.PrimitiveType;
+
+// TODO javadoc
+// low-level copying methods
+// implementations for all primitive types
+// T is a primitive array type
+interface MemCopy< T >
+{
+	/**
+	 * Copy {@code length} components from the {@code src} array to the {@code
+	 * dest} array. The components at positions {@code srcPos} through {@code
+	 * srcPos+length-1} in the source array are copied into positions {@code
+	 * destPos} through {@code destPos+length-1}, respectively, of the
+	 * destination array.
+	 */
+	void copyForward( T src, int srcPos, T dest, int destPos, int length );
+
+	/**
+	 * Copy {@code length} components from the {@code src} array to the {@code
+	 * dest} array, in reverse order. The components at positions {@code srcPos}
+	 * through {@code srcPos-length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 */
+	void copyReverse( T src, int srcPos, T dest, int destPos, int length );
+
+	/**
+	 * Copy component at position {@code srcPos} in the {@code src} array
+	 * ({@code length} times) into positions {@code destPos} through {@code
+	 * destPos+length-1} of the destination array.
+	 */
+	void copyValue( T src, int srcPos, T dest, int destPos, int length );
+
+	/**
+	 * TODO javadoc
+	 */
+	void copyStrided( T src, int srcPos, T dest, int destPos, int destStride, int length );
+
+	/**
+	 * Copy {@code numLines} stretches of {@code lineLength} elements.
+	 *
+	 * @param lineDir {@code 1}, {@code -1}, or {@code 0}. This corresponds (for every line being copied) to the source position moving forward, backward, or not at all, as the dest position is moving forward.
+	 * @param lineLength how many elements to copy per line
+	 * @param numLines how many lines to copy
+	 * @param src source array
+	 * @param srcPos starting position in source array
+	 * @param srcStep offset to next line in src
+	 * @param dest dest array
+	 * @param destPos starting position in dest array
+	 * @param destStep offset to next line in dest
+	 */
+	// Note that this default implementation is overridden in each
+	// implementation (with identical code) to soften the performance hit from
+	// polymorphism. The default implementation is left here, to make additional
+	// implementations easier.
+	default void copyLines(
+			final int lineDir,
+			final int lineLength,
+			final int numLines,
+			final T src,
+			final int srcPos,
+			final int srcStep,
+			final T dest,
+			final int destPos,
+			final int destStep )
+	{
+		if ( lineDir == 1 )
+			for ( int i = 0; i < numLines; ++i )
+				copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		else if ( lineDir == -1 )
+			for ( int i = 0; i < numLines; ++i )
+				copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		else // cstep0 == 0
+			for ( int i = 0; i < numLines; ++i )
+				copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+	}
+
+
+	MemCopyBoolean BOOLEAN = new MemCopyBoolean();
+	MemCopyByte BYTE = new MemCopyByte();
+	MemCopyChar CHAR = new MemCopyChar();
+	MemCopyShort SHORT = new MemCopyShort();
+	MemCopyInt INT = new MemCopyInt();
+	MemCopyLong LONG = new MemCopyLong();
+	MemCopyFloat FLOAT = new MemCopyFloat();
+	MemCopyDouble DOUBLE = new MemCopyDouble();
+
+	static MemCopy< ? > forPrimitiveType( final PrimitiveType primitiveType )
+	{
+		switch ( primitiveType )
+		{
+		case BOOLEAN:
+			return BOOLEAN;
+		case BYTE:
+			return BYTE;
+		case CHAR:
+			return CHAR;
+		case SHORT:
+			return SHORT;
+		case INT:
+			return INT;
+		case LONG:
+			return LONG;
+		case FLOAT:
+			return FLOAT;
+		case DOUBLE:
+			return DOUBLE;
+		default:
+		case UNDEFINED:
+			throw new IllegalArgumentException();
+		}
+	}
+
+	class MemCopyBoolean implements MemCopy< boolean[] >
+	{
+		@Override
+		public void copyForward( final boolean[] src, final int srcPos, final boolean[] dest, final int destPos, final int length )
+		{
+			System.arraycopy( src, srcPos, dest, destPos, length );
+		}
+
+		@Override
+		public void copyReverse( final boolean[] src, final int srcPos, final boolean[] dest, final int destPos, final int length )
+		{
+			for ( int i = 0; i < length; ++i )
+				dest[ destPos + i ] = src[ srcPos - i ];
+		}
+
+		@Override
+		public void copyValue( final boolean[] src, final int srcPos, final boolean[] dest, final int destPos, final int length )
+		{
+			Arrays.fill( dest, destPos, destPos + length, src[ srcPos ] );
+		}
+
+		@Override
+		public void copyStrided( final boolean[] src, final int srcPos, final boolean[] dest, final int destPos, final int destStride, final int length )
+		{
+			if ( destStride == 1 )
+				copyForward( src, srcPos, dest, destPos, length );
+			else
+				for ( int i = 0; i < length; ++i )
+					dest[ destPos + i * destStride ] = src[ srcPos + i ];
+		}
+
+		@Override
+		public void copyLines( final int lineDir, final int lineLength, final int numLines, final boolean[] src, final int srcPos, final int srcStep, final boolean[] dest, final int destPos, final int destStep )
+		{
+			if ( lineDir == 1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else if ( lineDir == -1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else // cstep0 == 0
+				for ( int i = 0; i < numLines; ++i )
+					copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		}
+	}
+
+	class MemCopyByte implements MemCopy< byte[] >
+	{
+		@Override
+		public void copyForward( final byte[] src, final int srcPos, final byte[] dest, final int destPos, final int length )
+		{
+			System.arraycopy( src, srcPos, dest, destPos, length );
+		}
+
+		@Override
+		public void copyReverse( final byte[] src, final int srcPos, final byte[] dest, final int destPos, final int length )
+		{
+			for ( int i = 0; i < length; ++i )
+				dest[ destPos + i ] = src[ srcPos - i ];
+		}
+
+		@Override
+		public void copyValue( final byte[] src, final int srcPos, final byte[] dest, final int destPos, final int length )
+		{
+			Arrays.fill( dest, destPos, destPos + length, src[ srcPos ] );
+		}
+
+		@Override
+		public void copyStrided( final byte[] src, final int srcPos, final byte[] dest, final int destPos, final int destStride, final int length )
+		{
+			if ( destStride == 1 )
+				copyForward( src, srcPos, dest, destPos, length );
+			else
+				for ( int i = 0; i < length; ++i )
+					dest[ destPos + i * destStride ] = src[ srcPos + i ];
+		}
+
+		@Override
+		public void copyLines( final int lineDir, final int lineLength, final int numLines, final byte[] src, final int srcPos, final int srcStep, final byte[] dest, final int destPos, final int destStep )
+		{
+			if ( lineDir == 1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else if ( lineDir == -1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else // cstep0 == 0
+				for ( int i = 0; i < numLines; ++i )
+					copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		}
+	}
+
+	class MemCopyShort implements MemCopy< short[] >
+	{
+		@Override
+		public void copyForward( final short[] src, final int srcPos, final short[] dest, final int destPos, final int length )
+		{
+			System.arraycopy( src, srcPos, dest, destPos, length );
+		}
+
+		@Override
+		public void copyReverse( final short[] src, final int srcPos, final short[] dest, final int destPos, final int length )
+		{
+			for ( int i = 0; i < length; ++i )
+				dest[ destPos + i ] = src[ srcPos - i ];
+		}
+
+		@Override
+		public void copyValue( final short[] src, final int srcPos, final short[] dest, final int destPos, final int length )
+		{
+			Arrays.fill( dest, destPos, destPos + length, src[ srcPos ] );
+		}
+
+
+		@Override
+		public void copyStrided( final short[] src, final int srcPos, final short[] dest, final int destPos, final int destStride, final int length )
+		{
+			if ( destStride == 1 )
+				copyForward( src, srcPos, dest, destPos, length );
+			else
+				for ( int i = 0; i < length; ++i )
+					dest[ destPos + i * destStride ] = src[ srcPos + i ];
+		}
+
+		@Override
+		public void copyLines( final int lineDir, final int lineLength, final int numLines, final short[] src, final int srcPos, final int srcStep, final short[] dest, final int destPos, final int destStep )
+		{
+			if ( lineDir == 1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else if ( lineDir == -1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else // cstep0 == 0
+				for ( int i = 0; i < numLines; ++i )
+					copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		}
+	}
+
+	class MemCopyChar implements MemCopy< char[] >
+	{
+		@Override
+		public void copyForward( final char[] src, final int srcPos, final char[] dest, final int destPos, final int length )
+		{
+			System.arraycopy( src, srcPos, dest, destPos, length );
+		}
+
+		@Override
+		public void copyReverse( final char[] src, final int srcPos, final char[] dest, final int destPos, final int length )
+		{
+			for ( int i = 0; i < length; ++i )
+				dest[ destPos + i ] = src[ srcPos - i ];
+		}
+
+		@Override
+		public void copyValue( final char[] src, final int srcPos, final char[] dest, final int destPos, final int length )
+		{
+			Arrays.fill( dest, destPos, destPos + length, src[ srcPos ] );
+		}
+
+		@Override
+		public void copyStrided( final char[] src, final int srcPos, final char[] dest, final int destPos, final int destStride, final int length )
+		{
+			if ( destStride == 1 )
+				copyForward( src, srcPos, dest, destPos, length );
+			else
+				for ( int i = 0; i < length; ++i )
+					dest[ destPos + i * destStride ] = src[ srcPos + i ];
+		}
+
+		@Override
+		public void copyLines( final int lineDir, final int lineLength, final int numLines, final char[] src, final int srcPos, final int srcStep, final char[] dest, final int destPos, final int destStep )
+		{
+			if ( lineDir == 1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else if ( lineDir == -1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else // cstep0 == 0
+				for ( int i = 0; i < numLines; ++i )
+					copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		}
+	}
+
+	class MemCopyInt implements MemCopy< int[] >
+	{
+		@Override
+		public void copyForward( final int[] src, final int srcPos, final int[] dest, final int destPos, final int length )
+		{
+			System.arraycopy( src, srcPos, dest, destPos, length );
+		}
+
+		@Override
+		public void copyReverse( final int[] src, final int srcPos, final int[] dest, final int destPos, final int length )
+		{
+			for ( int i = 0; i < length; ++i )
+				dest[ destPos + i ] = src[ srcPos - i ];
+		}
+
+		@Override
+		public void copyValue( final int[] src, final int srcPos, final int[] dest, final int destPos, final int length )
+		{
+			Arrays.fill( dest, destPos, destPos + length, src[ srcPos ] );
+		}
+
+		@Override
+		public void copyStrided( final int[] src, final int srcPos, final int[] dest, final int destPos, final int destStride, final int length )
+		{
+			if ( destStride == 1 )
+				copyForward( src, srcPos, dest, destPos, length );
+			else
+				for ( int i = 0; i < length; ++i )
+					dest[ destPos + i * destStride ] = src[ srcPos + i ];
+		}
+
+		@Override
+		public void copyLines( final int lineDir, final int lineLength, final int numLines, final int[] src, final int srcPos, final int srcStep, final int[] dest, final int destPos, final int destStep )
+		{
+			if ( lineDir == 1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else if ( lineDir == -1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else // cstep0 == 0
+				for ( int i = 0; i < numLines; ++i )
+					copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		}
+	}
+
+	class MemCopyLong implements MemCopy< long[] >
+	{
+		@Override
+		public void copyForward( final long[] src, final int srcPos, final long[] dest, final int destPos, final int length )
+		{
+			System.arraycopy( src, srcPos, dest, destPos, length );
+		}
+
+		@Override
+		public void copyReverse( final long[] src, final int srcPos, final long[] dest, final int destPos, final int length )
+		{
+			for ( int i = 0; i < length; ++i )
+				dest[ destPos + i ] = src[ srcPos - i ];
+		}
+
+		@Override
+		public void copyValue( final long[] src, final int srcPos, final long[] dest, final int destPos, final int length )
+		{
+			Arrays.fill( dest, destPos, destPos + length, src[ srcPos ] );
+		}
+
+		@Override
+		public void copyStrided( final long[] src, final int srcPos, final long[] dest, final int destPos, final int destStride, final int length )
+		{
+			if ( destStride == 1 )
+				copyForward( src, srcPos, dest, destPos, length );
+			else
+				for ( int i = 0; i < length; ++i )
+					dest[ destPos + i * destStride ] = src[ srcPos + i ];
+		}
+
+		@Override
+		public void copyLines( final int lineDir, final int lineLength, final int numLines, final long[] src, final int srcPos, final int srcStep, final long[] dest, final int destPos, final int destStep )
+		{
+			if ( lineDir == 1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else if ( lineDir == -1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else // cstep0 == 0
+				for ( int i = 0; i < numLines; ++i )
+					copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		}
+	}
+
+	class MemCopyFloat implements MemCopy< float[] >
+	{
+		@Override
+		public void copyForward( final float[] src, final int srcPos, final float[] dest, final int destPos, final int length )
+		{
+			System.arraycopy( src, srcPos, dest, destPos, length );
+		}
+
+		@Override
+		public void copyReverse( final float[] src, final int srcPos, final float[] dest, final int destPos, final int length )
+		{
+			for ( int i = 0; i < length; ++i )
+				dest[ destPos + i ] = src[ srcPos - i ];
+		}
+
+		@Override
+		public void copyValue( final float[] src, final int srcPos, final float[] dest, final int destPos, final int length )
+		{
+			Arrays.fill( dest, destPos, destPos + length, src[ srcPos ] );
+		}
+
+		@Override
+		public void copyStrided( final float[] src, final int srcPos, final float[] dest, final int destPos, final int destStride, final int length )
+		{
+			if ( destStride == 1 )
+				copyForward( src, srcPos, dest, destPos, length );
+			else
+				for ( int i = 0; i < length; ++i )
+					dest[ destPos + i * destStride ] = src[ srcPos + i ];
+		}
+
+		@Override
+		public void copyLines( final int lineDir, final int lineLength, final int numLines, final float[] src, final int srcPos, final int srcStep, final float[] dest, final int destPos, final int destStep )
+		{
+			if ( lineDir == 1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else if ( lineDir == -1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else // cstep0 == 0
+				for ( int i = 0; i < numLines; ++i )
+					copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		}
+	}
+
+	class MemCopyDouble implements MemCopy< double[] >
+	{
+		@Override
+		public void copyForward( final double[] src, final int srcPos, final double[] dest, final int destPos, final int length )
+		{
+			System.arraycopy( src, srcPos, dest, destPos, length );
+		}
+
+		@Override
+		public void copyReverse( final double[] src, final int srcPos, final double[] dest, final int destPos, final int length )
+		{
+			for ( int i = 0; i < length; ++i )
+				dest[ destPos + i ] = src[ srcPos - i ];
+		}
+
+		@Override
+		public void copyValue( final double[] src, final int srcPos, final double[] dest, final int destPos, final int length )
+		{
+			Arrays.fill( dest, destPos, destPos + length, src[ srcPos ] );
+		}
+
+		@Override
+		public void copyStrided( final double[] src, final int srcPos, final double[] dest, final int destPos, final int destStride, final int length )
+		{
+			if ( destStride == 1 )
+				copyForward( src, srcPos, dest, destPos, length );
+			else
+				for ( int i = 0; i < length; ++i )
+					dest[ destPos + i * destStride ] = src[ srcPos + i ];
+		}
+
+		@Override
+		public void copyLines( final int lineDir, final int lineLength, final int numLines, final double[] src, final int srcPos, final int srcStep, final double[] dest, final int destPos, final int destStep )
+		{
+			if ( lineDir == 1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyForward( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else if ( lineDir == -1 )
+				for ( int i = 0; i < numLines; ++i )
+					copyReverse( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+			else // cstep0 == 0
+				for ( int i = 0; i < numLines; ++i )
+					copyValue( src, srcPos + i * srcStep, dest, destPos + i * destStep, lineLength );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/blocks/PermuteInvert.java
+++ b/src/main/java/net/imglib2/blocks/PermuteInvert.java
@@ -1,0 +1,101 @@
+package net.imglib2.blocks;
+
+import net.imglib2.transform.integer.MixedTransform;
+
+class PermuteInvert
+{
+	private final MemCopy memCopy;
+
+	private final int n;
+
+	private final int[] scomp;
+
+	private final boolean[] sinv;
+
+	private final int[] ssize;
+
+	private final int[] ssteps;
+
+	private final int[] tsteps;
+
+	private final int[] csteps;
+
+	private int cstart;
+
+	public PermuteInvert( final MemCopy memCopy, MixedTransform transform )
+	{
+		this.memCopy = memCopy;
+		this.n = transform.numSourceDimensions();
+		scomp = new int[ n ];
+		sinv = new boolean[ n ];
+		transform.getComponentMapping( scomp );
+		transform.getComponentInversion( sinv );
+		ssize = new int[ n ];
+		ssteps = new int[ n ];
+		tsteps = new int[ n ];
+		csteps = new int[ n ];
+	}
+
+	// TODO: Object --> T
+	public void permuteAndInvert( Object src, Object dest, int[] destSize )
+	{
+		final int[] tsize = destSize;
+
+		for ( int d = 0; d < n; ++d )
+			ssize[ d ] = tsize[ scomp[ d ] ];
+
+		ssteps[ 0 ] = 1;
+		for ( int d = 0; d < n - 1; ++d )
+			ssteps[ d + 1 ] = ssteps[ d ] * ssize[ d ];
+
+		tsteps[ 0 ] = 1;
+		for ( int d = 0; d < n - 1; ++d )
+			tsteps[ d + 1 ] = tsteps[ d ] * tsize[ d ];
+
+		cstart = 0;
+		for ( int d = 0; d < n; ++d )
+		{
+			final int c = scomp[ d ];
+			csteps[ d ] = sinv[ d ] ? -tsteps[ c ] : tsteps[ c ];
+			cstart += sinv[ d ] ? ( tsize[ c ] - 1 ) * tsteps[ c ] : 0;
+		}
+
+		copyRecursively( src, 0, dest, cstart, n - 1 );
+	}
+
+	private void copyRecursively( final Object src, final int srcPos, final Object dest, final int destPos, final int d )
+	{
+		if ( d == 0 )
+		{
+			final int length = ssize[ d ];
+			final int stride = csteps[ d ];
+			memCopy.copyStrided( src, srcPos, dest, destPos, stride, length );
+		}
+		else
+		{
+			final int length = ssize[ d ];
+			final int srcStride = ssteps[ d ];
+			final int destStride = csteps[ d ];
+			for ( int i = 0; i < length; ++i )
+				copyRecursively( src, srcPos + i * srcStride, dest, destPos + i * destStride, d - 1 );
+		}
+	}
+
+	// creates an independent copy of {@code copier}
+	private PermuteInvert( PermuteInvert copier )
+	{
+		memCopy = copier.memCopy;
+		n = copier.n;
+		scomp = copier.scomp;
+		sinv = copier.sinv;
+		ssize = new int[ n ];
+		ssteps = new int[ n ];
+		tsteps = new int[ n ];
+		csteps = new int[ n ];
+	}
+
+	PermuteInvert newInstance()
+	{
+		return new PermuteInvert( this );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/PlanarImgRangeCopier.java
+++ b/src/main/java/net/imglib2/blocks/PlanarImgRangeCopier.java
@@ -1,0 +1,292 @@
+package net.imglib2.blocks;
+
+import java.util.List;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.planar.PlanarImg;
+
+import static net.imglib2.blocks.Ranges.Direction.CONSTANT;
+
+/**
+ * Does the actual copying work from a {@code PlanarImg} into a primitive array.
+ *
+ * @param <T> a primitive array type, e.g., {@code byte[]}.
+ */
+class PlanarImgRangeCopier< T > implements RangeCopier< T >
+{
+	private final int n;
+	private final SliceAccess< T > sliceAccess;
+	private final int[] srcDims;
+	private final Ranges findRanges;
+	private final MemCopy< T > memCopy;
+	private final T oob;
+
+	private final List< Ranges.Range >[] rangesPerDimension;
+	private final Ranges.Range[] ranges;
+
+	private final int[] dsteps;
+	private final int[] doffsets;
+	private final int[] cdims;
+	private final int[] csteps;
+	private final int[] lengths;
+
+
+	public PlanarImgRangeCopier(
+			final PlanarImg< ?, ? > planarImg,
+			final Ranges findRanges,
+			final MemCopy< T > memCopy,
+			final T oob )
+	{
+		n = planarImg.numDimensions();
+		sliceAccess = new SliceAccess<>( planarImg );
+		srcDims = new int[ n ];
+
+		this.findRanges = findRanges;
+		this.memCopy = memCopy;
+		this.oob = oob;
+
+		rangesPerDimension = new List[ n ];
+		ranges = new Ranges.Range[ n ];
+
+		dsteps = new int[ n ];
+		doffsets = new int[ n + 1 ];
+		cdims = new int[ n ];
+		csteps = new int[ n ];
+		lengths = new int[ n ];
+
+		for ( int d = 0; d < n; d++ )
+		{
+			srcDims[ d ] = ( int ) planarImg.dimension( d );
+			cdims[ d ] = d < 2 ? srcDims[ d ] : 1;
+		}
+	}
+
+	// creates an independent copy of {@code other}
+	private PlanarImgRangeCopier( PlanarImgRangeCopier< T > copier )
+	{
+		n = copier.n;
+		sliceAccess = copier.sliceAccess.copy();
+		srcDims = copier.srcDims.clone();
+		findRanges = copier.findRanges;
+		memCopy = copier.memCopy;
+		oob = copier.oob;
+
+		rangesPerDimension = new List[ n ];
+		ranges = new Ranges.Range[ n ];
+		dsteps = new int[ n ];
+		cdims = copier.cdims.clone();
+		doffsets = new int[ n + 1 ];
+		csteps = new int[ n ];
+		lengths = new int[ n ];
+	}
+
+	@Override
+	public PlanarImgRangeCopier< T > newInstance()
+	{
+		return new PlanarImgRangeCopier<>( this );
+	}
+
+	/**
+	 * Copy the block starting at {@code srcPos} with the given {@code size}
+	 * into the (appropriately sized) {@code dest} array.
+	 * <p>
+	 * This finds the src range lists for all dimensions and then calls
+	 * {@link #copy(Object, int)} to iterate all range combinations.
+	 *
+	 * @param srcPos
+	 * 		min coordinates of block to copy from src Img.
+	 * @param dest
+	 * 		destination array. Type is {@code byte[]}, {@code float[]},
+	 * 		etc, corresponding to the src Img's native type.
+	 * @param size
+	 * 		dimensions of block to copy from src Img.
+	 */
+	@Override
+	public void copy( final long[] srcPos, final T dest, final int[] size )
+	{
+		// find ranges
+		for ( int d = 0; d < n; ++d )
+			rangesPerDimension[ d ] = findRanges.findRanges( srcPos[ d ], size[ d ], srcDims[ d ], cdims[ d ] );
+
+		// copy data
+		setupDestSize( size );
+		copy( dest, n - 1 );
+	}
+
+	/**
+	 * Iterate the {@code rangesPerDimension} list for the given dimension {@code d}
+	 * and recursively call itself for iterating dimension {@code d-1}.
+	 *
+	 * @param dest
+	 * 		destination array. Type is {@code byte[]}, {@code float[]},
+	 * 		etc, corresponding to the src Img's native type.
+	 * @param d
+	 * 		current dimension. This method calls itself recursively with
+	 * 		        {@code d-1} until {@code d==0} is reached.
+     */
+	private void copy( final T dest, final int d )
+	{
+		for ( Ranges.Range range : rangesPerDimension[ d ] )
+		{
+			ranges[ d ] = range;
+			updateRange( d );
+			if ( range.dir == CONSTANT )
+				fillRanges( dest, d );
+			else if ( d > 0 )
+				copy( dest, d - 1 );
+			else
+				copyRanges( dest );
+		}
+	}
+
+	private void setupDestSize( final int[] size )
+	{
+		dsteps[ 0 ] = 1;
+		for ( int d = 0; d < n - 1; ++d )
+			dsteps[ d + 1 ] = dsteps[ d ] * size[ d ];
+	}
+
+	private void updateRange( final int d )
+	{
+		final Ranges.Range r = ranges[ d ];
+		sliceAccess.setPosition( r.gridx, d );
+		lengths[ d ] = r.w;
+		doffsets[ d ] = doffsets[ d + 1 ] + dsteps[ d ] * r.x; // doffsets[ n ] == 0
+	}
+
+	/**
+     * Once we get here, {@link #setupDestSize} and {@link #updateRange} for
+     * all dimensions have been called, so the {@code dsteps}, {@code
+     * doffsets}, {@code cdims}, and {@code lengths} fields have been
+     * appropriately set up for the current Range combination. Also {@code
+     * cellAccess} is positioned on the corresponding cell.
+     */
+	private void copyRanges( final T dest )
+	{
+		csteps[ 0 ] = 1;
+		for ( int d = 0; d < n - 1; ++d )
+			csteps[ d + 1 ] = csteps[ d ] * cdims[ d ];
+
+		int sOffset = 0;
+		for ( int d = 0; d < n; ++d )
+		{
+			final Ranges.Range r = ranges[ d ];
+			sOffset += csteps[ d ] * r.cellx;
+			switch( r.dir )
+			{
+			case BACKWARD:
+				csteps[ d ] = -csteps[ d ];
+				break;
+			case STAY:
+				csteps[ d ] = 0;
+				break;
+			}
+		}
+
+		final int dOffset = doffsets[ 0 ];
+
+		final T src = sliceAccess.getCurrentStorageArray();
+		if ( n > 1 )
+			copyRangesRecursively( src, sOffset, dest, dOffset, n - 1 );
+		else
+		{
+			final int l0 = lengths[ 0 ];
+			final int cstep0 = csteps[ 0 ];
+			memCopy.copyLines( cstep0, l0, 1, src, sOffset, 0, dest, dOffset, 0 );
+		}
+	}
+
+	private void copyRangesRecursively( final T src, final int srcPos, final T dest, final int destPos, final int d )
+	{
+		final int length = lengths[ d ];
+		final int cstep = csteps[ d ];
+		final int dstep = dsteps[ d ];
+		if ( d > 1 )
+			for ( int i = 0; i < length; ++i )
+				copyRangesRecursively( src, srcPos + i * cstep, dest, destPos + i * dstep, d - 1 );
+		else
+		{
+			final int l0 = lengths[ 0 ];
+			final int cstep0 = csteps[ 0 ];
+			memCopy.copyLines( cstep0, l0, length, src, srcPos, cstep, dest, destPos, dstep );
+		}
+	}
+
+	/**
+     * Once we get here, {@link #setupDestSize} and {@link #updateRange} for
+     * all dimensions have been called, so the {@code dsteps}, {@code
+     * doffsets}, {@code cdims}, and {@code lengths} fields have been
+     * appropriately set up for the current Range combination. Also {@code
+     * cellAccess} is positioned on the corresponding cell.
+     */
+	void fillRanges( final T dest, final int dConst )
+	{
+		final int dOffset = doffsets[ dConst ];
+		lengths[ dConst ] *= dsteps[ dConst ];
+
+		if ( n - 1 > dConst )
+			fillRangesRecursively( dest, dOffset, n - 1, dConst );
+		else
+			memCopy.copyValue( oob, 0, dest, dOffset, lengths[ dConst ] );
+	}
+
+	private void fillRangesRecursively( final T dest, final int destPos, final int d, final int dConst )
+	{
+		final int length = lengths[ d ];
+		final int dstep = dsteps[ d ];
+		if ( d > dConst + 1 )
+			for ( int i = 0; i < length; ++i )
+				fillRangesRecursively( dest, destPos + i * dstep, d - 1, dConst );
+		else
+			for ( int i = 0; i < length; ++i )
+				memCopy.copyValue( oob, 0, dest, destPos + i * dstep, lengths[ dConst ] );
+	}
+
+	static class SliceAccess< T > implements PlanarImg.PlanarContainerSampler
+	{
+		private final PlanarImg< ?, ? > planarImg;
+		private final int[] steps;
+		private final int[] pos;
+		private int i;
+
+		public SliceAccess( final PlanarImg< ?, ? > planarImg )
+		{
+			this.planarImg = planarImg;
+			final int n = planarImg.numDimensions();
+			steps = new int[ n ];
+			if ( n > 2 )
+			{
+				steps[ 2 ] = 1;
+				for ( int i = 3; i < n; ++i )
+					steps[ i ] = ( int ) planarImg.dimension( i - 1 ) * steps[ i - 1 ];
+			}
+			pos = new int[ n ];
+			i = 0;
+		}
+
+		public void setPosition( final int position, final int d )
+		{
+			if ( d >= 2 )
+			{
+				i += steps[ d ] * ( position - pos[ d ] );
+				pos[ d ] = position;
+			}
+		}
+
+		public T getCurrentStorageArray()
+		{
+			return ( T ) ( ( ( ArrayDataAccess< ? > ) planarImg.update( this ) ).getCurrentStorageArray() );
+		}
+
+		@Override
+		public int getCurrentSliceIndex()
+		{
+			return i;
+		}
+
+		// creates an independent SliceAccess on the same image
+		SliceAccess< T > copy()
+		{
+			return new SliceAccess<>( planarImg );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/blocks/PrimitiveBlocks.java
+++ b/src/main/java/net/imglib2/blocks/PrimitiveBlocks.java
@@ -1,0 +1,184 @@
+package net.imglib2.blocks;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.type.NativeType;
+import net.imglib2.util.Util;
+
+import static net.imglib2.blocks.PrimitiveBlocks.OnFallback.FAIL;
+import static net.imglib2.blocks.PrimitiveBlocks.OnFallback.WARN;
+
+
+/**
+ * Copy blocks of data out of a {@code NativeType<T>} source into primitive
+ * arrays (of the appropriate type).
+ * <p>
+ * Use the static method {@link PrimitiveBlocks#of(RandomAccessible)
+ * PrimitiveBlocks.of} to create a {@code PrimitiveBlocks} accessor for an
+ * arbitrary {@code RandomAccessible} source.
+ * Then use the {@link PrimitiveBlocks#copy} method, to copy blocks out of the
+ * source into flat primitive arrays.
+ * <p>
+ * {@link PrimitiveBlocks#of(RandomAccessible) PrimitiveBlocks.of} understands a
+ * lot of View constructions (that ultimately end in {@code CellImg}, {@code
+ * ArrayImg}, etc) and will try to build an optimized copier. For example, the
+ * following will work:
+ * <pre>{@code
+ * 		CellImg< UnsignedByteType, ? > cellImg3D;
+ * 		RandomAccessible< FloatType > view = Converters.convert(
+ * 				Views.extendBorder(
+ * 						Views.hyperSlice(
+ * 								Views.zeroMin(
+ * 										Views.rotate( cellImg3D, 1, 0 )
+ * 								),
+ * 								2, 80 )
+ * 				),
+ * 				new RealFloatConverter<>(),
+ * 				new FloatType()
+ * 		);
+ * 		PrimitiveBlocks< FloatType > blocks = PrimitiveBlocks.of( view );
+ *
+ * 		final float[] data = new float[ 40 * 50 ];
+ * 		blocks.copy( new int[] { 10, 20 }, data, new int[] { 40, 50 } );
+ * }</pre>
+ * <p>
+ * If a source {@code RandomAccessible} cannot be understood, {@link
+ * PrimitiveBlocks#of(RandomAccessible) PrimitiveBlocks.of} will return a
+ * fall-back implementation (based on {@code LoopBuilder}).
+ *
+ * With the optional {@link OnFallback OnFallback} argument to {@link
+ * PrimitiveBlocks#of(RandomAccessible, OnFallback) PrimitiveBlocks.of} it can
+ * be configured, whether
+ * fall-back should be silently accepted ({@link OnFallback#ACCEPT ACCEPT}),
+ * a warning should be printed ({@link OnFallback#WARN WARN}), or
+ * an {@code IllegalArgumentException} thrown ({@link OnFallback#FAIL FAIL}).
+ * The warning/exception message explains why the input {@code RandomAccessible}
+ * requires fall-back.
+ * <p>
+ * The only really un-supported case is if the pixel type {@code T} does not map
+ * one-to-one to a primitive type. (For example, {@code ComplexDoubleType} or
+ * {@code Unsigned4BitType} are not supported.)
+ * <p>
+ * Implementations are not thread-safe in general. Use {@link #threadSafe()} to
+ * obtain a thread-safe instance (implemented using {@link ThreadLocal} copies).
+ * E.g.,
+ * <pre{@code
+ * 		PrimitiveBlocks< FloatType > blocks = PrimitiveBlocks.of( view ).threadSafe();
+ * }</pre>
+ *
+ * @param <T>
+ * 		pixel type
+ */
+public interface PrimitiveBlocks< T extends NativeType< T > >
+{
+	T getType();
+
+	/**
+	 * Copy a block from the ({@code T}-typed) source into primitive arrays (of
+	 * the appropriate type).
+	 *
+	 * @param srcPos
+	 * 		min coordinate of the block to copy
+	 * @param dest
+	 * 		primitive array to copy into. Must correspond to {@code T}, for
+	 *      example, if {@code T} is {@code UnsignedByteType} then {@code dest} must
+	 *      be {@code byte[]}.
+	 * @param size
+	 * 		the size of the block to copy
+	 */
+	void copy( long[] srcPos, Object dest, int[] size );
+
+	/**
+	 * Copy a block from the ({@code T}-typed) source into primitive arrays (of
+	 * the appropriate type).
+	 *
+	 * @param srcPos
+	 * 		min coordinate of the block to copy
+	 * @param dest
+	 * 		primitive array to copy into. Must correspond to {@code T}, for
+	 *      example, if {@code T} is {@code UnsignedByteType} then {@code dest} must
+	 *      be {@code byte[]}.
+	 * @param size
+	 * 		the size of the block to copy
+	 */
+	default void copy( int[] srcPos, Object dest, int[] size )
+	{
+		copy( Util.int2long( srcPos ), dest, size );
+	}
+
+	/**
+	 * Get a thread-safe version of this {@code PrimitiveBlocks}.
+	 * (Implemented as a wrapper that makes {@link ThreadLocal} copies).
+	 */
+	PrimitiveBlocks< T > threadSafe();
+
+	enum OnFallback
+	{
+		ACCEPT,
+		WARN,
+		FAIL
+	}
+
+	/**
+	 * Create a {@code PrimitiveBlocks} accessor for an arbitrary {@code
+	 * RandomAccessible} source. Many View constructions (that ultimately end in
+	 * {@code CellImg}, {@code ArrayImg}, etc.) are understood and will be
+	 * handled by an optimized copier.
+	 * <p>
+	 * If the source {@code RandomAccessible} cannot be understood, a warning is
+	 * printed, and a fall-back implementation (based on {@code LoopBuilder}) is
+	 * returned.
+	 * <p>
+	 * The returned {@code PrimitiveBlocks} is not thread-safe in general. Use
+	 * {@link #threadSafe()} to obtain a thread-safe instance, e.g., {@code
+	 * PrimitiveBlocks.of(view).threadSafe()}.
+	 *
+	 * @param ra the source
+	 * @return a {@code PrimitiveBlocks} accessor for {@code ra}.
+	 * @param <T> pixel type
+	 */
+	static < T extends NativeType< T > > PrimitiveBlocks< T > of(
+			RandomAccessible< T > ra )
+	{
+		return of( ra, WARN );
+	}
+
+	/**
+	 * Create a {@code PrimitiveBlocks} accessor for an arbitrary {@code
+	 * RandomAccessible} source. Many View constructions (that ultimately end in
+	 * {@code CellImg}, {@code ArrayImg}, etc.) are understood and will be
+	 * handled by an optimized copier.
+	 * <p>
+	 * If the source {@code RandomAccessible} cannot be understood, a fall-back
+	 * implementation (based on {@code LoopBuilder}) has to be used. The {@code
+	 * onFallback} argument specifies how to handle this case:
+	 * <ul>
+	 *     <li>{@link OnFallback#ACCEPT ACCEPT}: silently accept fall-back</li>
+	 *     <li>{@link OnFallback#WARN WARN}: accept fall-back, but print a warning explaining why the input {@code ra} requires fall-back</li>
+	 *     <li>{@link OnFallback#FAIL FAIL}: throw {@code IllegalArgumentException} explaining why the input {@code ra} requires fall-back</li>
+	 * </ul>
+	 * The returned {@code PrimitiveBlocks} is not thread-safe in general. Use
+	 * {@link #threadSafe()} to obtain a thread-safe instance, e.g., {@code
+	 * PrimitiveBlocks.of(view).threadSafe()}.
+	 *
+	 * @param ra the source
+	 * @return a {@code PrimitiveBlocks} accessor for {@code ra}.
+	 * @param <T> pixel type
+	 */
+	static < T extends NativeType< T >, R extends NativeType< R > > PrimitiveBlocks< T > of(
+			RandomAccessible< T > ra,
+			OnFallback onFallback )
+	{
+		final ViewPropertiesOrError< T, R > props = ViewAnalyzer.getViewProperties( ra );
+		if ( props.isFullySupported() )
+		{
+			return new ViewPrimitiveBlocks<>( props.getViewProperties() );
+		}
+		else if ( props.isSupported() && onFallback != FAIL )
+		{
+			if ( onFallback == WARN )
+				System.err.println( props.getErrorMessage() );
+			return new FallbackPrimitiveBlocks<>( props.getFallbackProperties() );
+		}
+		throw new IllegalArgumentException( props.getErrorMessage() );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/PrimitiveBlocks.java
+++ b/src/main/java/net/imglib2/blocks/PrimitiveBlocks.java
@@ -61,7 +61,7 @@ import static net.imglib2.blocks.PrimitiveBlocks.OnFallback.WARN;
  * Implementations are not thread-safe in general. Use {@link #threadSafe()} to
  * obtain a thread-safe instance (implemented using {@link ThreadLocal} copies).
  * E.g.,
- * <pre{@code
+ * <pre>{@code
  * 		PrimitiveBlocks< FloatType > blocks = PrimitiveBlocks.of( view ).threadSafe();
  * }</pre>
  *

--- a/src/main/java/net/imglib2/blocks/PrimitiveBlocksUtils.java
+++ b/src/main/java/net/imglib2/blocks/PrimitiveBlocksUtils.java
@@ -1,0 +1,157 @@
+package net.imglib2.blocks;
+
+import java.util.Arrays;
+import java.util.function.Supplier;
+import net.imglib2.Interval;
+import net.imglib2.Point;
+import net.imglib2.RandomAccessible;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.Type;
+
+class PrimitiveBlocksUtils
+{
+	static < T extends NativeType< T > > PrimitiveBlocks< T > threadSafe( final Supplier< PrimitiveBlocks< T > > supplier )
+	{
+		final ThreadLocal< PrimitiveBlocks< T > > tl = ThreadLocal.withInitial( supplier );
+		return new PrimitiveBlocks< T >()
+		{
+			@Override
+			public T getType()
+			{
+				return tl.get().getType();
+			}
+
+			@Override
+			public void copy( final long[] srcPos, final Object dest, final int[] size )
+			{
+				tl.get().copy( srcPos, dest, size );
+			}
+
+			@Override
+			public PrimitiveBlocks< T > threadSafe()
+			{
+				return this;
+			}
+		};
+	}
+
+	static < T extends NativeType< T > > Object extractOobValue( final T type, final Extension extension )
+	{
+		if ( extension.type() == Extension.Type.CONSTANT )
+		{
+			final T oobValue = ( ( ExtensionImpl.ConstantExtension< T > ) extension ).getValue();
+			final ArrayImg< T, ? > img = new ArrayImgFactory<>( type ).create( 1 );
+			img.firstElement().set( oobValue );
+			return ( ( ArrayDataAccess< ? > ) ( img.update( null ) ) ).getCurrentStorageArray();
+		}
+		else
+			return null;
+	}
+
+	// TODO replace with ra.getType() when that is available in imglib2 core
+	static < T extends Type< T > > T getType( RandomAccessible< T > ra )
+	{
+		final Point p = new Point( ra.numDimensions() );
+		if ( ra instanceof Interval )
+			( ( Interval ) ra ).min( p );
+		return ra.getAt( p ).createVariable();
+	}
+
+	/**
+	 * Computes the inverse of (@code transform}. The {@code MixedTransform
+	 * transform} is a pure axis permutation followed by inversion of some axes,
+	 * that is
+	 * <ul>
+	 * <li>{@code numSourceDimensions == numTargetDimensions},</li>
+	 * <li>the translation vector is zero, and</li>
+	 * <li>no target component is zeroed out.</li>
+	 * </ul>
+	 * The computed inverse {@code MixedTransform} concatenates with {@code transform} to identity.
+	 * @return the inverse {@code MixedTransform}
+	 */
+	static MixedTransform invPermutationInversion( MixedTransform transform )
+	{
+		final int n = transform.numTargetDimensions();
+		final int[] component = new int[ n ];
+		final boolean[] invert = new boolean[ n ];
+		final boolean[] zero = new boolean[ n ];
+		transform.getComponentMapping( component );
+		transform.getComponentInversion( invert );
+		transform.getComponentZero( zero );
+
+		final int m = transform.numSourceDimensions();
+		final int[] invComponent = new int[ m ];
+		final boolean[] invInvert = new boolean[ m ];
+		final boolean[] invZero = new boolean[ m ];
+		Arrays.fill( invZero, true );
+		for ( int i = 0; i < n; i++ )
+		{
+			if ( transform.getComponentZero( i ) == false )
+			{
+				final int j = component[ i ];
+				invComponent[ j ] = i;
+				invInvert[ j ] = invert[ i ];
+				invZero[ j ] = false;
+			}
+		}
+		MixedTransform invTransform = new MixedTransform( n, m );
+		invTransform.setComponentMapping( invComponent );
+		invTransform.setComponentInversion( invInvert );
+		invTransform.setComponentZero( invZero );
+		return invTransform;
+	}
+
+	/**
+	 * Split {@code transform} into
+	 * <ol>
+	 * <li>{@code permuteInvert}, a pure axis permutation followed by inversion of some axes, and</li>
+	 * <li>{@code remainder}, a remainder transformation,</li>
+	 * </ol>
+	 * such that {@code remainder * permuteInvert == transform}.
+	 *
+	 * @param transform transform to decompose
+	 * @return {@code MixedTransform[]} array of {@code {permuteInvert, remainder}}
+	 */
+	static MixedTransform[] split( MixedTransform transform )
+	{
+		final int n = transform.numTargetDimensions();
+		final int[] component = new int[ n ];
+		final boolean[] invert = new boolean[ n ];
+		final boolean[] zero = new boolean[ n ];
+		final long[] translation = new long[ n ];
+		transform.getComponentMapping( component );
+		transform.getComponentInversion( invert );
+		transform.getComponentZero( zero );
+		transform.getTranslation( translation );
+
+		final int m = transform.numSourceDimensions();
+		final int[] splitComponent = new int[ m ];
+		final boolean[] splitInvert = new boolean[ m ];
+
+		int j = 0;
+		for ( int i = 0; i < n; i++ )
+		{
+			if ( !zero[ i ] )
+			{
+				splitComponent[ j ] = component[ i ];
+				splitInvert[ j ] = invert[ i ];
+				component[ i ] = j++;
+			}
+		}
+
+		final MixedTransform permuteInvert = new MixedTransform( m, m );
+		permuteInvert.setComponentMapping( splitComponent );
+		permuteInvert.setComponentInversion( splitInvert );
+
+		final MixedTransform remainder = new MixedTransform( m, n );
+		remainder.setComponentMapping( component );
+		remainder.setComponentZero( zero );
+		remainder.setTranslation( translation );
+
+		return new MixedTransform[] { permuteInvert, remainder };
+	}
+}

--- a/src/main/java/net/imglib2/blocks/PrimitiveBlocksUtils.java
+++ b/src/main/java/net/imglib2/blocks/PrimitiveBlocksUtils.java
@@ -11,12 +11,13 @@ import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
 import net.imglib2.transform.integer.MixedTransform;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
+import net.imglib2.util.CloseableThreadLocal;
 
 class PrimitiveBlocksUtils
 {
 	static < T extends NativeType< T > > PrimitiveBlocks< T > threadSafe( final Supplier< PrimitiveBlocks< T > > supplier )
 	{
-		final ThreadLocal< PrimitiveBlocks< T > > tl = ThreadLocal.withInitial( supplier );
+		final CloseableThreadLocal< PrimitiveBlocks< T > > tl = CloseableThreadLocal.withInitial( supplier );
 		return new PrimitiveBlocks< T >()
 		{
 			@Override

--- a/src/main/java/net/imglib2/blocks/PrimitiveTypeProperties.java
+++ b/src/main/java/net/imglib2/blocks/PrimitiveTypeProperties.java
@@ -1,0 +1,105 @@
+package net.imglib2.blocks;
+
+import java.util.EnumMap;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.ToIntFunction;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.array.BooleanArray;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.CharArray;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.type.PrimitiveType;
+
+import static net.imglib2.type.PrimitiveType.BOOLEAN;
+import static net.imglib2.type.PrimitiveType.BYTE;
+import static net.imglib2.type.PrimitiveType.CHAR;
+import static net.imglib2.type.PrimitiveType.DOUBLE;
+import static net.imglib2.type.PrimitiveType.FLOAT;
+import static net.imglib2.type.PrimitiveType.INT;
+import static net.imglib2.type.PrimitiveType.LONG;
+import static net.imglib2.type.PrimitiveType.SHORT;
+
+/**
+ * @param <P> a primitive array type, e.g., {@code byte[]}.
+ * @param <A> the corresponding {@code ArrayDataAccess} type.
+ */
+class PrimitiveTypeProperties< P, A extends ArrayDataAccess< A > >
+{
+	final Class< P > primitiveArrayClass;
+
+	final IntFunction< P > createPrimitiveArray;
+
+	final ToIntFunction< P > primitiveArrayLength;
+
+	final Function< P, A > wrapAsAccess;
+
+	static PrimitiveTypeProperties< ?, ? > get( final PrimitiveType primitiveType )
+	{
+		final PrimitiveTypeProperties< ?, ? > props = creators.get( primitiveType );
+		if ( props == null )
+			throw new IllegalArgumentException();
+		return props;
+	}
+
+	/**
+	 * Wrap a primitive array {@code data} into a corresponding {@code ArrayDataAccess}.
+	 *
+	 * @param data primitive array to wrap (actually type {@code P} instead of {@code Object}, but its easier to use this way)
+	 * @return {@code ArrayDataAccess} wrapping {@code data}
+	 */
+	A wrap( Object data )
+	{
+		if ( data == null )
+			throw new NullPointerException();
+		if ( !primitiveArrayClass.isInstance( data ) )
+			throw new IllegalArgumentException( "expected " + primitiveArrayClass.getSimpleName() + " argument" );
+		return wrapAsAccess.apply( ( P ) data );
+	}
+
+	/**
+	 * Allocate a primitive array (type {@code P}) with {@code length} elements.
+	 */
+	P allocate( int length )
+	{
+		return createPrimitiveArray.apply( length );
+	}
+
+	/**
+	 * Get the length of a primitive array (type {@code P}).
+	 */
+	int length( P array )
+	{
+		return primitiveArrayLength.applyAsInt( array );
+	}
+
+	private PrimitiveTypeProperties(
+			final Class< P > primitiveArrayClass,
+			final IntFunction< P > createPrimitiveArray,
+			final ToIntFunction< P > primitiveArrayLength,
+			final Function< P, A > wrapAsAccess )
+	{
+		this.primitiveArrayClass = primitiveArrayClass;
+		this.createPrimitiveArray = createPrimitiveArray;
+		this.primitiveArrayLength = primitiveArrayLength;
+		this.wrapAsAccess = wrapAsAccess;
+	}
+
+	private static final EnumMap< PrimitiveType, PrimitiveTypeProperties< ?, ? > > creators = new EnumMap<>( PrimitiveType.class );
+
+	static
+	{
+		creators.put( BOOLEAN, new PrimitiveTypeProperties<>( boolean[].class, boolean[]::new, a -> a.length, BooleanArray::new ) );
+		creators.put( BYTE, new PrimitiveTypeProperties<>( byte[].class, byte[]::new, a -> a.length, ByteArray::new ) );
+		creators.put( CHAR, new PrimitiveTypeProperties<>( char[].class, char[]::new, a -> a.length, CharArray::new ) );
+		creators.put( SHORT, new PrimitiveTypeProperties<>( short[].class, short[]::new, a -> a.length, ShortArray::new ) );
+		creators.put( INT, new PrimitiveTypeProperties<>( int[].class, int[]::new, a -> a.length, IntArray::new ) );
+		creators.put( LONG, new PrimitiveTypeProperties<>( long[].class, long[]::new, a -> a.length, LongArray::new ) );
+		creators.put( FLOAT, new PrimitiveTypeProperties<>( float[].class, float[]::new, a -> a.length, FloatArray::new ) );
+		creators.put( DOUBLE, new PrimitiveTypeProperties<>( double[].class, double[]::new, a -> a.length, DoubleArray::new ) );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/RangeCopier.java
+++ b/src/main/java/net/imglib2/blocks/RangeCopier.java
@@ -1,0 +1,58 @@
+package net.imglib2.blocks;
+
+import net.imglib2.img.NativeImg;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.cell.AbstractCellImg;
+import net.imglib2.img.cell.Cell;
+import net.imglib2.img.planar.PlanarImg;
+
+/**
+ * {@code RangeCopier} does the actual copying work from a {@code NativeImg}
+ * into a primitive array.
+ * <p>
+ * The static {@link RangeCopier#create} method will pick the correct
+ * implementation for a given {@NativeImg}.
+ *
+ * @param <T> a primitive array type, e.g., {@code byte[]}.
+ */
+interface RangeCopier< T >
+{
+	/**
+	 * Copy the block starting at {@code srcPos} with the given {@code size}
+	 * into the (appropriately sized) {@code dest} array.
+	 *
+	 * @param srcPos
+	 * 		min coordinates of block to copy from src Img.
+	 * @param dest
+	 * 		destination array. Type is {@code byte[]}, {@code float[]},
+	 * 		etc, corresponding to the src Img's native type.
+	 * @param size
+	 * 		dimensions of block to copy from src Img.
+	 */
+	void copy( final long[] srcPos, final T dest, final int[] size );
+
+	/**
+	 * Return a new independent instance of this {@code RangeCopier}. This is
+	 * used for multi-threading. The new instance works on the same source
+	 * image, but has independent internal state.
+	 *
+	 * @return new independent instance of this {@code RangeCopier}
+	 */
+	RangeCopier< T > newInstance();
+
+	static < T > RangeCopier< T > create(
+			final NativeImg< ?, ? > img,
+			final Ranges findRanges,
+			final MemCopy< T > memCopy,
+			final T oob )
+	{
+		if ( img instanceof AbstractCellImg )
+			return new CellImgRangeCopier<>( ( AbstractCellImg< ?, ?, ? extends Cell< ? >, ? > ) img, findRanges, memCopy, oob );
+		else if ( img instanceof PlanarImg )
+			return new PlanarImgRangeCopier<>( ( PlanarImg< ?, ? > ) img, findRanges, memCopy, oob );
+		else if ( img instanceof ArrayImg )
+			return new ArrayImgRangeCopier<>( ( ArrayImg<?, ?> ) img, findRanges, memCopy, oob );
+		else
+			throw new IllegalArgumentException();
+	}
+}

--- a/src/main/java/net/imglib2/blocks/Ranges.java
+++ b/src/main/java/net/imglib2/blocks/Ranges.java
@@ -1,0 +1,134 @@
+package net.imglib2.blocks;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Find {@link Ranges.Range ranges} for one dimension.
+ * <p>
+ * Split the requested interval into ranges covering (possibly partial)
+ * cells of the input image. The requested interval is given by start
+ * coordinate {@code bx} (in the extended source image) and size of the
+ * block to copy {@code bw}, in a particular dimension. The full size of the
+ * (non-extended) image in this dimension is given by {@code iw}, the size
+ * of a (non-truncated) cell in this dimension is given by {@code cw}.
+ * <p>
+ * Out-of-bounds values are handled depending on {@code Extension} strategy.
+ * Use {@link #forExtension(Extension)} to pick a particular strategy.
+ */
+@FunctionalInterface
+interface Ranges
+{
+	/**
+	 * Find ranges for one dimension.
+	 * <p>
+	 * Split the requested interval into ranges covering (possibly partial)
+	 * cells of the input image. The requested interval is given by start
+	 * coordinate {@code bx} (in the extended source image) and size of the
+	 * block to copy {@code bw}, in a particular dimension. The full size of the
+	 * (non-extended) image in this dimension is given by {@code iw}, the size
+	 * of a (non-truncated) cell in this dimension is given by {@code cw}.
+	 * <p>
+	 * Out-of-bounds values are handled depending on {@code Extension} strategy.
+	 * Use {@link #forExtension(Extension)} to pick a particular strategy.
+	 *
+	 * @param bx
+	 * 		start of block in source coordinates (in pixels)
+	 * @param bw
+	 * 		width of block to copy (in pixels)
+	 * @param iw
+	 * 		source image width (in pixels)
+	 * @param cw
+	 * 		source cell width (in pixels)
+	 */
+	List< Range > findRanges( long bx, int bw, long iw, int cw );
+
+	/**
+	 *
+	 * CONSTANT: Out-of-bounds values are set to a constant.
+	 * @param extension
+	 * @return
+	 */
+	static Ranges forExtension( Extension extension )
+	{
+		switch ( extension.type() )
+		{
+		case CONSTANT:
+			return RangesImpl.FIND_RANGES_CONSTANT;
+		case MIRROR_SINGLE:
+			return RangesImpl.FIND_RANGES_MIRROR_SINGLE;
+		case MIRROR_DOUBLE:
+			return RangesImpl.FIND_RANGES_MIRROR_DOUBLE;
+		case BORDER:
+			return RangesImpl.FIND_RANGES_BORDER;
+		default:
+			throw new IllegalArgumentException( "Extension type not supported: " + extension.type() );
+		}
+	}
+
+	// TODO javadoc
+	//    FORWARD
+	//    BACKWARD
+	//    STAY do not move, always take the same input value (used for border extension)
+	//    CONSTANT don't take value from input (use constant OOB value instead)
+	enum Direction
+	{
+		FORWARD,
+		BACKWARD,
+		STAY,
+		CONSTANT;
+	}
+
+	/**
+	 * Instructions for copying along a particular dimension. (To copy an <em>n</em>-dimensional
+	 * region, <em>n</em> Ranges are combined.)
+	 * <p>
+	 * Copy {@code w} elements to coordinates {@code x} through {@code x + w}
+	 * (exclusive) in destination, from source cell with {@code gridx} grid
+	 * coordinate, starting at coordinate {@code cellx} within cell, and from
+	 * there moving in {@code dir} for successive source elements.
+	 * <p>
+	 * It is guaranteed that all {@code w} elements fall within the same cell
+	 * (i.e., primitive array).
+	 */
+	class Range
+	{
+		final int gridx;
+		final int cellx;
+		final int w;
+		final Direction dir;
+		final int x;
+
+		public Range( final int gridx, final int cellx, final int w, final Direction dir, final int x )
+		{
+			this.gridx = gridx;
+			this.cellx = cellx;
+			this.w = w;
+			this.dir = dir;
+			this.x = x;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Range{gridx=" + gridx + ", cellx=" + cellx + ", w=" + w + ", dir=" + dir + ", x=" + x + '}';
+		}
+
+		@Override
+		public boolean equals( final Object o )
+		{
+			if ( this == o )
+				return true;
+			if ( o == null || getClass() != o.getClass() )
+				return false;
+			final Range range = ( Range ) o;
+			return gridx == range.gridx && cellx == range.cellx && w == range.w && x == range.x && dir == range.dir;
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return Objects.hash( gridx, cellx, w, dir, x );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/blocks/RangesImpl.java
+++ b/src/main/java/net/imglib2/blocks/RangesImpl.java
@@ -1,0 +1,359 @@
+package net.imglib2.blocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.imglib2.blocks.Ranges.Direction.BACKWARD;
+import static net.imglib2.blocks.Ranges.Direction.CONSTANT;
+import static net.imglib2.blocks.Ranges.Direction.FORWARD;
+import static net.imglib2.blocks.Ranges.Direction.STAY;
+
+class RangesImpl
+{
+	static Ranges FIND_RANGES_CONSTANT = RangesImpl::findRanges_constant;
+	static Ranges FIND_RANGES_MIRROR_SINGLE = RangesImpl::findRanges_mirror_single;
+	static Ranges FIND_RANGES_MIRROR_DOUBLE = RangesImpl::findRanges_mirror_double;
+	static Ranges FIND_RANGES_BORDER = RangesImpl::findRanges_border;
+
+	/**
+	 * Find ranges for one dimension.
+	 * <p>
+	 * Out-of-bounds values are set to a constant.
+	 * <p>
+	 * Split the requested interval into ranges covering (possibly partial)
+	 * cells of the input image. The requested interval is given by start
+	 * coordinate {@code bx} (in the extended source image) and size of the
+	 * block to copy {@code bw}, in a particular dimension. The full size of the
+	 * (non-extended) image in this dimension is given by {@code iw}, the size
+	 * of a (non-truncated) cell in this dimension is given by {@code cw}.
+	 *
+	 * @param bx
+	 * 		start of block in source coordinates (in pixels)
+	 * @param bw
+	 * 		width of block to copy (in pixels)
+	 * @param iw
+	 * 		source image width (in pixels)
+	 * @param cw
+	 * 		source cell width (in pixels)
+	 */
+	static List< Ranges.Range > findRanges_constant(
+			long bx, // start of block in source coordinates (in pixels)
+			int bw, // width of block to copy (in pixels)
+			final long iw, // source image width (in pixels)
+			final int cw  // source cell width (in pixels)
+	)
+	{
+		List< Ranges.Range > ranges = new ArrayList<>();
+
+		if ( bw <= 0 )
+			return ranges;
+
+		int x = 0;
+		if ( bx < 0 )
+		{
+			int w = ( int ) Math.min( bw, -bx );
+			ranges.add( new Ranges.Range( -1, -1, w, CONSTANT, x ) );
+			bw -= w;
+			bx += w; // = 0
+			x += w;
+		}
+
+		if ( bw <= 0 )
+			return ranges;
+
+		int gx = ( int ) ( bx / cw );
+		int cx = ( int ) ( bx - ( ( long ) gx * cw ) );
+		while ( bw > 0 && bx < iw )
+		{
+			final int w = Math.min( bw, cellWidth( gx, cw, iw ) - cx );
+			ranges.add( new Ranges.Range( gx, cx, w, FORWARD, x ) );
+			bw -= w;
+			bx += w;
+			x += w;
+			++gx;
+			cx = 0;
+		}
+
+		if ( bw > 0 )
+			ranges.add( new Ranges.Range( -1, -1, bw, CONSTANT, x ) );
+
+		return ranges;
+	}
+
+	/**
+	 * Find ranges for one dimension.
+	 * <p>
+	 * Out-of-bounds values are determined by border extension (clamping to
+	 * the nearest pixel in the image).
+	 * <p>
+	 * Split the requested interval into ranges covering (possibly partial)
+	 * cells of the input image. The requested interval is given by start
+	 * coordinate {@code bx} (in the extended source image) and size of the
+	 * block to copy {@code bw}, in a particular dimension. The full size of the
+	 * (non-extended) image in this dimension is given by {@code iw}, the size
+	 * of a (non-truncated) cell in this dimension is given by {@code cw}.
+	 *
+	 * @param bx
+	 * 		start of block in source coordinates (in pixels)
+	 * @param bw
+	 * 		width of block to copy (in pixels)
+	 * @param iw
+	 * 		source image width (in pixels)
+	 * @param cw
+	 * 		source cell width (in pixels)
+	 */
+	static List< Ranges.Range > findRanges_border(
+			long bx, // start of block in source coordinates (in pixels)
+			int bw, // width of block to copy (in pixels)
+			final long iw, // source image width (in pixels)
+			final int cw  // source cell width (in pixels)
+	)
+	{
+		List< Ranges.Range > ranges = new ArrayList<>();
+
+		if ( bw <= 0 )
+			return ranges;
+
+		int x = 0;
+		if ( bx < 0 )
+		{
+			int w = ( int ) Math.min( bw, -bx );
+			ranges.add( new Ranges.Range( 0, 0, w, STAY, x ) );
+			bw -= w;
+			bx += w; // = 0
+			x += w;
+		}
+
+		if ( bw <= 0 )
+			return ranges;
+
+		int gx = ( int ) ( bx / cw );
+		int cx = ( int ) ( bx - ( ( long ) gx * cw ) );
+		while ( bw > 0 && bx < iw )
+		{
+			final int w = Math.min( bw, cellWidth( gx, cw, iw ) - cx );
+			ranges.add( new Ranges.Range( gx, cx, w, FORWARD, x ) );
+			bw -= w;
+			bx += w;
+			x += w;
+			++gx;
+			cx = 0;
+		}
+
+		if ( bw <= 0 )
+			return ranges;
+
+		gx = ( int ) ( ( iw - 1 ) / cw );
+		cx = cellWidth( gx, cw, iw ) - 1;
+		ranges.add( new Ranges.Range( gx, cx, bw, STAY, x ) );
+
+		return ranges;
+	}
+
+	/**
+	 * Find ranges for one dimension.
+	 * <p>
+	 * Out-of-bounds values are determined by mirroring with double boundary,
+	 * i.e., border pixels are repeated.
+	 * <p>
+	 * Split the requested interval into ranges covering (possibly partial)
+	 * cells of the input image. The requested interval is given by start
+	 * coordinate {@code bx} (in the extended source image) and size of the
+	 * block to copy {@code bw}, in a particular dimension. The full size of the
+	 * (non-extended) image in this dimension is given by {@code iw}, the size
+	 * of a (non-truncated) cell in this dimension is given by {@code cw}.
+	 *
+	 * @param bx
+	 * 		start of block in source coordinates (in pixels)
+	 * @param bw
+	 * 		width of block to copy (in pixels)
+	 * @param iw
+	 * 		source image width (in pixels)
+	 * @param cw
+	 * 		source cell width (in pixels)
+	 */
+	static List< Ranges.Range > findRanges_mirror_double(
+			long bx, // start of block in source coordinates (in pixels)
+			int bw, // width of block to copy (in pixels)
+			final long iw, // source image width (in pixels)
+			final int cw  // source cell width (in pixels)
+	)
+	{
+		List< Ranges.Range > ranges = new ArrayList<>();
+
+		final long pi = 2 * iw;
+		bx = ( bx < 0 )
+				? ( bx + 1 ) % pi + pi - 1
+				: bx % pi;
+		Ranges.Direction dir = FORWARD;
+		if ( bx >= iw )
+		{
+			bx = pi - 1 - bx;
+			dir = BACKWARD;
+		}
+
+		int gx = ( int ) ( bx / cw );
+		int cx = ( int ) ( bx - ( ( long ) gx * cw ) );
+		int x = 0;
+		while ( bw > 0 )
+		{
+			if ( dir == FORWARD )
+			{
+				final int gxw = cellWidth( gx, cw, iw );
+				final int w = Math.min( bw, gxw - cx );
+				final Ranges.Range range = new Ranges.Range( gx, cx, w, FORWARD, x );
+				ranges.add( range );
+
+				bw -= w;
+				x += w;
+
+				if ( ( long ) ++gx * cw >= iw ) // moving out of bounds
+				{
+					--gx;
+					cx = gxw - 1;
+					dir = BACKWARD;
+				}
+				else
+				{
+					cx = 0;
+				}
+			}
+			else // dir == BACKWARD
+			{
+				final int w = Math.min( bw, cx + 1 );
+				final Ranges.Range range = new Ranges.Range( gx, cx, w, BACKWARD, x );
+				ranges.add( range );
+
+				bw -= w;
+				x += w;
+
+				if ( gx == 0 ) // moving into bounds
+				{
+					cx = 0;
+					dir = FORWARD;
+				}
+				else
+				{
+					cx = cellWidth( --gx, cw, iw ) - 1;
+				}
+			}
+
+		}
+		return ranges;
+	}
+
+	/**
+	 * Find ranges for one dimension.
+	 * <p>
+	 * Out-of-bounds values are determined by mirroring with single boundary,
+	 * i.e., border pixels are not repeated.
+	 * <p>
+	 * Split the requested interval into ranges covering (possibly partial)
+	 * cells of the input image. The requested interval is given by start
+	 * coordinate {@code bx} (in the extended source image) and size of the
+	 * block to copy {@code bw}, in a particular dimension. The full size of the
+	 * (non-extended) image in this dimension is given by {@code iw}, the size
+	 * of a (non-truncated) cell in this dimension is given by {@code cw}.
+	 *
+	 * @param bx
+	 * 		start of block in source coordinates (in pixels)
+	 * @param bw
+	 * 		width of block to copy (in pixels)
+	 * @param iw
+	 * 		source image width (in pixels)
+	 * @param cw
+	 * 		source cell width (in pixels)
+	 */
+	static List< Ranges.Range > findRanges_mirror_single(
+			long bx, // start of block in source coordinates (in pixels)
+			int bw, // width of block to copy (in pixels)
+			final long iw, // source image width (in pixels)
+			final int cw  // source cell width (in pixels)
+	)
+	{
+		List< Ranges.Range > ranges = new ArrayList<>();
+
+		final long pi = 2 * iw - 2;
+		bx = ( bx < 0 )
+				? ( bx + 1 ) % pi + pi - 1
+				: bx % pi;
+		Ranges.Direction dir = FORWARD;
+		if ( bx >= iw )
+		{
+			bx = pi - bx;
+			dir = BACKWARD;
+		}
+
+		int gx = ( int ) ( bx / cw );
+		int cx = ( int ) ( bx - ( ( long ) gx * cw ) );
+		int x = 0;
+		while ( bw > 0 )
+		{
+			if ( dir == FORWARD )
+			{
+				final int gxw = cellWidth( gx, cw, iw );
+				final int w = Math.min( bw, gxw - cx );
+				final Ranges.Range range = new Ranges.Range( gx, cx, w, FORWARD, x );
+				ranges.add( range );
+
+				bw -= w;
+				x += w;
+
+				if ( ( long ) ++gx * cw >= iw ) // moving out of bounds
+				{
+					--gx;
+					cx = gxw - 2;
+					dir = BACKWARD;
+				}
+				else
+				{
+					cx = 0;
+				}
+			}
+			else // dir == BACKWARD
+			{
+				final int w = Math.min( bw, gx == 0 ? cx : ( cx + 1 ) );
+				final Ranges.Range range = new Ranges.Range( gx, cx, w, BACKWARD, x );
+				ranges.add( range );
+
+				bw -= w;
+				x += w;
+
+				if ( gx == 0 ) // moving into bounds
+				{
+					cx = 0;
+					dir = FORWARD;
+				}
+				else
+				{
+					cx = cellWidth( --gx, cw, iw ) - 1;
+				}
+			}
+
+		}
+		return ranges;
+	}
+
+	/**
+	 * Get width of a cell (depending on whether it's an inner cell or a border cell).
+	 *
+	 * @param gx
+	 * 		grid coordinate of the cell
+	 * @param cw
+	 * 		cell width (of grid)
+	 * @param iw
+	 * 		image width
+	 *
+	 * @return cell width
+	 */
+	private static int cellWidth( final int gx, final int cw, final long iw )
+	{
+		final int gw = ( int ) ( iw / cw );
+		if ( gx < gw )
+			return cw;
+		else if ( gx == gw )
+			return ( int ) ( iw - cw * gw );
+		else
+			throw new IllegalArgumentException();
+	}
+}

--- a/src/main/java/net/imglib2/blocks/TempArray.java
+++ b/src/main/java/net/imglib2/blocks/TempArray.java
@@ -13,14 +13,15 @@ import net.imglib2.type.PrimitiveType;
  * @param <T> a primitive array type
  */
 // TODO: make public? This will be reused in blk algorithms probably?
-interface TempArray< T >
+public interface TempArray< T >
 {
 	T get( final int minSize );
 
 	TempArray<T> newInstance();
 
-	static TempArray< ? > forPrimitiveType( PrimitiveType primitiveType )
+	@SuppressWarnings( { "unchecked" } )
+	static < T > TempArray< T > forPrimitiveType( PrimitiveType primitiveType )
 	{
-		return new TempArrayImpl<>( PrimitiveTypeProperties.get( primitiveType ) );
+		return ( TempArray< T > ) new TempArrayImpl<>( PrimitiveTypeProperties.get( primitiveType ) );
 	}
 }

--- a/src/main/java/net/imglib2/blocks/TempArray.java
+++ b/src/main/java/net/imglib2/blocks/TempArray.java
@@ -1,0 +1,26 @@
+package net.imglib2.blocks;
+
+import net.imglib2.type.PrimitiveType;
+
+/**
+ * Provides a temporary array of type {@code T}.
+ * <p>
+ * {@link #get} returns an array of type {@code T} with at least the specified
+ * length. If {@code get} is called multiple times, it will either return a
+ * previously returned array if it has at least requested length, or allocate a
+ * new array, if the requested length exceeds the previously allocated length.
+ *
+ * @param <T> a primitive array type
+ */
+// TODO: make public? This will be reused in blk algorithms probably?
+interface TempArray< T >
+{
+	T get( final int minSize );
+
+	TempArray<T> newInstance();
+
+	static TempArray< ? > forPrimitiveType( PrimitiveType primitiveType )
+	{
+		return new TempArrayImpl<>( PrimitiveTypeProperties.get( primitiveType ) );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/TempArrayImpl.java
+++ b/src/main/java/net/imglib2/blocks/TempArrayImpl.java
@@ -1,22 +1,28 @@
 package net.imglib2.blocks;
 
+import java.lang.ref.WeakReference;
+
 class TempArrayImpl< T > implements TempArray< T >
 {
 	private final PrimitiveTypeProperties< T, ? > props;
 
-	private T array;
+	private WeakReference< T > arrayRef;
 
 	TempArrayImpl( PrimitiveTypeProperties< T, ? > props )
 	{
+		arrayRef = new WeakReference<>( null );
 		this.props = props;
-		array = props.allocate( 0 );
 	}
 
 	@Override
 	public T get( final int minSize )
 	{
-		if ( props.length( array ) < minSize )
+		T array = arrayRef.get();
+		if ( array == null || props.length( array ) < minSize )
+		{
 			array = props.allocate( minSize );
+			arrayRef = new WeakReference<>( array );
+		}
 		return array;
 	}
 

--- a/src/main/java/net/imglib2/blocks/TempArrayImpl.java
+++ b/src/main/java/net/imglib2/blocks/TempArrayImpl.java
@@ -1,0 +1,28 @@
+package net.imglib2.blocks;
+
+class TempArrayImpl< T > implements TempArray< T >
+{
+	private final PrimitiveTypeProperties< T, ? > props;
+
+	private T array;
+
+	TempArrayImpl( PrimitiveTypeProperties< T, ? > props )
+	{
+		this.props = props;
+		array = props.allocate( 0 );
+	}
+
+	@Override
+	public T get( final int minSize )
+	{
+		if ( props.length( array ) < minSize )
+			array = props.allocate( minSize );
+		return array;
+	}
+
+	@Override
+	public TempArray< T > newInstance()
+	{
+		return new TempArrayImpl<>( props );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/ViewAnalyzer.java
+++ b/src/main/java/net/imglib2/blocks/ViewAnalyzer.java
@@ -1,0 +1,628 @@
+package net.imglib2.blocks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import net.imglib2.RandomAccessible;
+import net.imglib2.blocks.ViewNode.ConverterViewNode;
+import net.imglib2.blocks.ViewNode.DefaultViewNode;
+import net.imglib2.blocks.ViewNode.ExtensionViewNode;
+import net.imglib2.blocks.ViewNode.MixedTransformViewNode;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.read.ConvertedRandomAccessible;
+import net.imglib2.converter.read.ConvertedRandomAccessibleInterval;
+import net.imglib2.img.ImgView;
+import net.imglib2.img.NativeImg;
+import net.imglib2.img.WrappedImg;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.cell.AbstractCellImg;
+import net.imglib2.img.planar.PlanarImg;
+import net.imglib2.transform.integer.BoundingBox;
+import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.Type;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.ExtendedRandomAccessibleInterval;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.MixedTransformView;
+
+import static net.imglib2.blocks.PrimitiveBlocksUtils.getType;
+
+class ViewAnalyzer
+{
+	/**
+	 * The target {@code RandomAccessible}, that is, the View to analyze.
+	 */
+	private final RandomAccessible< ? > ra;
+
+	/**
+	 * View sequence of the target {@code RandomAccessible}. The first element
+	 * is the target {@code RandomAccessible} itself. The last element is the
+	 * source {@code NativeImg} where the View sequence originates.
+	 */
+	private final List< ViewNode > nodes = new ArrayList<>();
+
+	private final StringBuilder errorDescription = new StringBuilder();
+
+	private ViewAnalyzer( final RandomAccessible< ? > ra )
+	{
+		this.ra = ra;
+	}
+
+	/**
+	 * Check whether the pixel {@code Type} of the View is supported. All {@code
+	 * NativeType}s with {@code entitiesPerPixel==1} are supported.
+	 *
+	 * @return {@code true}, if the view's pixel type is supported.
+	 */
+	private < T extends Type< T > > boolean checkViewTypeSupported()
+	{
+		final T type = getType( ( RandomAccessible< T > ) ra );
+		if ( type instanceof NativeType
+				&& ( ( NativeType ) type ).getEntitiesPerPixel().getRatio() == 1 )
+		{
+			return true;
+		}
+		else
+		{
+			errorDescription.append(
+					"The pixel Type of the View must be a NativeType with entitiesPerPixel==1. (Found "
+							+ type.getClass().getSimpleName() + ")" );
+			return false;
+		}
+	}
+
+	/**
+	 * Deconstruct the View sequence of the target {@link #ra RandomAccessible}
+	 * into a list of {@link #nodes ViewNodes}.
+	 *
+	 * @return {@code false}, if during the analysis a View type is encountered that can not be handled.
+	 *         {@code true}, if everything went ok.
+	 */
+	private boolean analyze()
+	{
+		RandomAccessible< ? > source = ra;
+		while ( source != null )
+		{
+			// NATIVE_IMG,
+			if ( source instanceof NativeImg )
+			{
+				final NativeImg< ?, ? > view = ( NativeImg< ?, ? > ) source;
+				nodes.add( new DefaultViewNode( ViewNode.ViewType.NATIVE_IMG, view ) );
+				source = null;
+			}
+			// IDENTITY,
+			else if ( source instanceof WrappedImg )
+			{
+				final WrappedImg< ? > view = ( WrappedImg< ? > ) source;
+				nodes.add( new DefaultViewNode( ViewNode.ViewType.IDENTITY, source ) );
+				source = view.getImg();
+			}
+			else if ( source instanceof ImgView )
+			{
+				final ImgView< ? > view = ( ImgView< ? > ) source;
+				nodes.add( new DefaultViewNode( ViewNode.ViewType.IDENTITY, view ) );
+				source = view.getSource();
+			}
+			// INTERVAL,
+			else if ( source instanceof IntervalView )
+			{
+				final IntervalView< ? > view = ( IntervalView< ? > ) source;
+				nodes.add( new DefaultViewNode( ViewNode.ViewType.INTERVAL, view ) );
+				source = view.getSource();
+			}
+			// CONVERTER,
+			else if ( source instanceof ConvertedRandomAccessible )
+			{
+				final ConvertedRandomAccessible< ?, ? > view = ( ConvertedRandomAccessible< ?, ? > ) source;
+				nodes.add( new ConverterViewNode<>( view ) );
+				source = view.getSource();
+			}
+			else if ( source instanceof ConvertedRandomAccessibleInterval )
+			{
+				final ConvertedRandomAccessibleInterval< ?, ? > view = ( ConvertedRandomAccessibleInterval< ?, ? > ) source;
+				nodes.add( new ConverterViewNode<>( view ) );
+				source = view.getSource();
+			}
+			// MIXED_TRANSFORM,
+			else if ( source instanceof MixedTransformView )
+			{
+				final MixedTransformView< ? > view = ( MixedTransformView< ? > ) source;
+				nodes.add( new MixedTransformViewNode( view ) );
+				source = view.getSource();
+			}
+			// EXTENSION
+			else if ( source instanceof ExtendedRandomAccessibleInterval )
+			{
+				ExtendedRandomAccessibleInterval< ?, ? > view = ( ExtendedRandomAccessibleInterval< ?, ? > ) source;
+				nodes.add( new ExtensionViewNode( view ) );
+				source = view.getSource();
+			}
+			// fallback
+			else
+			{
+				errorDescription.append( "Cannot analyze view " + source + " of class " + source.getClass().getSimpleName() );
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Check whether the root of the View sequence is supported. Supported roots
+	 * are {@code PlanarImg}, {@code ArrayImg}, and {@code CellImg} variants.
+	 *
+	 * @return {@code true}, if the root is supported.
+	 */
+	private boolean checkRootSupported()
+	{
+		final ViewNode root = nodes.get( nodes.size() - 1 );
+		if ( root.viewType() != ViewNode.ViewType.NATIVE_IMG )
+		{
+			errorDescription.append( "The root of the View sequence must be a NativeImg. (Found "
+					+ root.view() + " of class " + root.view().getClass().getSimpleName() + ")" );
+			return false;
+		}
+		if ( ( root.view() instanceof PlanarImg )
+				|| ( root.view() instanceof ArrayImg )
+				|| ( root.view() instanceof AbstractCellImg ) )
+		{
+			return true;
+		}
+		else
+		{
+			errorDescription.append(
+					"The root of the View sequence must be PlanarImg, ArrayImg, or AbstractCellImg. (Found "
+							+ root.view() + " of class " + root.view().getClass().getSimpleName() + ")" );
+			return false;
+		}
+	}
+
+	/**
+	 * Check whether the pixel {@code Type} of the root of the View sequence is
+	 * supported. All {@code NativeType}s with {@code entitiesPerPixel==1} are
+	 * supported.
+	 *
+	 * @return {@code true}, if the root's pixel type is supported.
+	 */
+	private boolean checkRootTypeSupported()
+	{
+		final ViewNode root = nodes.get( nodes.size() - 1 );
+		final NativeType< ? > type = ( NativeType< ? > ) ( ( NativeImg< ?, ? > ) root.view() ).createLinkedType();
+		if ( type.getEntitiesPerPixel().getRatio() == 1 )
+		{
+			return true;
+		}
+		else
+		{
+			errorDescription.append(
+					"The pixel Type of root of the View sequence must be a NativeType with entitiesPerPixel==1. (Found "
+							+ type.getClass().getSimpleName() + ")" );
+			return false;
+		}
+	}
+
+	/**
+	 * The index of the out-of-bounds extension in {@link #nodes}.
+	 */
+	private int oobIndex = -1;
+
+	/**
+	 * The description of the out-of-bounds extension.
+	 */
+	private Extension oobExtension = null;
+
+
+	/**
+	 * Check whether there is at most one out-of-bounds extension.
+	 * If an extension is found, store its index into {@link #oobIndex},
+	 * and its description into {@link #oobExtension}.
+	 *
+	 * @return {@code true}, if there is at most one out-of-bounds extension.
+	 *         {@code false}, otherwise
+	 */
+	private boolean checkExtensions1()
+	{
+		// TODO: This could be weakened to allow for extensions that are
+		//       "swallowed" by subsequent extensions on a fully contained
+		//       sub-interval (i.e., the earlier extension doesn't really do
+		//       anything).
+
+		oobIndex = -1;
+		for ( int i = 0; i < nodes.size(); i++ )
+		{
+			if ( nodes.get( i ).viewType() == ViewNode.ViewType.EXTENSION )
+			{
+				if ( oobIndex < 0 )
+					oobIndex = i;
+				else
+				{
+					errorDescription.append( "There must be at most one out-of-bounds extension." );
+					return false;
+				}
+			}
+		}
+
+		if (oobIndex >= 0)
+		{
+			final ExtensionViewNode node = ( ExtensionViewNode ) nodes.get( oobIndex );
+			oobExtension = Extension.of( node.getOutOfBoundsFactory() );
+		}
+		return true;
+	}
+
+	/**
+	 * Check whether the out-of-bounds extension (if any) is of a supported type
+	 * (constant-value, border, mirror-single, mirror-double).
+	 *
+	 * @return {@code true}, if the out-of-bounds extension is of a supported
+	 *         type, or if there is no extension.
+	 */
+	private boolean checkExtensions2()
+	{
+		// TODO: This could be weakened to allow for unknown extensions, by using
+		//       fast copying for in-bounds regions, and fall-back for the rest.
+
+		if ( oobIndex < 0 ) // there is no extension
+			return true;
+
+		if ( oobExtension.type() != Extension.Type.UNKNOWN )
+		{
+			return true;
+		}
+		else
+		{
+			final ExtensionViewNode node = ( ExtensionViewNode ) nodes.get( oobIndex );
+			errorDescription.append(
+					"Only constant-value, border, mirror-single, mirror-double out-of-bounds extensions are supported. (Found "
+							+ node.getOutOfBoundsFactory().getClass().getSimpleName() + ")" );
+			return false;
+		}
+	}
+
+	/**
+	 * Check whether the interval at the out-of-bounds extension is compatible.
+	 * The interval must be equal to the root interval carried through the
+	 * transforms so far. This means that the extension can be applied to the
+	 * root directly (assuming that extension method is the same for every
+	 * axis.)
+	 *
+	 * @return {@code true}, if the out-of-bounds extension interval is
+	 *         compatible, or if there is no extension.
+	 */
+	private boolean checkExtensions3()
+	{
+		// TODO: This could be weakened to allow intervals that are fully
+		//       contained in the bottom interval. This would require revising
+		//       the Ranges.findRanges() implementations.
+
+		if ( oobIndex < 0 ) // there is no extension
+			return true;
+
+		BoundingBox bbExtension = nodes.get( oobIndex + 1 ).bbox();
+		BoundingBox bb = nodes.get( nodes.size() - 1 ).bbox();
+		for ( int i = nodes.size() - 1; i > oobIndex; --i )
+		{
+			final ViewNode node = nodes.get( i );
+
+			// all other view types are ignored.
+			if ( node.viewType() == ViewNode.ViewType.MIXED_TRANSFORM )
+			{
+				final MixedTransform t = ( ( MixedTransformViewNode ) node ).getTransformToSource();
+				bb = transform( t, bb );
+			}
+		}
+
+		if ( Intervals.equals( bb.getInterval(), bbExtension.getInterval() ) )
+		{
+			return true;
+		}
+		else
+		{
+			errorDescription.append(
+					"The interval at the out-of-bounds extension must be equal to the root interval carried through the transforms so far." );
+			return false;
+		}
+	}
+
+	/**
+	 * Apply the {@code transformToSource} to a target vector to obtain a
+	 * source vector.
+	 *
+	 * @param transformToSource
+	 * 		the transformToSource from target to source.
+	 * @param source
+	 * 		set this to the source coordinates.
+	 * @param target
+	 * 		target coordinates.
+	 */
+	private static void apply( MixedTransform transformToSource, long[] source, long[] target )
+	{
+		assert source.length >= transformToSource.numSourceDimensions();
+		assert target.length >= transformToSource.numSourceDimensions();
+
+		for ( int d = 0; d < transformToSource.numTargetDimensions(); ++d )
+		{
+			if ( !transformToSource.getComponentZero( d ) )
+			{
+				long v = target[ d ] - transformToSource.getTranslation( d );
+				source[ transformToSource.getComponentMapping( d ) ] = transformToSource.getComponentInversion( d ) ? -v : v;
+			}
+		}
+	}
+
+	/**
+	 * Apply the {@code transformToSource} to a target bounding box to obtain a
+	 * source bounding box.
+	 *
+	 * @param transformToSource
+	 * 		the transformToSource from target to source.
+	 * @param boundingBox
+	 * 		the target bounding box.
+	 *
+	 * @return the source bounding box.
+	 */
+	private static BoundingBox transform( final MixedTransform transformToSource, final BoundingBox boundingBox )
+	{
+		assert boundingBox.numDimensions() == transformToSource.numSourceDimensions();
+
+		if ( transformToSource.numSourceDimensions() == transformToSource.numTargetDimensions() )
+		{ // apply in-place
+			final long[] tmp = new long[ transformToSource.numTargetDimensions() ];
+			boundingBox.corner1( tmp );
+			apply( transformToSource, boundingBox.corner1, tmp );
+			boundingBox.corner2( tmp );
+			apply( transformToSource, boundingBox.corner2, tmp );
+			return boundingBox;
+		}
+		final BoundingBox b = new BoundingBox( transformToSource.numSourceDimensions() );
+		apply( transformToSource, b.corner1, boundingBox.corner1 );
+		apply( transformToSource, b.corner2, boundingBox.corner2 );
+		return b;
+	}
+
+	/**
+	 * Supplies Converter from root type to view type.
+	 * Maybe {@code null}, if there is no conversion required.
+	 */
+	private Supplier< ? extends Converter< ?, ? > > converterSupplier;
+
+	/**
+	 * Connect all converters in the view sequence into a combined converter. If
+	 * the out-of-bounds extension requires values of a specific type (like
+	 * constant-value extension), then all converters have to <em>happen
+	 * after</em> the out-of-bounds extension (that is, they have to occur
+	 * earlier in the {@code nodes} sequence).
+	 * <p>
+	 * For example if a constant-value extension is applied to a {@code
+	 * DoubleType} {@code RandomAccessible} the oob value will be of {@code
+	 * DoubleType}. If the RA was converted from a {@code UnsignedByteType}
+	 * {@code NativeImg} we don't know the {@code UnsignedByteType} oob value
+	 * for the underlying {@code NativeImg} which would lead to the same effect.
+	 * Therefore, this is not allowed.
+	 * <p>
+	 * If everything works, the combined converter is provided in {@link #converterSupplier}.
+	 *
+	 * @return {@code true}, if all converters could be combined and work with the out-of-bounds extension.
+	 */
+	private boolean checkConverters()
+	{
+		final boolean dontConvertBeforeExtend = oobExtension != null && oobExtension.type().isValueDependent();
+
+		final List< ConverterViewNode< ?, ? > > converterViewNodes = new ArrayList<>();
+		for ( int i = 0; i < nodes.size(); i++ )
+		{
+			final ViewNode node = nodes.get( i );
+			if ( node.viewType() == ViewNode.ViewType.CONVERTER )
+			{
+				if ( i > oobIndex && dontConvertBeforeExtend )
+				{
+					errorDescription.append(
+							"The out-of-bounds extension in the view sequence requires that no converter is applied before it." );
+					return false;
+				}
+				else
+				{
+					converterViewNodes.add( ( ConverterViewNode< ?, ? > ) node );
+				}
+			}
+		}
+
+		if ( !converterViewNodes.isEmpty() )
+			converterSupplier = accumulateConverters( converterViewNodes );
+
+		return true;
+	}
+
+	private static Supplier< ? extends Converter< ?, ? > > accumulateConverters(final List< ConverterViewNode< ?, ? > > nodes )
+	{
+		final AccumulateConverters acc = new AccumulateConverters();
+		for ( int i = nodes.size() - 1; i >= 0; --i )
+			acc.append( nodes.get( i ) );
+		return acc.converterSupplier;
+	}
+
+	private static class AccumulateConverters
+	{
+		private Supplier< ? extends Converter< ?, ? > > converterSupplier = null;
+
+		private Supplier< ? > destinationSupplier = null;
+
+		private < A, B, C > void append( ConverterViewNode< B, C > node )
+		{
+			if ( converterSupplier == null )
+			{
+				converterSupplier = node.getConverterSupplier();
+				destinationSupplier = node.getDestinationSupplier();
+			}
+			else
+			{
+				Supplier< Converter< A, B > > pcs = ( Supplier< Converter< A, B > > ) converterSupplier;
+				Supplier< ? extends B > pds = ( Supplier< ? extends B > ) destinationSupplier;
+				converterSupplier = () -> new Converter< A, C >()
+				{
+					final Converter< A, B > cAB = pcs.get();
+
+					final B b = pds.get();
+
+					final Converter< ? super B, ? super C > cBC = node.getConverterSupplier().get();
+
+					@Override
+					public void convert( final A a, final C c )
+					{
+						cAB.convert( a, b );
+						cBC.convert( b, c );
+					}
+				};
+				destinationSupplier = node.getDestinationSupplier();
+			}
+		}
+	}
+
+	/**
+	 * The concatenated transform from the View {@link #ra RandomAccessible} to the root.
+	 */
+	private MixedTransform transform;
+
+	/**
+	 * Compute the concatenated {@link #transform transform} from the View
+	 * {@link #ra RandomAccessible} to the root.
+	 *
+	 * @return {@code true}
+	 */
+	private boolean concatenateTransforms()
+	{
+		final int n = ra.numDimensions();
+		transform = new MixedTransform( n, n );
+		for ( ViewNode node : nodes )
+		{
+			if ( node.viewType() == ViewNode.ViewType.MIXED_TRANSFORM )
+			{
+				final MixedTransformViewNode tnode = ( MixedTransformViewNode ) node;
+				transform = transform.preConcatenate( tnode.getTransformToSource() );
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Check that all View dimensions are used (mapped to some root dimension).
+	 *
+	 * @return {@code true}, if all View dimensions are used.
+	 */
+	private boolean checkNoDimensionsAdded()
+	{
+		// TODO: Views.addDimension(...) is not allowed for now. This could be
+		//       supported by replicating hyperplanes in the target block.
+
+		if(transform.hasFullSourceMapping())
+		{
+			return true;
+		}
+		else
+		{
+			errorDescription.append(
+					"All View dimensions must map to a dimension of the underlying NativeImg. "
+							+ "That is Views.addDimension(...) is not allowed." );
+			return false;
+		}
+	}
+
+	private MixedTransform permuteInvertTransform;
+
+	private MixedTransform remainderTransform;
+
+	/**
+	 * Split {@link #transform} into
+	 * <ol>
+	 * <li>{@link #permuteInvertTransform}, a pure axis permutation followed by inversion of some axes, and</li>
+	 * <li>{@link #remainderTransform}, a remainder transformation,</li>
+	 * </ol>
+	 * such that {@code remainder * permuteInvert == transform}.
+	 * <p>
+	 * Block copying will then first use {@code remainderTransform} to extract a
+	 * intermediate block from the root {@code NativeImg}. Then compute the
+	 * final block by applying {@code permuteInvertTransform}.
+	 *
+	 * @return {@code true}
+	 */
+	private boolean splitTransform()
+	{
+		final MixedTransform[] split = PrimitiveBlocksUtils.split( transform );
+		permuteInvertTransform = split[ 0 ];
+		remainderTransform = split[ 1 ];
+		return true;
+	}
+
+	private < T extends NativeType< T >, R extends NativeType< R > > ViewProperties< T, R > getViewProperties()
+	{
+		final T viewType = getType( ( RandomAccessible< T > ) ra );
+		final NativeImg< R, ? > root = ( NativeImg< R, ? > ) nodes.get( nodes.size() - 1 ).view();
+		final R rootType = root.createLinkedType();
+		return new ViewProperties<>( viewType, root, rootType, oobExtension, transform, permuteInvertTransform, converterSupplier );
+	}
+
+	private < T extends NativeType< T > > FallbackProperties< T > getFallbackProperties()
+	{
+		final RandomAccessible< T > view = ( RandomAccessible< T > ) ra;
+		return new FallbackProperties<>( getType( view ), view );
+	}
+
+	public static < T extends NativeType< T >, R extends NativeType< R > > ViewPropertiesOrError< T, R > getViewProperties( RandomAccessible< T > view )
+	{
+		final ViewAnalyzer v = new ViewAnalyzer( view );
+
+		// Check whether the pixel type of ciew is supported (NativeType with entitiesPerPixel==1)
+		final boolean supportsFallback = v.checkViewTypeSupported();
+		if ( !supportsFallback )
+		{
+			return new ViewPropertiesOrError<>( null, null, v.errorDescription.toString() );
+		}
+
+		final boolean fullySupported =
+				// Deconstruct the target view into a list of ViewNodes
+				v.analyze()
+
+				// check whether the root of the view is supported
+				// (PlanarImg, ArrayImg, CellImg)
+				&& v.checkRootSupported()
+
+				// Check whether the pixel type of the root is supported
+				// (NativeType with entitiesPerPixel==1)
+				&& v.checkRootTypeSupported()
+
+				// Check whether there is at most one out-of-bounds extension
+				&& v.checkExtensions1()
+
+				// Check whether the out-of-bounds extension (if any) is of a
+				// supported type (constant-value, border, mirror-single, mirror-double)
+				&& v.checkExtensions2()
+
+				// Check whether the interval at the out-of-bounds extension is compatible.
+				&& v.checkExtensions3()
+
+				// Connect all converters in the view sequence into a combined converter
+				&& v.checkConverters()
+
+				// Compute the concatenated MixedTransform
+				&& v.concatenateTransforms()
+
+				// Check that all View dimensions are used (mapped to some root dimension)
+				&& v.checkNoDimensionsAdded()
+
+				// Split concatenated transform into remainder * permuteInvert
+				&& v.splitTransform();
+		if ( !fullySupported )
+		{
+			final String errorMessage = "The RandomAccessible " + view +
+					" is only be supported through the fall-back implementation of PrimitiveBlocks. \n" +
+					v.errorDescription;
+			final FallbackProperties fallbackProperties = v.getFallbackProperties();
+			return new ViewPropertiesOrError<>( null, fallbackProperties, errorMessage );
+		}
+
+		final ViewProperties viewProperties = v.getViewProperties();
+		final FallbackProperties fallbackProperties = v.getFallbackProperties();
+		return new ViewPropertiesOrError<>( viewProperties, fallbackProperties, "" );
+	}
+}

--- a/src/main/java/net/imglib2/blocks/ViewNode.java
+++ b/src/main/java/net/imglib2/blocks/ViewNode.java
@@ -1,0 +1,166 @@
+package net.imglib2.blocks;
+
+import java.util.function.Supplier;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.read.ConvertedRandomAccessible;
+import net.imglib2.converter.read.ConvertedRandomAccessibleInterval;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.transform.integer.BoundingBox;
+import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.view.ExtendedRandomAccessibleInterval;
+import net.imglib2.view.MixedTransformView;
+
+interface ViewNode
+{
+	enum ViewType
+	{
+		NATIVE_IMG,
+		IDENTITY, // for wrappers like ImgPlus, ImgView
+		INTERVAL, //
+		CONVERTER, //
+		MIXED_TRANSFORM, // for Mixed transforms
+		EXTENSION // oob extensions
+	}
+
+	ViewType viewType();
+
+	RandomAccessible< ? > view();
+
+	Interval interval();
+
+	default BoundingBox bbox()
+	{
+		return interval() == null ? null : new BoundingBox( interval() );
+	}
+
+
+	// -----------------------------------------------
+	// implementations
+	// -----------------------------------------------
+
+
+	abstract class AbstractViewNode< V extends RandomAccessible< ? > > implements ViewNode
+	{
+		final ViewType viewType;
+
+		final V view;
+
+		final Interval interval;
+
+		AbstractViewNode( final ViewType viewType, final V view )
+		{
+			this.viewType = viewType;
+			this.view = view;
+			this.interval = view instanceof Interval ? ( Interval ) view : null;
+		}
+
+		@Override
+		public ViewType viewType()
+		{
+			return viewType;
+		}
+
+		@Override
+		public RandomAccessible< ? > view()
+		{
+			return view;
+		}
+
+		@Override
+		public Interval interval()
+		{
+			return interval;
+		}
+	}
+
+	class DefaultViewNode extends AbstractViewNode< RandomAccessible< ? > >
+	{
+		DefaultViewNode( final ViewType viewType, final RandomAccessible< ? > view )
+		{
+			super( viewType, view );
+		}
+
+		@Override
+		public String toString()
+		{
+			return "DefaultViewNode{viewType=" + viewType + ", view=" + view + ", interval=" + interval + '}';
+		}
+	}
+
+	class MixedTransformViewNode extends AbstractViewNode< MixedTransformView< ? > >
+	{
+		MixedTransformViewNode( final MixedTransformView< ? > view )
+		{
+			super( ViewType.MIXED_TRANSFORM, view );
+		}
+
+		public MixedTransform getTransformToSource()
+		{
+			return view.getTransformToSource();
+		}
+
+		@Override
+		public String toString()
+		{
+			return "MixedTransformViewNode{viewType=" + viewType + ", view=" + view + ", interval=" + interval + ", transformToSource=" + getTransformToSource() + '}';
+		}
+	}
+
+	class ExtensionViewNode extends AbstractViewNode< ExtendedRandomAccessibleInterval< ?, ? > >
+	{
+		ExtensionViewNode( final ExtendedRandomAccessibleInterval< ?, ? > view )
+		{
+			super( ViewType.EXTENSION, view );
+		}
+
+		public OutOfBoundsFactory< ?, ? > getOutOfBoundsFactory()
+		{
+			return view.getOutOfBoundsFactory();
+		}
+
+		@Override
+		public String toString()
+		{
+			return "ExtensionViewNode{viewType=" + viewType + ", view=" + view + ", interval=" + interval + ", oobFactory=" + getOutOfBoundsFactory() + '}';
+		}
+	}
+
+	class ConverterViewNode< A, B > extends AbstractViewNode< RandomAccessible< B > >
+	{
+		private final Supplier< ? extends B > destinationSupplier;
+
+		private final Supplier< Converter< ? super A, ? super B > > converterSupplier;
+
+		ConverterViewNode( final ConvertedRandomAccessibleInterval< A, B > view )
+		{
+			super( ViewType.CONVERTER, view );
+			converterSupplier = view.getConverterSupplier();
+			destinationSupplier = view.getDestinationSupplier();
+		}
+
+		ConverterViewNode( final ConvertedRandomAccessible< A, B > view )
+		{
+			super( ViewType.CONVERTER, view );
+			converterSupplier = view.getConverterSupplier();
+			destinationSupplier = view.getDestinationSupplier();
+		}
+
+		public Supplier< ? extends B > getDestinationSupplier()
+		{
+			return destinationSupplier;
+		}
+
+		public Supplier< Converter< ? super A, ? super B > > getConverterSupplier()
+		{
+			return converterSupplier;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "ConverterViewNode{viewType=" + viewType + ", view=" + view + ", interval=" + interval + '}';
+		}
+	}
+}

--- a/src/main/java/net/imglib2/blocks/ViewPrimitiveBlocks.java
+++ b/src/main/java/net/imglib2/blocks/ViewPrimitiveBlocks.java
@@ -1,0 +1,143 @@
+package net.imglib2.blocks;
+
+import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.PrimitiveType;
+import net.imglib2.util.Cast;
+import net.imglib2.util.Intervals;
+
+import static net.imglib2.blocks.PrimitiveBlocksUtils.extractOobValue;
+
+class ViewPrimitiveBlocks< T extends NativeType< T >, R extends NativeType< R > > implements PrimitiveBlocks< T >
+{
+	private final ViewProperties< T, R > props;
+
+	// copies from view root. root type primitive equivalent
+	private final RangeCopier copier;
+
+	// root primitive type
+	private final TempArray< R > tempArrayPermute;
+
+	// root primitive type
+	private final TempArray< R > tempArrayConvert;
+
+	private final PermuteInvert permuteInvert;
+
+	private final Convert convert;
+
+	public ViewPrimitiveBlocks( final ViewProperties< T, R > props )
+	{
+		this.props = props;
+		final PrimitiveType primitiveType = props.getRootType().getNativeTypeFactory().getPrimitiveType();
+		final MemCopy memCopy = MemCopy.forPrimitiveType( primitiveType );
+		final Extension extension = props.getExtension() != null ? props.getExtension() : Extension.border();
+		final Object oob = extractOobValue( props.getRootType(), extension );
+		final Ranges findRanges = Ranges.forExtension( extension );
+		copier = RangeCopier.create( props.getRoot(), findRanges, memCopy, oob );
+		tempArrayConvert = Cast.unchecked( TempArray.forPrimitiveType( primitiveType ) );
+		tempArrayPermute = Cast.unchecked( TempArray.forPrimitiveType( primitiveType ) );
+		permuteInvert = new PermuteInvert( memCopy, props.getPermuteInvertTransform() );
+		convert = props.hasConverterSupplier()
+				? Convert.create( props.getRootType(), props.getViewType(), props.getConverterSupplier() )
+				: null;
+	}
+
+	@Override
+	public T getType()
+	{
+		return props.getViewType();
+	}
+
+	/**
+	 * @param srcPos
+	 * 		min coordinates of block to copy from src Img.
+	 * @param dest
+	 * 		destination array. Type is {@code byte[]}, {@code float[]},
+	 * 		etc, corresponding to the src Img's native type.
+	 * @param size
+	 * 		dimensions of block to copy from src Img.
+	 */
+	public void copy( final long[] srcPos, final Object dest, final int[] size )
+	{
+		final long[] destPos;
+		final int[] destSize;
+		if ( props.hasTransform() )
+		{
+			final MixedTransform transform = props.getTransform();
+			final int n = transform.numTargetDimensions();
+			destPos = new long[ n ];
+			destSize = new int[ n ];
+			for ( int d = 0; d < n; d++ )
+			{
+				final int t = ( int ) transform.getTranslation( d );
+				if ( transform.getComponentZero( d ) )
+				{
+					destPos[ d ] = t;
+					destSize[ d ] = 1;
+				}
+				else
+				{
+					final int c = transform.getComponentMapping( d );
+					destPos[ d ] = transform.getComponentInversion( d )
+							? t - srcPos[ c ] - size[ c ] + 1
+							: t + srcPos[ c ];
+					destSize[ d ] = size[ c ];
+				}
+			}
+		}
+		else
+		{
+			destPos = srcPos;
+			destSize = size;
+		}
+
+		final boolean doPermute = props.hasPermuteInvertTransform();
+		final boolean doConvert = props.hasConverterSupplier();
+		final int length = ( int ) Intervals.numElements( size );
+		if ( doPermute && doConvert )
+		{
+			final Object copyDest = tempArrayPermute.get( length );
+			final Object permuteDest = tempArrayConvert.get( length );
+			copier.copy( destPos, copyDest, destSize );
+			permuteInvert.permuteAndInvert( copyDest, permuteDest, size );
+			convert.convert( permuteDest, dest, length );
+		}
+		else if ( doPermute )
+		{
+			final Object copyDest = tempArrayConvert.get( length );
+			copier.copy( destPos, copyDest, destSize );
+			permuteInvert.permuteAndInvert( copyDest, dest, size );
+		}
+		else if ( doConvert )
+		{
+			final Object copyDest = tempArrayPermute.get( length );
+			copier.copy( destPos, copyDest, destSize );
+			convert.convert( copyDest, dest, length );
+		}
+		else
+		{
+			copier.copy( destPos, dest, destSize );
+		}
+	}
+
+	@Override
+	public PrimitiveBlocks< T > threadSafe()
+	{
+		return PrimitiveBlocksUtils.threadSafe( this::newInstance );
+	}
+
+	ViewPrimitiveBlocks< T, R > newInstance()
+	{
+		return new ViewPrimitiveBlocks<>( this );
+	}
+
+	private ViewPrimitiveBlocks( final ViewPrimitiveBlocks< T, R > blocks )
+	{
+		props = blocks.props;
+		copier = blocks.copier.newInstance();
+		permuteInvert = blocks.permuteInvert.newInstance();
+		convert = blocks.convert == null ? null : blocks.convert.newInstance();
+		tempArrayConvert = blocks.tempArrayConvert.newInstance();
+		tempArrayPermute = blocks.tempArrayPermute.newInstance();
+	}
+}

--- a/src/main/java/net/imglib2/blocks/ViewProperties.java
+++ b/src/main/java/net/imglib2/blocks/ViewProperties.java
@@ -1,0 +1,150 @@
+package net.imglib2.blocks;
+
+import java.util.function.Supplier;
+import net.imglib2.RandomAccessible;
+import net.imglib2.converter.Converter;
+import net.imglib2.img.NativeImg;
+import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.type.NativeType;
+import net.imglib2.view.TransformBuilder;
+
+/**
+ * Data that describes {@code RandomAccessible} View that can be copied from using
+ * {@link ViewPrimitiveBlocks}.
+ * <p>
+ * Use {@link ViewAnalyzer#getViewProperties(RandomAccessible)} to (try to)
+ * extract {@code ViewProperties} for a given {@code RandomAccessible}.
+ *
+ * @param <T>
+ * 		type of the view {@code RandomAccessible}
+ * @param <R>
+ * 		type of the root {@code NativeImg}
+ */
+class ViewProperties< T extends NativeType< T >, R extends NativeType< R > >
+{
+	private final T viewType;
+
+	private final NativeImg< R, ? > root;
+
+	private final R rootType;
+
+	private final Extension extension;
+
+	private final MixedTransform transform;
+
+	private final boolean hasTransform;
+
+	private final MixedTransform permuteInvertTransform;
+
+	private final boolean hasPermuteInvertTransform;
+
+	private final Supplier< Converter< R, T > > converterSupplier;
+
+	/**
+	 * Create {@code ViewProperties}.
+	 *
+	 * @param viewType pixel type of the View to copy from
+	 * @param root the {@code NativeImg} at the root of the View chain
+	 * @param rootType pixel type of the root {@code NativeImg}
+	 * @param extension out-of-bounds extension to apply to the root
+	 * @param transform the concatenated transform from the final View to the root.
+	 * @param permuteInvertTransform captures axis permutation and inversion part in {@code transform}.
+	 * @param converterSupplier creates {@code Converter} from {@code rootType} to {@code viewType}.
+	 */
+	ViewProperties(
+			final T viewType,
+			final NativeImg< R, ? > root,
+			final R rootType,
+			final Extension extension,
+			final MixedTransform transform,
+			final MixedTransform permuteInvertTransform,
+			final Supplier< ? extends Converter< ?, ? > > converterSupplier )
+	{
+		this.viewType = viewType;
+		this.root = root;
+		this.rootType = rootType;
+		this.extension = extension;
+		this.transform = transform;
+		hasTransform = !TransformBuilder.isIdentity( transform );
+		this.permuteInvertTransform = permuteInvertTransform;
+		hasPermuteInvertTransform = !TransformBuilder.isIdentity( permuteInvertTransform );
+		this.converterSupplier = converterSupplier == null ? null : () -> ( Converter< R, T > ) converterSupplier.get();
+	}
+
+	@Override
+	public String toString()
+	{
+		return "ViewProperties{" +
+				"viewType=" + viewType.getClass().getSimpleName() +
+				", root=" + root +
+				", rootType=" + rootType.getClass().getSimpleName() +
+				", extension=" + extension +
+				", transform=" + transform +
+				", hasPermuteInvertTransform=" + hasPermuteInvertTransform +
+				", permuteInvertTransform=" + permuteInvertTransform +
+				", converterSupplier=" + converterSupplier +
+				'}';
+	}
+
+	public T getViewType()
+	{
+		return viewType;
+	}
+
+	public NativeImg< R, ? > getRoot()
+	{
+		return root;
+	}
+
+	public R getRootType()
+	{
+		return rootType;
+	}
+
+	public Extension getExtension()
+	{
+		return extension;
+	}
+
+	/**
+	 * Returns {@code true} if there is a non-identity {@link #getTransform() transform}.
+	 *
+	 * @return {@code true} iff the {@link #getTransform() transform} is not identity.
+	 */
+	public boolean hasTransform()
+	{
+		return hasTransform;
+	}
+
+	public MixedTransform getTransform()
+	{
+		return transform;
+	}
+
+	/**
+	 * Returns {@code true} if there is a non-identity {@link
+	 * #getPermuteInvertTransform() permute-invert} transform.
+	 *
+	 * @return {@code true} iff the {@link #getPermuteInvertTransform()
+	 * permute-invert} transform is not identity.
+	 */
+	public boolean hasPermuteInvertTransform()
+	{
+		return hasPermuteInvertTransform;
+	}
+
+	public MixedTransform getPermuteInvertTransform()
+	{
+		return permuteInvertTransform;
+	}
+
+	public boolean hasConverterSupplier()
+	{
+		return converterSupplier != null;
+	}
+
+	public Supplier< Converter< R, T > > getConverterSupplier()
+	{
+		return converterSupplier;
+	}
+}

--- a/src/main/java/net/imglib2/blocks/ViewPropertiesOrError.java
+++ b/src/main/java/net/imglib2/blocks/ViewPropertiesOrError.java
@@ -1,0 +1,60 @@
+package net.imglib2.blocks;
+
+import net.imglib2.type.NativeType;
+
+class ViewPropertiesOrError< T extends NativeType< T >, R extends NativeType< R > >
+{
+	private final ViewProperties< T, R > viewProperties;
+
+	private final FallbackProperties< T > fallbackProperties;
+
+	private final String errorMessage;
+
+	ViewPropertiesOrError(
+			final ViewProperties< T, R > viewProperties,
+			final FallbackProperties< T > fallbackProperties,
+			final String errorMessage )
+	{
+		this.viewProperties = viewProperties;
+		this.fallbackProperties = fallbackProperties;
+		this.errorMessage = errorMessage;
+	}
+
+	/**
+	 * Whether {@code PrimitiveBlocks} copying from the view is supported, at
+	 * all, either {@link #isFullySupported() fully} or via the fall-back implementation.
+	 *
+	 * @return {@code true}, if {@code PrimitiveBlocks} copying from the view is supported, at all.
+	 */
+	public boolean isSupported()
+	{
+		return isFullySupported() || fallbackProperties != null;
+	}
+
+	/**
+	 * Whether optimized {@code PrimitiveBlocks} copying from the view is supported.
+	 *
+	 * @return {@code true}, if optimized {@code PrimitiveBlocks} copying from the view is supported.
+	 */
+	public boolean isFullySupported()
+	{
+		return viewProperties != null;
+	}
+
+	public ViewProperties< T, R > getViewProperties()
+	{
+		// TODO: null-check, throw Exception (which type?) with errorMessage
+		return viewProperties;
+	}
+
+	public FallbackProperties< T > getFallbackProperties()
+	{
+		// TODO: null-check, throw Exception (which type?) with errorMessage
+		return fallbackProperties;
+	}
+
+	public String getErrorMessage()
+	{
+		return errorMessage;
+	}
+}

--- a/src/main/java/net/imglib2/type/PrimitiveType.java
+++ b/src/main/java/net/imglib2/type/PrimitiveType.java
@@ -69,7 +69,7 @@ public enum PrimitiveType
 		this.byteCount = byteCount;
 	}
 
-	int getByteCount()
+	public int getByteCount()
 	{
 		return byteCount;
 	}

--- a/src/main/java/net/imglib2/util/CloseableThreadLocal.java
+++ b/src/main/java/net/imglib2/util/CloseableThreadLocal.java
@@ -45,8 +45,6 @@ import java.util.function.Supplier;
  * <p>We can not rely on {@link ThreadLocal#remove()} as it only removes the value for the caller
  * thread, whereas {@link #close} takes care of all threads. You should not call {@link #close}
  * until all threads are done using the instance.
- *
- * @lucene.internal
  */
 public class CloseableThreadLocal< T > implements Closeable
 {

--- a/src/main/java/net/imglib2/util/CloseableThreadLocal.java
+++ b/src/main/java/net/imglib2/util/CloseableThreadLocal.java
@@ -1,0 +1,186 @@
+/*
+ * This class is adapted from Apache Lucene's CloseableThreadLocal.
+ * https://github.com/apache/lucene/blob/8a602b5063d2154bf1ffa7ddb2a13a313cd954e0/lucene/core/src/java/org/apache/lucene/util/CloseableThreadLocal.java#L46
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.imglib2.util;
+
+import java.io.Closeable;
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * Java's builtin ThreadLocal has a serious flaw: it can take an arbitrarily long amount of time to
+ * dereference the things you had stored in it, even once the ThreadLocal instance itself is no
+ * longer referenced. This is because there is single, master map stored for each thread, which all
+ * ThreadLocals share, and that master map only periodically purges "stale" entries.
+ *
+ * <p>While not technically a memory leak, because eventually the memory will be reclaimed, it can
+ * take a long time and you can easily hit OutOfMemoryError because from the GC's standpoint the
+ * stale entries are not reclaimable.
+ *
+ * <p>This class works around that, by only enrolling WeakReference values into the ThreadLocal, and
+ * separately holding a hard reference to each stored value. When you call {@link #close}, these
+ * hard references are cleared and then GC is freely able to reclaim space by objects stored in it.
+ *
+ * <p>We can not rely on {@link ThreadLocal#remove()} as it only removes the value for the caller
+ * thread, whereas {@link #close} takes care of all threads. You should not call {@link #close}
+ * until all threads are done using the instance.
+ *
+ * @lucene.internal
+ */
+public class CloseableThreadLocal< T > implements Closeable
+{
+	static final class SuppliedCloseableThreadLocal< T > extends CloseableThreadLocal< T >
+	{
+
+		private final Supplier< ? extends T > supplier;
+
+		SuppliedCloseableThreadLocal( Supplier< ? extends T > supplier )
+		{
+			this.supplier = Objects.requireNonNull( supplier );
+		}
+
+		@Override
+		protected T initialValue()
+		{
+			return supplier.get();
+		}
+	}
+
+	/**
+	 * Creates a thread local variable. The initial value of the variable is
+	 * determined by invoking the {@code get} method on the {@code Supplier}.
+	 */
+	public static < S > CloseableThreadLocal< S > withInitial( Supplier< ? extends S > supplier )
+	{
+		return new SuppliedCloseableThreadLocal<>( supplier );
+	}
+
+	private ThreadLocal< WeakReference< T > > t = new ThreadLocal<>();
+
+	// Use a WeakHashMap so that if a Thread exits and is
+	// GC'able, its entry may be removed:
+	private Map< Thread, T > hardRefs = new WeakHashMap<>();
+
+	// Increase this to decrease frequency of purging in get:
+	private static int PURGE_MULTIPLIER = 20;
+
+	// On each get or set we decrement this; when it hits 0 we
+	// purge.  After purge, we set this to
+	// PURGE_MULTIPLIER * stillAliveCount.  This keeps
+	// amortized cost of purging linear.
+	private final AtomicInteger countUntilPurge = new AtomicInteger( PURGE_MULTIPLIER );
+
+	protected T initialValue()
+	{
+		return null;
+	}
+
+	public T get()
+	{
+		WeakReference< T > weakRef = t.get();
+		if ( weakRef == null )
+		{
+			T iv = initialValue();
+			if ( iv != null )
+			{
+				set( iv );
+				return iv;
+			}
+			else
+			{
+				return null;
+			}
+		}
+		else
+		{
+			maybePurge();
+			return weakRef.get();
+		}
+	}
+
+	public void set( T object )
+	{
+
+		t.set( new WeakReference<>( object ) );
+
+		synchronized ( hardRefs )
+		{
+			hardRefs.put( Thread.currentThread(), object );
+			maybePurge();
+		}
+	}
+
+	private void maybePurge()
+	{
+		if ( countUntilPurge.getAndDecrement() == 0 )
+		{
+			purge();
+		}
+	}
+
+	// Purge dead threads
+	private void purge()
+	{
+		synchronized ( hardRefs )
+		{
+			int stillAliveCount = 0;
+			for ( Iterator< Thread > it = hardRefs.keySet().iterator(); it.hasNext(); )
+			{
+				final Thread t = it.next();
+				if ( !t.isAlive() )
+				{
+					it.remove();
+				}
+				else
+				{
+					stillAliveCount++;
+				}
+			}
+			int nextCount = ( 1 + stillAliveCount ) * PURGE_MULTIPLIER;
+			if ( nextCount <= 0 )
+			{
+				// defensive: int overflow!
+				nextCount = 1000000;
+			}
+
+			countUntilPurge.set( nextCount );
+		}
+	}
+
+	@Override
+	public void close()
+	{
+		// Clear the hard refs; then, the only remaining refs to
+		// all values we were storing are weak (unless somewhere
+		// else is still using them) and so GC may reclaim them:
+		hardRefs = null;
+		// Take care of the current thread right now; others will be
+		// taken care of via the WeakReferences.
+		if ( t != null )
+		{
+			t.remove();
+		}
+		t = null;
+	}
+}

--- a/src/test/java/net/imglib2/blocks/ConvertBenchmark.java
+++ b/src/test/java/net/imglib2/blocks/ConvertBenchmark.java
@@ -1,0 +1,107 @@
+package net.imglib2.blocks;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import net.imglib2.converter.Converter;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MICROSECONDS )
+@Fork( 1 )
+public class ConvertBenchmark
+{
+	private static final int LENGTH = 64 * 64 * 64;
+
+	private final short[] uint16src;
+	private final float[] src;
+	private final float[] dest;
+
+	public ConvertBenchmark()
+	{
+		src = new float[ LENGTH ];
+		dest = new float[ LENGTH ];
+		uint16src = new short[ LENGTH ];
+	}
+
+	@Benchmark
+	public void benchmarkConvert()
+	{
+		convert( uint16src, dest, LENGTH );
+	}
+
+	@Benchmark
+	public void benchmarkConvert2()
+	{
+		final Converter< UnsignedShortType, FloatType > converter = ( in, out ) -> out.setReal( in.getRealFloat() );
+		convert2( uint16src, dest, LENGTH, converter );
+	}
+
+	@Benchmark
+	public void benchmarkConvert3()
+	{
+		final Supplier< Converter< UnsignedShortType, FloatType > > converterSupplier = () -> ( in, out ) -> out.setReal( in.getRealFloat() );
+		final Convert convert = Convert.create( new UnsignedShortType(), new FloatType(), converterSupplier );
+		convert3( uint16src, dest, LENGTH, convert );
+	}
+
+	static void copy1( float[] src, float[] dest, int src_offset, int dest_offset, int length )
+	{
+		for ( int i = 0; i < length; i++ )
+			dest[ i + dest_offset ] = src[ i + src_offset ];
+	}
+
+	static void copy2( float[] src, float[] dest, int length )
+	{
+		for ( int i = 0; i < length; i++ )
+			dest[ i ] = src[ i ];
+	}
+
+	static void convert( short[] src, float[] dest, int length )
+	{
+		for ( int i = 0; i < length; i++ )
+			dest[ i ] = src[ i ] & 0xffff;
+	}
+
+	static void convert2( short[] src, float[] dest, int length, final Converter< UnsignedShortType, FloatType > converter )
+	{
+		final UnsignedShortType in = new UnsignedShortType( new ShortArray( src ) );
+		final FloatType out = new FloatType( new FloatArray( dest ) );
+		for ( int i = 0; i < length; i++ )
+		{
+			in.index().set( i );
+			out.index().set( i );
+			converter.convert( in, out );
+		}
+	}
+
+	static void convert3( short[] src, float[] dest, int length, Convert convert )
+	{
+		convert.convert( src, dest, length );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( ConvertBenchmark.class.getSimpleName() ).build();
+		new Runner( options ).run();
+//		new ConvertBenchmark().benchmarkConvert3();
+	}
+}

--- a/src/test/java/net/imglib2/blocks/CopyBenchmarkDouble.java
+++ b/src/test/java/net/imglib2/blocks/CopyBenchmarkDouble.java
@@ -1,0 +1,120 @@
+package net.imglib2.blocks;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class CopyBenchmarkDouble
+{
+	private final int[] cellDimensions = { 64, 64, 64 };
+	private final int[] srcDimensions = { 300, 300, 300 };
+	private final int[] destDimensions = { 64, 64, 64 };
+	private final int[] pos = { 64, 100, 100 };
+	private final int[] oobPos = { -32, -32, -32 };
+
+	private final CellImg< DoubleType, ? > cellImg;
+
+	private final ArrayImg< DoubleType, ? > destArrayImg;
+
+	private final double[] dest;
+
+	public CopyBenchmarkDouble()
+	{
+		final CellImgFactory< DoubleType > cellImgFactory = new CellImgFactory<>( new DoubleType(), cellDimensions );
+		cellImg = cellImgFactory.create( srcDimensions );
+		destArrayImg = new ArrayImgFactory<>( new DoubleType() ).create( destDimensions );
+		dest = new double[ ( int ) Intervals.numElements( destDimensions ) ];
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilder()
+	{
+		final long[] min = Util.int2long( pos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( cellImg, min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobMirrorSingle()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendMirrorSingle( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobConstant()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendZero( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocks()
+	{
+		final PrimitiveBlocks< DoubleType > blocks = PrimitiveBlocks.of( cellImg );
+		blocks.copy( pos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobMirrorSingle()
+	{
+		final PrimitiveBlocks< DoubleType > blocks = PrimitiveBlocks.of( Views.extendMirrorSingle( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobConstant()
+	{
+		final PrimitiveBlocks< DoubleType > blocks = PrimitiveBlocks.of( Views.extendZero( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( CopyBenchmarkDouble.class.getSimpleName() + "\\." ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/blocks/CopyBenchmarkFloat.java
+++ b/src/test/java/net/imglib2/blocks/CopyBenchmarkFloat.java
@@ -1,0 +1,120 @@
+package net.imglib2.blocks;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class CopyBenchmarkFloat
+{
+	private final int[] cellDimensions = { 64, 64, 64 };
+	private final int[] srcDimensions = { 300, 300, 300 };
+	private final int[] destDimensions = { 64, 64, 64 };
+	private final int[] pos = { 64, 100, 100 };
+	private final int[] oobPos = { -32, -32, -32 };
+
+	private final CellImg< FloatType, ? > cellImg;
+
+	private final ArrayImg< FloatType, ? > destArrayImg;
+
+	private final float[] dest;
+
+	public CopyBenchmarkFloat()
+	{
+		final CellImgFactory< FloatType > cellImgFactory = new CellImgFactory<>( new FloatType(), cellDimensions );
+		cellImg = cellImgFactory.create( srcDimensions );
+		destArrayImg = new ArrayImgFactory<>( new FloatType() ).create( destDimensions );
+		dest = new float[ ( int ) Intervals.numElements( destDimensions ) ];
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilder()
+	{
+		final long[] min = Util.int2long( pos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( cellImg, min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobMirrorSingle()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendMirrorSingle( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobConstant()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendZero( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocks()
+	{
+		final PrimitiveBlocks< FloatType > blocks = PrimitiveBlocks.of( cellImg );
+		blocks.copy( pos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobMirrorSingle()
+	{
+		final PrimitiveBlocks< FloatType > blocks = PrimitiveBlocks.of( Views.extendMirrorSingle( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobConstant()
+	{
+		final PrimitiveBlocks< FloatType > blocks = PrimitiveBlocks.of( Views.extendZero( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( CopyBenchmarkFloat.class.getSimpleName() + "\\." ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/blocks/CopyBenchmarkPolymorphic.java
+++ b/src/test/java/net/imglib2/blocks/CopyBenchmarkPolymorphic.java
@@ -1,0 +1,170 @@
+package net.imglib2.blocks;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class CopyBenchmarkPolymorphic
+{
+	private final int[] cellDimensions = { 64, 64, 64 };
+	private final int[] srcDimensions = { 300, 300, 300 };
+	private final int[] destDimensions = { 100, 100, 100 };
+	private final int[] pos = { 64, 100, 100 };
+	private final int[] oobPos = { -64, -64, -64 };
+
+	private final CellImg< UnsignedByteType, ? > cellImg;
+
+	private final ArrayImg< UnsignedByteType, ? > destArrayImg;
+
+	private final byte[] dest;
+
+	void spoil()
+	{
+		// byte
+		final CellImgFactory< UnsignedByteType > factoryByte = new CellImgFactory<>( new UnsignedByteType(), cellDimensions );
+		final CellImg< UnsignedByteType, ? > cellImgByte = factoryByte.create( srcDimensions );
+		final byte[] destByte = new byte[ ( int ) Intervals.numElements( destDimensions ) ];
+		PrimitiveBlocks< UnsignedByteType > blocksByte = PrimitiveBlocks.of( cellImgByte );
+		blocksByte.copy( pos, destByte, destDimensions );
+		blocksByte = PrimitiveBlocks.of( Views.extendMirrorSingle( cellImgByte ) );
+		blocksByte.copy( oobPos, destByte, destDimensions );
+		blocksByte = PrimitiveBlocks.of( Views.extendZero( cellImgByte ) );
+		blocksByte.copy( oobPos, destByte, destDimensions );
+
+		// float
+		final CellImgFactory< FloatType > factoryFloat = new CellImgFactory<>( new FloatType(), cellDimensions );
+		final CellImg< FloatType, ? > cellImgFloat = factoryFloat.create( srcDimensions );
+		final float[] destFloat = new float[ ( int ) Intervals.numElements( destDimensions ) ];
+		PrimitiveBlocks< FloatType > blocksFloat = PrimitiveBlocks.of( cellImgFloat );
+		blocksFloat.copy( pos, destFloat, destDimensions );
+		blocksFloat = PrimitiveBlocks.of( Views.extendMirrorSingle( cellImgFloat ) );
+		blocksFloat.copy( oobPos, destFloat, destDimensions );
+		blocksFloat = PrimitiveBlocks.of( Views.extendZero( cellImgFloat ) );
+		blocksFloat.copy( oobPos, destFloat, destDimensions );
+
+		// double
+		final CellImgFactory< DoubleType > factoryDouble = new CellImgFactory<>( new DoubleType(), cellDimensions );
+		final CellImg< DoubleType, ? > cellImgDouble = factoryDouble.create( srcDimensions );
+		final double[] destDouble = new double[ ( int ) Intervals.numElements( destDimensions ) ];
+		PrimitiveBlocks< DoubleType > blocksDouble = PrimitiveBlocks.of( cellImgDouble );
+		blocksDouble.copy( pos, destDouble, destDimensions );
+		blocksDouble = PrimitiveBlocks.of( Views.extendMirrorSingle( cellImgDouble ) );
+		blocksDouble.copy( oobPos, destDouble, destDimensions );
+		blocksDouble = PrimitiveBlocks.of( Views.extendZero( cellImgDouble ) );
+		blocksDouble.copy( oobPos, destDouble, destDimensions );
+	}
+
+	@Param( value = { "false", "true" } )
+	private boolean slowdown;
+
+	@Setup
+	public void setup()
+	{
+		if ( slowdown )
+			spoil();
+	}
+
+	public CopyBenchmarkPolymorphic()
+	{
+		final CellImgFactory< UnsignedByteType > cellImgFactory = new CellImgFactory<>( new UnsignedByteType(), cellDimensions );
+		cellImg = cellImgFactory.create( srcDimensions );
+		destArrayImg = new ArrayImgFactory<>( new UnsignedByteType() ).create( destDimensions );
+		dest = new byte[ ( int ) Intervals.numElements( destDimensions ) ];
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilder()
+	{
+		final long[] min = Util.int2long( pos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( cellImg, min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobMirrorSingle()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendMirrorSingle( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobConstant()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendZero( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocks()
+	{
+		final PrimitiveBlocks< UnsignedByteType > blocks = PrimitiveBlocks.of( cellImg );
+		blocks.copy( pos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobMirrorSingle()
+	{
+		final PrimitiveBlocks< UnsignedByteType > blocks = PrimitiveBlocks.of( Views.extendMirrorSingle( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobConstant()
+	{
+		final PrimitiveBlocks< UnsignedByteType > blocks = PrimitiveBlocks.of( Views.extendZero( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( CopyBenchmarkPolymorphic.class.getSimpleName() ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/blocks/CopyBenchmarkUnsignedByte.java
+++ b/src/test/java/net/imglib2/blocks/CopyBenchmarkUnsignedByte.java
@@ -1,0 +1,123 @@
+package net.imglib2.blocks;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmark copying from a CellImg with various out-of-bounds extensions.
+ */
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class CopyBenchmarkUnsignedByte
+{
+	private final int[] cellDimensions = { 64, 64, 64 };
+	private final int[] srcDimensions = { 300, 300, 300 };
+	private final int[] destDimensions = { 100, 100, 100 };
+	private final int[] pos = { 64, 100, 100 };
+	private final int[] oobPos = { -64, -64, -64 };
+
+	private final CellImg< UnsignedByteType, ? > cellImg;
+
+	private final ArrayImg< UnsignedByteType, ? > destArrayImg;
+
+	private final byte[] dest;
+
+	public CopyBenchmarkUnsignedByte()
+	{
+		final CellImgFactory< UnsignedByteType > cellImgFactory = new CellImgFactory<>( new UnsignedByteType(), cellDimensions );
+		cellImg = cellImgFactory.create( srcDimensions );
+		destArrayImg = new ArrayImgFactory<>( new UnsignedByteType() ).create( destDimensions );
+		dest = new byte[ ( int ) Intervals.numElements( destDimensions ) ];
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilder()
+	{
+		final long[] min = Util.int2long( pos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( cellImg, min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobMirrorSingle()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendMirrorSingle( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobConstant()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendZero( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocks()
+	{
+		final PrimitiveBlocks< UnsignedByteType > blocks = PrimitiveBlocks.of( cellImg );
+		blocks.copy( pos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobMirrorSingle()
+	{
+		final PrimitiveBlocks< UnsignedByteType > blocks = PrimitiveBlocks.of( Views.extendMirrorSingle( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobConstant()
+	{
+		final PrimitiveBlocks< UnsignedByteType > blocks = PrimitiveBlocks.of( Views.extendZero( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( CopyBenchmarkUnsignedByte.class.getSimpleName() + "\\." ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/blocks/CopyBenchmarkUnsignedShort.java
+++ b/src/test/java/net/imglib2/blocks/CopyBenchmarkUnsignedShort.java
@@ -1,0 +1,120 @@
+package net.imglib2.blocks;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class CopyBenchmarkUnsignedShort
+{
+	private final int[] cellDimensions = { 64, 64, 64 };
+	private final int[] srcDimensions = { 300, 300, 300 };
+	private final int[] destDimensions = { 100, 100, 100 };
+	private final int[] pos = { 64, 100, 100 };
+	private final int[] oobPos = { -64, -64, -64 };
+
+	private final CellImg< UnsignedShortType, ? > cellImg;
+
+	private final ArrayImg< UnsignedShortType, ? > destArrayImg;
+
+	private final short[] dest;
+
+	public CopyBenchmarkUnsignedShort()
+	{
+		final CellImgFactory< UnsignedShortType > cellImgFactory = new CellImgFactory<>( new UnsignedShortType(), cellDimensions );
+		cellImg = cellImgFactory.create( srcDimensions );
+		destArrayImg = new ArrayImgFactory<>( new UnsignedShortType() ).create( destDimensions );
+		dest = new short[ ( int ) Intervals.numElements( destDimensions ) ];
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilder()
+	{
+		final long[] min = Util.int2long( pos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( cellImg, min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobMirrorSingle()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendMirrorSingle( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkLoopBuilderOobConstant()
+	{
+		final long[] min = Util.int2long( oobPos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( Views.extendZero( cellImg ), min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocks()
+	{
+		final PrimitiveBlocks< UnsignedShortType > blocks = PrimitiveBlocks.of( cellImg );
+		blocks.copy( pos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobMirrorSingle()
+	{
+		final PrimitiveBlocks< UnsignedShortType > blocks = PrimitiveBlocks.of( Views.extendMirrorSingle( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	@Benchmark
+	public void benchmarkCellImgBlocksOobConstant()
+	{
+		final PrimitiveBlocks< UnsignedShortType > blocks = PrimitiveBlocks.of( Views.extendZero( cellImg ) );
+		blocks.copy( oobPos, dest, destDimensions );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( CopyBenchmarkUnsignedShort.class.getSimpleName() + "\\." ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/blocks/CopyBenchmarkViewPrimitiveBlocks.java
+++ b/src/test/java/net/imglib2/blocks/CopyBenchmarkViewPrimitiveBlocks.java
@@ -1,0 +1,99 @@
+package net.imglib2.blocks;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.RandomAccessible;
+import net.imglib2.converter.Converters;
+import net.imglib2.converter.RealDoubleConverter;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmark copying from a CellImg with various out-of-bounds extensions.
+ */
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class CopyBenchmarkViewPrimitiveBlocks
+{
+	private final int[] cellDimensions = { 64, 64, 64 };
+	private final int[] srcDimensions = { 300, 300, 300 };
+	private final int[] destDimensions = { 64, 64, 64 };
+	private final int[] pos = { 64, 100, 100 };
+	private final int[] oobPos = { -32, -32, -32 };
+
+	private final RandomAccessible< DoubleType > srcView;
+
+	private final RandomAccessible< DoubleType > srcViewPermuted;
+
+	private final ArrayImg< DoubleType, ? > destArrayImg;
+
+	private final double[] dest;
+
+	public CopyBenchmarkViewPrimitiveBlocks()
+	{
+		final CellImgFactory< UnsignedByteType > cellImgFactory = new CellImgFactory<>( new UnsignedByteType(), cellDimensions );
+		final CellImg< UnsignedByteType, ? > cellImg = cellImgFactory.create( srcDimensions );
+		srcView = Converters.convert( Views.extendZero( cellImg ), new RealDoubleConverter<>(), new DoubleType() );
+		srcViewPermuted = Converters.convert( Views.extendZero( Views.zeroMin( Views.permute( cellImg, 0, 1 ) ) ), new RealDoubleConverter<>(), new DoubleType() );
+		destArrayImg = new ArrayImgFactory<>( new DoubleType() ).create( destDimensions );
+		dest = new double[ ( int ) Intervals.numElements( destDimensions ) ];
+	}
+
+
+	@Param( { "true", "false" } )
+	private boolean oob;
+
+	@Param( { "true", "false" } )
+	private boolean permute;
+
+	@Benchmark
+	public void benchmarkLoopBuilder()
+	{
+		final long[] min = Util.int2long( oob ? oobPos : pos );
+		final long[] max = min.clone();
+		for ( int d = 0; d < max.length; d++ )
+			max[ d ] += destDimensions[ d ] - 1;
+		LoopBuilder
+				.setImages( Views.interval( permute ? srcViewPermuted : srcView, min, max), destArrayImg )
+				.multiThreaded( false )
+				.forEachPixel( (i,o) -> o.set( i.get() ) );
+	}
+
+	@Benchmark
+	public void benchmarkPrimitiveBlocks()
+	{
+		final PrimitiveBlocks< DoubleType > blocks = PrimitiveBlocks.of( permute ? srcViewPermuted : srcView );
+		blocks.copy( oob ? oobPos : pos, dest, destDimensions );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( CopyBenchmarkViewPrimitiveBlocks.class.getSimpleName() + "\\." ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/blocks/PermuteInvertBenchmark.java
+++ b/src/test/java/net/imglib2/blocks/PermuteInvertBenchmark.java
@@ -1,0 +1,79 @@
+package net.imglib2.blocks;
+
+import java.util.concurrent.TimeUnit;
+import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.util.Intervals;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class PermuteInvertBenchmark
+{
+	@Param( value = { "0", "1", "2" } )
+	private int scenario;
+
+	private final int[][] destSizes = new int[][] {
+			{ 64, 64 },
+			{ 128, 128 },
+			{ 256, 256 },
+	};
+
+	private int[] destSize;
+
+	private byte[] src;
+
+	private byte[] dest;
+
+	private MixedTransform transform;
+
+	private PermuteInvert permuteInvert;
+
+	public PermuteInvertBenchmark()
+	{
+	}
+
+	@Setup
+	public void setup()
+	{
+		transform = new MixedTransform( 2, 2 );
+		transform.setComponentMapping( new int[] { 1, 0 } );
+		transform.setComponentInversion( new boolean[] { true, false } );
+
+		destSize = destSizes[ scenario ];
+		src = new byte[ ( int ) Intervals.numElements( destSize ) ];
+		dest = new byte[ ( int ) Intervals.numElements( destSize ) ];
+
+		final MemCopy memCopy = MemCopy.BYTE;
+		permuteInvert = new PermuteInvert( memCopy, transform );
+	}
+
+	@Benchmark
+	public void benchmark()
+	{
+		permuteInvert.permuteAndInvert( src, dest, destSize );
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( PermuteInvertBenchmark.class.getSimpleName() ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/blocks/RangesTest.java
+++ b/src/test/java/net/imglib2/blocks/RangesTest.java
@@ -1,0 +1,279 @@
+package net.imglib2.blocks;
+
+import java.util.List;
+import net.imglib2.blocks.Ranges.Range;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static net.imglib2.blocks.Ranges.Direction.BACKWARD;
+import static net.imglib2.blocks.Ranges.Direction.CONSTANT;
+import static net.imglib2.blocks.Ranges.Direction.FORWARD;
+import static net.imglib2.blocks.Ranges.Direction.STAY;
+
+public class RangesTest
+{
+
+	// simplified 1D copy() for testing computed ranges
+	// takes into account Range.dir copy direction
+	static void copy( final List< Range > ranges, final int[][] data, final int[] dest )
+	{
+		int x = 0;
+		for ( Range range : ranges )
+		{
+			if ( range.dir == CONSTANT )
+			{
+				for ( int i = 0; i < range.w; ++i )
+					dest[ x++ ] = -1;
+			}
+			else
+			{
+				final int[] cell = data[ range.gridx ];
+				if ( range.dir == FORWARD )
+				{
+					for ( int i = 0; i < range.w; ++i )
+						dest[ x++ ] = cell[ range.cellx + i ];
+				}
+				else if ( range.dir == BACKWARD )
+				{
+					for ( int i = 0; i < range.w; ++i )
+						dest[ x++ ] = cell[ range.cellx - i ];
+				}
+				else if ( range.dir == STAY )
+				{
+					for ( int i = 0; i < range.w; ++i )
+						dest[ x++ ] = cell[ range.cellx ];
+				}
+			}
+		}
+	}
+
+
+	@Test
+	public void copyInBounds()
+	{
+		// test data:
+		// image consisting of 3 cells with 5 elements each.
+		// border cell is not truncated.
+		int[][] data = {
+				{ 0, 1, 2, 3, 4 },
+				{ 5, 6, 7, 8, 9 },
+				{ 10, 11, 12, 13, 14 }
+		};
+		final int iw = 15; // image width
+		final int cw = 5; // cell width
+
+		final int[] dest = new int[ 9 ];
+		final int bw = dest.length;
+		final List< Range > ranges = RangesImpl.findRanges_constant( 3, bw, iw, cw );
+		copy( ranges, data, dest );
+
+		final Range[] expectedRanges = {
+				new Range( 0, 3, 2, FORWARD, 0 ),
+				new Range( 1, 0, 5, FORWARD, 2 ),
+				new Range( 2, 0, 2, FORWARD, 7 )
+		};
+		Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+		final int[] expectedDest = new int[] { 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+		Assert.assertArrayEquals( expectedDest, dest );
+	}
+
+	@Test
+	public void copyMirrorSingle()
+	{
+		// test data:
+		// image consisting of 2 cells with 4 elements each.
+		// border cell is truncated.
+		int[][] data = {
+				{ 0, 1, 2, 3 },
+				{ 4, 5 }
+		};
+		final int iw = 6; // image width
+		final int cw = 4; // cell width
+
+		// singled mirrored it looks like this:
+		//   4   5   4   3   2   1   0   1   2   3   4   5   4   3   2   1   0   1
+		// ----|-------|-----------|===============|=======|---|---------------|----
+
+
+		final int[] dest = new int[ 7 ];
+		final int bw = dest.length;
+
+		{
+			final List< Range > ranges = RangesImpl.findRanges_mirror_single( -3, bw, iw, cw );
+			copy( ranges, data, dest );
+
+			final Range[] expectedRanges = {
+					new Range(0, 3, 3, BACKWARD, 0),
+					new Range(0, 0, 4, FORWARD, 3),
+			};
+			Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+			final int[] expectedDest = new int[] { 3, 2, 1, 0, 1, 2, 3 };
+			Assert.assertArrayEquals( expectedDest, dest );
+		}
+		{
+			final List< Range > ranges = RangesImpl.findRanges_mirror_single( 5, bw, iw, cw );
+			copy( ranges, data, dest );
+
+			final Range[] expectedRanges = {
+					new Range( 1, 1, 1, FORWARD, 0 ),
+					new Range( 1, 0, 1, BACKWARD, 1 ),
+					new Range( 0, 3, 3, BACKWARD, 2 ),
+					new Range( 0, 0, 2, FORWARD, 5 )
+			};
+			Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+			final int[] expectedDest = new int[] { 5, 4, 3, 2, 1, 0, 1};
+			Assert.assertArrayEquals( expectedDest, dest );
+		}
+	}
+
+	@Test
+	public void copyMirrorDouble()
+	{
+		// test data:
+		// image consisting of 2 cells with 4 elements each.
+		// border cell is truncated.
+		int[][] data = {
+				{ 0, 1, 2, 3 },
+				{ 4, 5 }
+		};
+		final int iw = 6; // image width
+		final int cw = 4; // cell width
+
+		// double mirrored it looks like this:
+		//   5   4   3   2   1   0   0   1   2   3   4   5   5   4   3   2   1   0
+		// |-------|---------------|===============|=======|-------|---------------|
+
+		final int[] dest = new int[ 7 ];
+		final int bw = dest.length;
+
+		{
+			final List< Range > ranges = RangesImpl.findRanges_mirror_double( -3, bw, iw, cw );
+			copy( ranges, data, dest );
+
+			final Range[] expectedRanges = {
+					new Range( 0, 2, 3, BACKWARD, 0 ),
+					new Range( 0, 0, 4, FORWARD, 3 )
+			};
+			Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+			final int[] expectedDest = new int[] { 2, 1, 0, 0, 1, 2, 3 };
+			Assert.assertArrayEquals( expectedDest, dest );
+		}
+		{
+			final List< Range > ranges = RangesImpl.findRanges_mirror_double( 3, bw, iw, cw );
+			copy( ranges, data, dest );
+
+			final Range[] expectedRanges = {
+					new Range(0, 3, 1, FORWARD, 0),
+					new Range(1, 0, 2, FORWARD, 1),
+					new Range(1, 1, 2, BACKWARD, 3),
+					new Range(0, 3, 2, BACKWARD, 5),
+			};
+			Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+			final int[] expectedDest = new int[] { 3, 4, 5, 5, 4, 3, 2 };
+			Assert.assertArrayEquals( expectedDest, dest );
+		}
+	}
+
+	@Test
+	public void copyBorder()
+	{
+		// test data:
+		// image consisting of 2 cells with 4 elements each.
+		// border cell is truncated.
+		int[][] data = {
+				{ 0, 1, 2, 3 },
+				{ 4, 5 }
+		};
+		final int iw = 6; // image width
+		final int cw = 4; // cell width
+
+		// border extended it looks like this:
+		//   0   0   0   0   1   2   3   4   5   5   5   5
+		// ------------|===============|=======|------------
+
+		final int[] dest = new int[ 7 ];
+		final int bw = dest.length;
+
+		{
+			final List< Range > ranges = RangesImpl.findRanges_border( -3, bw, iw, cw );
+			copy( ranges, data, dest );
+
+			final Range[] expectedRanges = {
+					new Range( 0, 0, 3, STAY, 0 ),
+					new Range( 0, 0, 4, FORWARD, 3 )
+			};
+			Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+			final int[] expectedDest = new int[] { 0, 0, 0, 0, 1, 2, 3 };
+			Assert.assertArrayEquals( expectedDest, dest );
+		}
+		{
+			final List< Range > ranges = RangesImpl.findRanges_border( 1, bw, iw, cw );
+			copy( ranges, data, dest );
+
+			final Range[] expectedRanges = {
+					new Range( 0, 1, 3, FORWARD, 0 ),
+					new Range( 1, 0, 2, FORWARD, 3 ),
+					new Range( 1, 1, 2, STAY, 5 )
+			};
+			Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+			final int[] expectedDest = new int[] { 1, 2, 3, 4, 5, 5, 5 };
+			Assert.assertArrayEquals( expectedDest, dest );
+		}
+	}
+
+	@Test
+	public void copyConstant()
+	{
+		// test data:
+		// image consisting of 2 cells with 4 elements each.
+		// border cell is truncated.
+		int[][] data = {
+				{ 0, 1, 2, 3 },
+				{ 4, 5 }
+		};
+		final int iw = 6; // image width
+		final int cw = 4; // cell width
+
+		// border extended it looks like this:
+		//  -1  -1  -1   0   1   2   3   4   5  -1  -1  -1
+		// ------------|===============|=======|------------
+
+		final int[] dest = new int[ 7 ];
+		final int bw = dest.length;
+
+		{
+			final List< Range > ranges = RangesImpl.findRanges_constant( -3, bw, iw, cw );
+			copy( ranges, data, dest );
+
+			final Range[] expectedRanges = {
+					new Range( -1, -1, 3, CONSTANT, 0 ),
+					new Range( 0, 0, 4, FORWARD, 3 )
+			};
+			Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+			final int[] expectedDest = new int[] { -1, -1, -1, 0, 1, 2, 3 };
+			Assert.assertArrayEquals( expectedDest, dest );
+		}
+		{
+			final List< Range > ranges = RangesImpl.findRanges_constant( 1, bw, iw, cw );
+			copy( ranges, data, dest );
+
+			final Range[] expectedRanges = {
+					new Range( 0, 1, 3, FORWARD, 0 ),
+					new Range( 1, 0, 2, FORWARD, 3 ),
+					new Range( -1, -1, 2, CONSTANT, 5 )
+			};
+			Assert.assertArrayEquals( expectedRanges, ranges.toArray() );
+
+			final int[] expectedDest = new int[] { 1, 2, 3, 4, 5, -1, -1 };
+			Assert.assertArrayEquals( expectedDest, dest );
+		}
+	}
+}


### PR DESCRIPTION
This PR adds functionality to extract blocks from `RandomAccessible` into flat primitive arrays.
This will be useful for example to copy data to [`Tensor`](https://github.com/bioimage-io/model-runner-java/blob/main/src/main/java/io/bioimage/modelrunner/tensor/Tensor.java), to extract blocks for storing into [N5](https://github.com/saalfeldlab/n5), for interfacing CLIJ, for running small algorithm kernels directly on primitive arrays, etc...

The only public API introduced is the interface `PrimitiveBlocks<T extends NativeType<T>>`.
The static method `PrimitiveBlocks.of(...)` creates a `PrimitiveBlocks` accessor for an arbitrary `RandomAccessible` source.
The method `PrimitiveBlocks.copy(long[] srcPos, Object dest, int[]size)` is then used to copy blocks out of the source into flat primitive arrays. The idea is to provide an interface similar to `System.arraycopy`. `Object dest` is a primitive array of type corresponding to `T`.

`PrimitiveBlocks.of(...)` understands a lot of `View` constructions (that ultimately end in CellImg, ArrayImg, etc) and will try to create an optimized copier. For example, the following will work:
```java
CellImg< UnsignedByteType, ? > cellImg3D;
RandomAccessible< FloatType > view = Converters.convert(
    Views.extendBorder(
        Views.hyperSlice(
            Views.zeroMin(
                Views.rotate( cellImg3D, 1, 0 )
            ),
            2, 80 )
    ),
    new RealFloatConverter<>(),
    new FloatType()
);

PrimitiveBlocks< FloatType > blocks = PrimitiveBlocks.of( view );

final float[] data = new float[ 40 * 50 ];
blocks.copy( new int[] { 10, 20 }, data, new int[] { 40, 50 } );
```
The idea of the optimized copier is:
Instead of using `RandomAccess` that checks for every pixel whether it enters a new `Cell`, whether it is out-of-bounds, etc., all these checks are precomputed and then relevant data from each `Cell` is copied in one go.
The speedup can be dramatic, in particular if the underlying source data is in a `CellImg`. 
Some benchmarks included, here is for example results of [`CopyBenchmarkViewPrimitiveBlocks`](https://github.com/imglib/imglib2/blob/1fd92e5385127f25d27695771f001810c6e11109/src/test/java/net/imglib2/blocks/CopyBenchmarkViewPrimitiveBlocks.java)
```
# JMH version: 1.35
# VM version: JDK 17.0.3, OpenJDK 64-Bit Server VM, 17.0.3+7-LTS
...

Benchmark                                                  (oob)  (permute)  Mode  Cnt   Score   Error  Units
CopyBenchmarkViewPrimitiveBlocks.benchmarkLoopBuilder       true       true  avgt    5  12,789 ± 0,285  ms/op
CopyBenchmarkViewPrimitiveBlocks.benchmarkLoopBuilder       true      false  avgt    5   9,682 ± 0,152  ms/op
CopyBenchmarkViewPrimitiveBlocks.benchmarkLoopBuilder      false       true  avgt    5  14,333 ± 0,099  ms/op
CopyBenchmarkViewPrimitiveBlocks.benchmarkLoopBuilder      false      false  avgt    5  12,721 ± 0,123  ms/op
CopyBenchmarkViewPrimitiveBlocks.benchmarkPrimitiveBlocks   true       true  avgt    5   0,541 ± 0,010  ms/op
CopyBenchmarkViewPrimitiveBlocks.benchmarkPrimitiveBlocks   true      false  avgt    5   0,315 ± 0,024  ms/op
CopyBenchmarkViewPrimitiveBlocks.benchmarkPrimitiveBlocks  false       true  avgt    5   0,570 ± 0,013  ms/op
CopyBenchmarkViewPrimitiveBlocks.benchmarkPrimitiveBlocks  false      false  avgt    5   0,322 ± 0,008  ms/op
```


If a source `RandomAccessible` cannot be understood, `PrimitiveBlocks.of(...)` will return a fall-back implementation (based on `LoopBuilder`). With the optional `OnFallback` argument of `PrimitiveBlocks.of(...)` it can be configured whether fall-back should be
* silently accepted (`ACCEPT`),
* a warning should be printed (`WARN`) -- the default,
* or an `IllegalArgumentException` thrown (`FAIL`).
The warning/exception message explains why the source `RandomAccessible` requires fall-back.

The only really un-supported case is if the pixel type `T` does not map one-to-one to a primitive type.
For example, `ComplexDoubleType` or `Unsigned4BitType` are not supported. (at least not yet).

`PrimitiveBlocks.copy` is single-threaded, the idea being to parallelize over blocks instead of the copying within a block.
`PrimitiveBlocks` is not thread-safe in general, but has a method `threadSafe()` to obtain a thread-safe instance (implemented using `ThreadLocal` copies). For example,
```java
PrimitiveBlocks< FloatType > blocks = PrimitiveBlocks.of( view ).threadSafe();
```
can safely be used multi-threaded, for example in `CellLoader`s.