### PR TITLE
Add stream methods to IterableRealInterval

### DIFF
--- a/src/main/java/net/imglib2/AbstractCursorInt.java
+++ b/src/main/java/net/imglib2/AbstractCursorInt.java
@@ -98,6 +98,20 @@ public abstract class AbstractCursorInt< T > extends AbstractEuclideanSpace impl
 	}
 
 	@Override
+	public void localize( final Positionable position )
+	{
+		localize( tmp );
+		position.setPosition( tmp );
+	}
+
+	@Override
+	public void localize( final RealPositionable position )
+	{
+		localize( tmp );
+		position.setPosition( tmp );
+	}
+
+	@Override
 	public float getFloatPosition( final int d )
 	{
 		return getIntPosition( d );

--- a/src/main/java/net/imglib2/IterableInterval.java
+++ b/src/main/java/net/imglib2/IterableInterval.java
@@ -34,6 +34,10 @@
 
 package net.imglib2;
 
+import java.util.Spliterator;
+import net.imglib2.stream.CursorSpliterator;
+import net.imglib2.stream.LocalizableSpliterator;
+
 /**
  * An {@link IterableRealInterval} whose elements are located at integer
  * coordinates.
@@ -59,4 +63,10 @@ public interface IterableInterval< T > extends IterableRealInterval< T >, Interv
 
 	@Override
 	Cursor< T > localizingCursor();
+
+	@Override
+	default LocalizableSpliterator< T > spliterator()
+	{
+		return new CursorSpliterator<>( cursor(),0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
+	}
 }

--- a/src/main/java/net/imglib2/IterableInterval.java
+++ b/src/main/java/net/imglib2/IterableInterval.java
@@ -69,4 +69,10 @@ public interface IterableInterval< T > extends IterableRealInterval< T >, Interv
 	{
 		return new CursorSpliterator<>( cursor(),0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
 	}
+
+	@Override
+	default LocalizableSpliterator< T > localizingSpliterator()
+	{
+		return new CursorSpliterator<>( localizingCursor(), 0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
+	}
 }

--- a/src/main/java/net/imglib2/IterableInterval.java
+++ b/src/main/java/net/imglib2/IterableInterval.java
@@ -69,8 +69,7 @@ public interface IterableInterval< T > extends IterableRealInterval< T >, Interv
 	 * IterableInterval}. The returned {@code Spliterator} iterates with optimal
 	 * speed without calculating the location at each iteration step.
 	 * Localization is performed on demand.
-	 *
-	 * @implSpec
+	 * <p>
 	 * The default implementation wraps a {@code Cursor} on the interval. The
 	 * created {@code Spliterator} reports {@link Spliterator#SIZED}, {@link
 	 * Spliterator#SUBSIZED},  {@link Spliterator#ORDERED} and {@link
@@ -87,8 +86,7 @@ public interface IterableInterval< T > extends IterableRealInterval< T >, Interv
 	 * IterableInterval}. The returned {@code Spliterator} calculates its
 	 * location at each iteration step. That is, localization is performed with
 	 * optimal speed.
-	 *
-	 * @implSpec
+	 * <p>
 	 * The default implementation wraps a {@link #localizingCursor() localizing}
 	 * {@code Cursor} on the interval. The created {@code Spliterator} reports
 	 * {@link Spliterator#SIZED}, {@link Spliterator#SUBSIZED},  {@link

--- a/src/main/java/net/imglib2/IterableInterval.java
+++ b/src/main/java/net/imglib2/IterableInterval.java
@@ -64,12 +64,36 @@ public interface IterableInterval< T > extends IterableRealInterval< T >, Interv
 	@Override
 	Cursor< T > localizingCursor();
 
+	/**
+	 * Creates a {@link LocalizableSpliterator} over the elements of this {@code
+	 * IterableInterval}. The returned {@code Spliterator} iterates with optimal
+	 * speed without calculating the location at each iteration step.
+	 * Localization is performed on demand.
+	 *
+	 * @implSpec
+	 * The default implementation wraps a {@code Cursor} on the interval. The
+	 * created {@code Spliterator} reports {@link Spliterator#SIZED}, {@link
+	 * Spliterator#SUBSIZED},  {@link Spliterator#ORDERED} and {@link
+	 * Spliterator#NONNULL}.
+	 */
 	@Override
 	default LocalizableSpliterator< T > spliterator()
 	{
 		return new CursorSpliterator<>( cursor(),0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
 	}
 
+	/**
+	 * Creates a {@link LocalizableSpliterator} over the elements of this {@code
+	 * IterableInterval}. The returned {@code Spliterator} calculates its
+	 * location at each iteration step. That is, localization is performed with
+	 * optimal speed.
+	 *
+	 * @implSpec
+	 * The default implementation wraps a {@link #localizingCursor() localizing}
+	 * {@code Cursor} on the interval. The created {@code Spliterator} reports
+	 * {@link Spliterator#SIZED}, {@link Spliterator#SUBSIZED},  {@link
+	 * Spliterator#ORDERED} and {@link Spliterator#NONNULL}.
+	 */
 	@Override
 	default LocalizableSpliterator< T > localizingSpliterator()
 	{

--- a/src/main/java/net/imglib2/IterableRealInterval.java
+++ b/src/main/java/net/imglib2/IterableRealInterval.java
@@ -147,8 +147,7 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 * Note that the returned {@code Stream} gives access only to the values
 	 * of the elements, not their locations. To obtain a {@code Stream} that
 	 * includes locations, see {@link Streams#localizable}.
-	 *
-	 * @implSpec
+	 * <p>
 	 * The default implementation creates a sequential {@code Stream} from the
 	 * interval's {@link #spliterator()}.
 	 */
@@ -164,8 +163,7 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 * Note that the returned {@code Stream} gives access only to the values
 	 * of the elements, not their locations. To obtain a {@code Stream} that
 	 * includes locations, see {@link Streams#localizable}.
-	 *
-	 * @implSpec
+	 * <p>
 	 * The default implementation creates a parallel {@code Stream} from the
 	 * interval's {@link #spliterator()}.
 	 */
@@ -179,8 +177,7 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 * {@code IterableRealInterval}. The returned {@code Spliterator} iterates
 	 * with optimal speed without calculating the location at each iteration
 	 * step. Localization is performed on demand.
-	 *
-	 * @implSpec
+	 * <p>
 	 * The default implementation wraps a {@code RealCursor} on the interval.
 	 * The created {@code Spliterator} reports {@link Spliterator#SIZED}, {@link
 	 * Spliterator#SUBSIZED},  {@link Spliterator#ORDERED} and {@link
@@ -197,8 +194,7 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	 * {@code IterableRealInterval}. The returned {@code Spliterator} calculates
 	 * its location at each iteration step. That is, localization is performed
 	 * with optimal speed.
-	 *
-	 * @implSpec
+	 * <p>
 	 * The default implementation wraps a {@link #localizingCursor() localizing}
 	 * {@code RealCursor} on the interval. The created {@code Spliterator}
 	 * reports {@link Spliterator#SIZED}, {@link Spliterator#SUBSIZED},  {@link

--- a/src/main/java/net/imglib2/IterableRealInterval.java
+++ b/src/main/java/net/imglib2/IterableRealInterval.java
@@ -34,6 +34,11 @@
 
 package net.imglib2;
 
+import java.util.Spliterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import net.imglib2.stream.RealCursorSpliterator;
+
 /**
  * <p>
  * <em>f</em>:R<sup><em>n</em></sup>&isin;[0,<em>s</em>]&rarr;T
@@ -131,5 +136,21 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	default java.util.Iterator< T > iterator() // TODO: fix places where it is not necessary to implement this anymore
 	{
 		return cursor();
+	}
+
+	default Stream< T > stream()
+	{
+		return StreamSupport.stream( spliterator(), false );
+	}
+
+	default Stream< T > parallelStream()
+	{
+		return StreamSupport.stream( spliterator(), true );
+	}
+
+	@Override
+	default Spliterator< T > spliterator()
+	{
+		return new RealCursorSpliterator<>( cursor(),0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
 	}
 }

--- a/src/main/java/net/imglib2/IterableRealInterval.java
+++ b/src/main/java/net/imglib2/IterableRealInterval.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import net.imglib2.stream.RealCursorSpliterator;
 import net.imglib2.stream.RealLocalizableSpliterator;
+import net.imglib2.stream.Streams;
 
 /**
  * <p>
@@ -139,22 +140,70 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 		return cursor();
 	}
 
+	/**
+	 * Returns a sequential {@code Stream} over the elements of this {@code
+	 * IterableRealInterval}.
+	 * <p>
+	 * Note that the returned {@code Stream} gives access only to the values
+	 * of the elements, not their locations. To obtain a {@code Stream} that
+	 * includes locations, see {@link Streams#localizable}.
+	 *
+	 * @implSpec
+	 * The default implementation creates a sequential {@code Stream} from the
+	 * interval's {@link #spliterator()}.
+	 */
 	default Stream< T > stream()
 	{
 		return StreamSupport.stream( spliterator(), false );
 	}
 
+	/**
+	 * Returns a parallel {@code Stream} over the elements of this {@code
+	 * IterableRealInterval}.
+	 * <p>
+	 * Note that the returned {@code Stream} gives access only to the values
+	 * of the elements, not their locations. To obtain a {@code Stream} that
+	 * includes locations, see {@link Streams#localizable}.
+	 *
+	 * @implSpec
+	 * The default implementation creates a parallel {@code Stream} from the
+	 * interval's {@link #spliterator()}.
+	 */
 	default Stream< T > parallelStream()
 	{
 		return StreamSupport.stream( spliterator(), true );
 	}
 
+	/**
+	 * Creates a {@link RealLocalizableSpliterator} over the elements of this
+	 * {@code IterableRealInterval}. The returned {@code Spliterator} iterates
+	 * with optimal speed without calculating the location at each iteration
+	 * step. Localization is performed on demand.
+	 *
+	 * @implSpec
+	 * The default implementation wraps a {@code RealCursor} on the interval.
+	 * The created {@code Spliterator} reports {@link Spliterator#SIZED}, {@link
+	 * Spliterator#SUBSIZED},  {@link Spliterator#ORDERED} and {@link
+	 * Spliterator#NONNULL}.
+	 */
 	@Override
 	default RealLocalizableSpliterator< T > spliterator()
 	{
 		return new RealCursorSpliterator<>( cursor(),0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
 	}
 
+	/**
+	 * Creates a {@link RealLocalizableSpliterator} over the elements of this
+	 * {@code IterableRealInterval}. The returned {@code Spliterator} calculates
+	 * its location at each iteration step. That is, localization is performed
+	 * with optimal speed.
+	 *
+	 * @implSpec
+	 * The default implementation wraps a {@link #localizingCursor() localizing}
+	 * {@code RealCursor} on the interval. The created {@code Spliterator}
+	 * reports {@link Spliterator#SIZED}, {@link Spliterator#SUBSIZED},  {@link
+	 * Spliterator#ORDERED} and {@link Spliterator#NONNULL}.
+	 */
 	default RealLocalizableSpliterator< T > localizingSpliterator()
 	{
 		return new RealCursorSpliterator<>( localizingCursor(), 0, size(), Spliterator.ORDERED | Spliterator.NONNULL );

--- a/src/main/java/net/imglib2/IterableRealInterval.java
+++ b/src/main/java/net/imglib2/IterableRealInterval.java
@@ -154,4 +154,9 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	{
 		return new RealCursorSpliterator<>( cursor(),0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
 	}
+
+	default RealLocalizableSpliterator< T > localizingSpliterator()
+	{
+		return new RealCursorSpliterator<>( localizingCursor(), 0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
+	}
 }

--- a/src/main/java/net/imglib2/IterableRealInterval.java
+++ b/src/main/java/net/imglib2/IterableRealInterval.java
@@ -38,6 +38,7 @@ import java.util.Spliterator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import net.imglib2.stream.RealCursorSpliterator;
+import net.imglib2.stream.RealLocalizableSpliterator;
 
 /**
  * <p>
@@ -149,7 +150,7 @@ public interface IterableRealInterval< T > extends RealInterval, Iterable< T >
 	}
 
 	@Override
-	default Spliterator< T > spliterator()
+	default RealLocalizableSpliterator< T > spliterator()
 	{
 		return new RealCursorSpliterator<>( cursor(),0, size(), Spliterator.ORDERED | Spliterator.NONNULL );
 	}

--- a/src/main/java/net/imglib2/Localizable.java
+++ b/src/main/java/net/imglib2/Localizable.java
@@ -96,6 +96,12 @@ public interface Localizable extends RealLocalizable
 		}
 	}
 
+	@Override
+	default void localize( final RealPositionable position )
+	{
+		localize( ( Positionable ) position );
+	}
+
 	/**
 	 * Return the current position in a given dimension.
 	 *

--- a/src/main/java/net/imglib2/LocalizableSampler.java
+++ b/src/main/java/net/imglib2/LocalizableSampler.java
@@ -1,0 +1,7 @@
+package net.imglib2;
+
+public interface LocalizableSampler< T > extends Localizable, RealLocalizableSampler< T >
+{
+	@Override
+	LocalizableSampler< T > copy();
+}

--- a/src/main/java/net/imglib2/LocalizableSampler.java
+++ b/src/main/java/net/imglib2/LocalizableSampler.java
@@ -1,5 +1,12 @@
 package net.imglib2;
 
+/**
+ * Combination of {@code Localizable} and {@code Sampler} interfaces. In
+ * general, it is preferable to use {@code Localizable & Sampler<T>} where
+ * possible.
+ *
+ * @param <T> pixel type
+ */
 public interface LocalizableSampler< T > extends Localizable, RealLocalizableSampler< T >
 {
 	@Override

--- a/src/main/java/net/imglib2/RealLocalizableSampler.java
+++ b/src/main/java/net/imglib2/RealLocalizableSampler.java
@@ -1,5 +1,12 @@
 package net.imglib2;
 
+/**
+ * Combination of {@code RealLocalizable} and {@code Sampler} interfaces. In
+ * general, it is preferable to use {@code RealLocalizable & Sampler<T>} where
+ * possible.
+ *
+ * @param <T> pixel type
+ */
 public interface RealLocalizableSampler< T > extends RealLocalizable, Sampler< T >
 {
 	@Override

--- a/src/main/java/net/imglib2/RealLocalizableSampler.java
+++ b/src/main/java/net/imglib2/RealLocalizableSampler.java
@@ -1,0 +1,7 @@
+package net.imglib2;
+
+public interface RealLocalizableSampler< T > extends RealLocalizable, Sampler< T >
+{
+	@Override
+	RealLocalizableSampler< T > copy();
+}

--- a/src/main/java/net/imglib2/img/array/AbstractArrayLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/array/AbstractArrayLocalizingCursor.java
@@ -181,11 +181,7 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 		 * loop. We have tested that and it does not provide improved speed when
 		 * done in the above version of the code. Below, it plays a role.
 		 */
-		if ( ++position[ 0 ] <= max[ 0 ] )
-		{
-			return;
-		}
-		else
+		if ( ++position[ 0 ] > max[ 0 ] )
 		{
 			position[ 0 ] = 0;
 
@@ -196,8 +192,6 @@ public abstract class AbstractArrayLocalizingCursor< T extends NativeType< T > >
 				else
 					position[ d ] = 0;
 			}
-
-			return;
 		}
 	}
 

--- a/src/main/java/net/imglib2/img/array/ArrayImg.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImg.java
@@ -235,11 +235,11 @@ public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends
 		return new FlatIterationOrder( interval );
 	}
 
-	@Override
-	public Spliterator< T > spliterator()
-	{
-		return new ArraySpliterator<>( this, 0, ( int ) size() );
-	}
+//	@Override
+//	public Spliterator< T > spliterator()
+//	{
+//		return new ArraySpliterator<>( this, 0, ( int ) size() );
+//	}
 
 	/**
 	 * Deprecated constructor for binary compatibility when A was not bounded by

--- a/src/main/java/net/imglib2/img/array/ArrayImg.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImg.java
@@ -241,6 +241,12 @@ public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends
 		return new ArraySpliterator<>( this, 0, ( int ) size() );
 	}
 
+	@Override
+	public LocalizableSpliterator< T > localizingSpliterator()
+	{
+		return new ArrayLocalizingSpliterator<>( this, 0, ( int ) size() );
+	}
+
 	/**
 	 * Deprecated constructor for binary compatibility when A was not bounded by
 	 * DataAccess

--- a/src/main/java/net/imglib2/img/array/ArrayImg.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImg.java
@@ -34,6 +34,7 @@
 
 package net.imglib2.img.array;
 
+import java.util.Spliterator;
 import net.imglib2.Cursor;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
@@ -232,6 +233,12 @@ public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends
 	public Object subIntervalIterationOrder( final Interval interval )
 	{
 		return new FlatIterationOrder( interval );
+	}
+
+	@Override
+	public Spliterator< T > spliterator()
+	{
+		return new ArraySpliterator<>( this, 0, ( int ) size() );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/array/ArrayImg.java
+++ b/src/main/java/net/imglib2/img/array/ArrayImg.java
@@ -34,13 +34,13 @@
 
 package net.imglib2.img.array;
 
-import java.util.Spliterator;
 import net.imglib2.Cursor;
 import net.imglib2.FlatIterationOrder;
 import net.imglib2.Interval;
 import net.imglib2.img.AbstractNativeImg;
 import net.imglib2.img.Img;
 import net.imglib2.img.basictypeaccess.DataAccess;
+import net.imglib2.stream.LocalizableSpliterator;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Fraction;
 import net.imglib2.util.IntervalIndexer;
@@ -235,11 +235,11 @@ public class ArrayImg< T extends NativeType< T >, A extends DataAccess > extends
 		return new FlatIterationOrder( interval );
 	}
 
-//	@Override
-//	public Spliterator< T > spliterator()
-//	{
-//		return new ArraySpliterator<>( this, 0, ( int ) size() );
-//	}
+	@Override
+	public LocalizableSpliterator< T > spliterator()
+	{
+		return new ArraySpliterator<>( this, 0, ( int ) size() );
+	}
 
 	/**
 	 * Deprecated constructor for binary compatibility when A was not bounded by

--- a/src/main/java/net/imglib2/img/array/ArrayLocalizingSpliterator.java
+++ b/src/main/java/net/imglib2/img/array/ArrayLocalizingSpliterator.java
@@ -80,17 +80,6 @@ class ArrayLocalizingSpliterator< T extends NativeType< T > > extends AbstractLo
 		return false;
 	}
 
-	@Override
-	public boolean tryAdvance()
-	{
-		if ( index.get() < fence - 1 )
-		{
-			fwd();
-			return true;
-		}
-		return false;
-	}
-
 	private void fwd()
 	{
 		index.inc();

--- a/src/main/java/net/imglib2/img/array/ArrayLocalizingSpliterator.java
+++ b/src/main/java/net/imglib2/img/array/ArrayLocalizingSpliterator.java
@@ -1,0 +1,186 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2023 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.array;
+
+import java.util.function.Consumer;
+import net.imglib2.AbstractLocalizableInt;
+import net.imglib2.stream.LocalizableSpliterator;
+import net.imglib2.type.Index;
+import net.imglib2.type.NativeType;
+import net.imglib2.util.IntervalIndexer;
+
+class ArrayLocalizingSpliterator< T extends NativeType< T > > extends AbstractLocalizableInt implements LocalizableSpliterator< T >
+{
+	private final ArrayImg< T, ? > img;
+
+	private final T type;
+
+	private final Index index;
+
+	private final int fence;  // one past last index
+
+	ArrayLocalizingSpliterator( ArrayImg< T, ? > img, int origin, int fence )
+	{
+		super( img.numDimensions() );
+		this.img = img;
+		type = img.createLinkedType();
+		index = type.index();
+		this.fence = fence;
+
+		type.updateContainer( this );
+		index.set( origin - 1 );
+
+		IntervalIndexer.indexToPosition( origin, img.dim, position );
+		position[ 0 ]--;
+	}
+
+	@Override
+	public boolean tryAdvance( final Consumer< ? super T > action )
+	{
+		if ( action == null )
+			throw new NullPointerException();
+		if ( index.get() < fence - 1 )
+		{
+			fwd();
+			action.accept( type );
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean tryAdvance()
+	{
+		if ( index.get() < fence - 1 )
+		{
+			fwd();
+			return true;
+		}
+		return false;
+	}
+
+	private void fwd()
+	{
+		index.inc();
+		if ( ++position[ 0 ] > img.dim[ 0 ] - 1 )
+		{
+			position[ 0 ] = 0;
+
+			for ( int d = 1; d < n; ++d )
+			{
+				if ( ++position[ d ] <= img.dim[ d ] - 1 )
+					break;
+				else
+					position[ d ] = 0;
+			}
+		}
+	}
+
+	@Override
+	public void forEachRemaining( final Consumer< ? super T > action )
+	{
+		if ( action == null )
+			throw new NullPointerException();
+
+		int len = fence - index.get() - 1;
+		while ( len > 0 )
+		{
+			final int lenX = Math.min(
+					len,
+					img.dim[ 0 ] - 1 - position[ 0 ] );
+			for ( int x = 0; x < lenX; ++x )
+			{
+				++position[ 0 ];
+				index.inc();
+				action.accept( type );
+			}
+			len -= lenX;
+			if ( len > 0 )
+				nextLine();
+		}
+	}
+
+	private void nextLine()
+	{
+		position[ 0 ] = -1;
+		for ( int d = 1; d < n; ++d )
+		{
+			if ( ++position[ d ] <= img.dim[ d ] - 1 )
+				break;
+			else
+				position[ d ] = 0;
+		}
+	}
+
+	@Override
+	public ArrayLocalizingSpliterator< T > trySplit()
+	{
+		int lo = index.get() + 1, mid = ( lo + fence ) >>> 1;
+		if ( lo >= mid )
+			return null;
+		else
+		{
+			final ArrayLocalizingSpliterator< T > prefix = new ArrayLocalizingSpliterator<>( img, lo, mid );
+			index.set( mid - 1 );
+			IntervalIndexer.indexToPosition( mid, img.dim, position );
+			position[ 0 ]--;
+			return prefix;
+		}
+	}
+
+	@Override
+	public long estimateSize()
+	{
+		return fence - index.get() - 1;
+	}
+
+	@Override
+	public int characteristics()
+	{
+		return IMMUTABLE | NONNULL | ORDERED | SIZED | SUBSIZED;
+	}
+
+	@Override
+	public ArrayLocalizingSpliterator< T > copy()
+	{
+		return new ArrayLocalizingSpliterator<>( img, index.get() + 1, fence );
+	}
+
+	@Override
+	public T get()
+	{
+		return type;
+	}
+}

--- a/src/main/java/net/imglib2/img/array/ArrayLocalizingSpliterator.java
+++ b/src/main/java/net/imglib2/img/array/ArrayLocalizingSpliterator.java
@@ -41,6 +41,12 @@ import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.IntervalIndexer;
 
+/**
+ * LocalizableSpliterator for ArrayImg.
+ * Keeps track of location on every step.
+ *
+ * @param <T> pixel type
+ */
 class ArrayLocalizingSpliterator< T extends NativeType< T > > extends AbstractLocalizableInt implements LocalizableSpliterator< T >
 {
 	private final ArrayImg< T, ? > img;

--- a/src/main/java/net/imglib2/img/array/ArraySpliterator.java
+++ b/src/main/java/net/imglib2/img/array/ArraySpliterator.java
@@ -1,0 +1,101 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2023 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.array;
+
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import net.imglib2.type.Index;
+import net.imglib2.type.NativeType;
+
+public class ArraySpliterator< T extends NativeType< T > > implements Spliterator< T >
+{
+	private final ArrayImg< T, ? > img;
+
+	private final T type;
+
+	private final Index typeIndex;
+
+	private final int fence;  // one past last index
+
+	ArraySpliterator( final ArrayImg< T, ? > img, int origin, int fence )
+	{
+		this.img = img;
+		type = img.createLinkedType();
+		type.updateContainer( this );
+		typeIndex = type.index();
+		typeIndex.set( origin );
+		this.fence = fence;
+	}
+
+	@Override
+	public boolean tryAdvance( final Consumer< ? super T > action )
+	{
+		if ( action == null )
+			throw new NullPointerException();
+		if ( typeIndex.get() < fence )
+		{
+			action.accept( type );
+			typeIndex.inc();
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public ArraySpliterator< T > trySplit()
+	{
+		int lo = typeIndex.get(), mid = ( lo + fence ) >>> 1;
+		if ( lo >= mid )
+			return null;
+		else
+		{
+			final ArraySpliterator< T > prefix = new ArraySpliterator<>( img, lo, mid );
+			typeIndex.set( mid );
+			return prefix;
+		}
+	}
+
+	@Override
+	public long estimateSize()
+	{
+		return fence - typeIndex.get();
+	}
+
+	@Override
+	public int characteristics()
+	{
+		return IMMUTABLE | NONNULL | ORDERED | SIZED | SUBSIZED;
+	}
+}

--- a/src/main/java/net/imglib2/img/array/ArraySpliterator.java
+++ b/src/main/java/net/imglib2/img/array/ArraySpliterator.java
@@ -42,6 +42,12 @@ import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.IntervalIndexer;
 
+/**
+ * LocalizableSpliterator for ArrayImg.
+ * Localizes on demand.
+ *
+ * @param <T> pixel type
+ */
 class ArraySpliterator< T extends NativeType< T > > implements LocalizableSpliterator< T >
 {
 	private final ArrayImg< T, ? > img;

--- a/src/main/java/net/imglib2/img/array/ArraySpliterator.java
+++ b/src/main/java/net/imglib2/img/array/ArraySpliterator.java
@@ -78,17 +78,6 @@ class ArraySpliterator< T extends NativeType< T > > implements LocalizableSplite
 	}
 
 	@Override
-	public boolean tryAdvance()
-	{
-		if ( index.get() < fence - 1 )
-		{
-			index.inc();
-			return true;
-		}
-		return false;
-	}
-
-	@Override
 	public void forEachRemaining( final Consumer< ? super T > action )
 	{
 		if ( action == null )

--- a/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
+++ b/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
@@ -39,6 +39,7 @@ import net.imglib2.RandomAccessible;
 import net.imglib2.img.AbstractNativeImg;
 import net.imglib2.img.Img;
 import net.imglib2.img.basictypeaccess.DataAccess;
+import net.imglib2.stream.LocalizableSpliterator;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Fraction;
 
@@ -91,6 +92,12 @@ public abstract class AbstractCellImg<
 	public CellCursor< T, C > cursor()
 	{
 		return new CellCursor<>( this );
+	}
+
+	@Override
+	public LocalizableSpliterator< T > spliterator()
+	{
+		return new CellSpliterator<>( this, 0, size() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
+++ b/src/main/java/net/imglib2/img/cell/AbstractCellImg.java
@@ -101,6 +101,13 @@ public abstract class AbstractCellImg<
 	}
 
 	@Override
+	public LocalizableSpliterator< T > localizingSpliterator()
+	{
+		// TODO: Implement CellLocalizingSpliterator
+		return spliterator();
+	}
+
+	@Override
 	public CellLocalizingCursor< T, C > localizingCursor()
 	{
 		return new CellLocalizingCursor<>( this );

--- a/src/main/java/net/imglib2/img/cell/CellSpliterator.java
+++ b/src/main/java/net/imglib2/img/cell/CellSpliterator.java
@@ -1,0 +1,373 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2023 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.cell;
+
+import java.util.function.Consumer;
+import net.imglib2.Cursor;
+import net.imglib2.Positionable;
+import net.imglib2.RealPositionable;
+import net.imglib2.stream.LocalizableSpliterator;
+import net.imglib2.type.Index;
+import net.imglib2.type.NativeType;
+
+/**
+ * Spliterator for {@link CellImg}.
+ */
+class CellSpliterator< T extends NativeType< T >, C extends Cell< ? > > implements LocalizableSpliterator< T >
+{
+	private final AbstractCellImg< T, ?, C, ? > img;
+
+	private final CellGrid grid;
+
+	private final T type;
+
+	private final Index index;
+
+	private final CursorOnCells< C > currentCell;
+
+	private int lastIndexInCurrentCell;
+
+	private final long lastCell;
+
+	private final int lastIndexInLastCell;
+
+	private final long[] tmpIndices;
+
+	CellSpliterator( AbstractCellImg< T, ?, C, ? > img, long origin, long fence )
+	{
+		this.img = img;
+		grid = img.getCellGrid();
+		type = img.createLinkedType();
+		index = type.index();
+		currentCell = new CursorOnCells<>( img.getCells().cursor() );
+
+		tmpIndices = new long[ 2 ];
+
+		grid.getCellAndPixelIndices( fence - 1, tmpIndices );
+		lastCell = tmpIndices[ 0 ];
+		lastIndexInLastCell = ( int ) tmpIndices[ 1 ];
+
+		jumpBefore( origin );
+
+		tmp = new long[ img.numDimensions() ];
+	}
+
+	private CellSpliterator( CellSpliterator< T, C > o )
+	{
+		img = o.img;
+		grid = o.grid;
+		type = o.type.duplicateTypeOnSameNativeImg();
+		index = type.index();
+		index.set( o.index.get() );
+		currentCell = o.currentCell.copy();
+		lastCell = o.lastCell;
+		lastIndexInLastCell = o.lastIndexInLastCell;
+
+		lastIndexInCurrentCell = o.lastIndexInCurrentCell;
+		tmp = new long[ o.tmp.length ];
+		tmpIndices = new long[ 2 ];
+		type.updateContainer( currentCell );
+	}
+
+	private void jumpBefore( final long i )
+	{
+		grid.getCellAndPixelIndices( i, tmpIndices );
+		currentCell.setIndex( tmpIndices[ 0 ] );
+		cellUpdated();
+		final int indexInCell = ( int ) tmpIndices[ 1 ];
+		index.set( indexInCell - 1 );
+	}
+
+	private void cellUpdated()
+	{
+		final boolean isLastCell = currentCell.index() == lastCell;
+		lastIndexInCurrentCell = isLastCell
+				? lastIndexInLastCell
+				: ( int ) ( currentCell.getCell().size() - 1 );
+		type.updateContainer( currentCell );
+	}
+
+
+	@Override
+	public boolean tryAdvance( final Consumer< ? super T > action )
+	{
+		if ( action == null )
+			throw new NullPointerException();
+
+		if ( tryAdvance() )
+		{
+			action.accept( type );
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean tryAdvance()
+	{
+		if ( index.get() < lastIndexInCurrentCell )
+		{
+			index.inc();
+			return true;
+		}
+		else if ( currentCell.index() < lastCell )
+		{
+			currentCell.fwd();
+			cellUpdated();
+			index.set( 0 );
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	@Override
+	public void forEachRemaining( final Consumer< ? super T > action )
+	{
+		if ( action == null )
+			throw new NullPointerException();
+
+		while ( currentCell.index() < lastCell )
+		{
+			forEachRemainingInCell( action );
+			currentCell.fwd();
+			cellUpdated();
+			index.set( -1 );
+		}
+		forEachRemainingInCell( action );
+	}
+
+	private void forEachRemainingInCell( final Consumer< ? super T > action )
+	{
+		final int len = lastIndexInCurrentCell - index.get();
+		for ( int i = 0; i < len; i++ )
+		{
+			index.inc();
+			action.accept( type );
+		}
+	}
+
+	private long globalIndex( long cell, int index )
+	{
+		return grid.indexOfFirstPixelInCell( cell, tmp ) + index;
+	}
+
+	@Override
+	public CellSpliterator< T, C > trySplit()
+	{
+		long lo = globalIndex( currentCell.index(), index.get() ) + 1;
+		long mid = ( lo + globalIndex( lastCell, lastIndexInLastCell ) + 1 ) >>> 1;
+		if ( lo >= mid )
+			return null;
+		else
+		{
+			final CellSpliterator< T, C > prefix = new CellSpliterator<>( img, lo, mid );
+			jumpBefore( mid );
+			return prefix;
+		}
+	}
+
+	@Override
+	public long estimateSize()
+	{
+		if ( currentCell.index() == lastCell )
+			return lastIndexInLastCell - index.get();
+		else
+			return globalIndex( lastCell, lastIndexInLastCell ) - globalIndex( currentCell.index(), index.get() );
+	}
+
+	@Override
+	public int characteristics()
+	{
+		return IMMUTABLE | NONNULL | ORDERED | SIZED | SUBSIZED;
+	}
+
+	@Override
+	public CellSpliterator< T, C > copy()
+	{
+		return new CellSpliterator<>( this );
+	}
+
+	@Override
+	public T get()
+	{
+		return type;
+	}
+
+	@Override
+	public String toString()
+	{
+		long lo = globalIndex( currentCell.index(), index.get() ) + 1;
+		long hi = globalIndex( lastCell, lastIndexInLastCell ) + 1;
+		return "lo = " + lo + ", hi = " + hi;
+	}
+
+	// -- Localizable --
+
+	@Override
+	public long getLongPosition( final int d )
+	{
+		return currentCell.getCell().indexToGlobalPosition( index.get(), d );
+	}
+
+	@Override
+	public void localize( final long[] pos )
+	{
+		currentCell.getCell().indexToGlobalPosition( index.get(), pos );
+	}
+
+	/**
+	 * used internally to forward all localize() versions to the (abstract)
+	 * long[] version.
+	 */
+	final private long[] tmp;
+
+	@Override
+	public int numDimensions()
+	{
+		return tmp.length;
+	}
+
+	@Override
+	public void localize( final int[] pos )
+	{
+		localize( tmp );
+		for ( int d = 0; d < tmp.length; d++ )
+			pos[ d ] = ( int ) tmp[ d ];
+	}
+
+	@Override
+	public void localize( final float[] pos )
+	{
+		localize( tmp );
+		for ( int d = 0; d < tmp.length; d++ )
+			pos[ d ] = tmp[ d ];
+	}
+
+	@Override
+	public void localize( final double[] pos )
+	{
+		localize( tmp );
+		for ( int d = 0; d < tmp.length; d++ )
+			pos[ d ] = tmp[ d ];
+	}
+
+	@Override
+	public void localize( final Positionable position )
+	{
+		localize( tmp );
+		position.setPosition( tmp );
+	}
+
+	@Override
+	public void localize( final RealPositionable position )
+	{
+		localize( tmp );
+		position.setPosition( tmp );
+	}
+
+	@Override
+	public float getFloatPosition( final int d )
+	{
+		return getLongPosition( d );
+	}
+
+	@Override
+	public double getDoublePosition( final int d )
+	{
+		return getLongPosition( d );
+	}
+
+	@Override
+	public int getIntPosition( final int d )
+	{
+		return ( int ) getLongPosition( d );
+	}
+
+	private static class CursorOnCells< C extends Cell< ? > > implements AbstractCellImg.CellImgSampler< C >
+	{
+		private long index;
+
+		private final Cursor< C > delegate;
+
+		/**
+		 * Delegate is assumed to be in initial state, such that the first fwd()
+		 * will move to the first element.
+		 */
+		CursorOnCells( final Cursor< C > delegate )
+		{
+			this.delegate = delegate;
+			index = -1;
+		}
+
+		CursorOnCells( final CursorOnCells< C > o )
+		{
+			delegate = o.delegate.copy();
+			index = o.index;
+		}
+
+		public long index()
+		{
+			return index;
+		}
+
+		public void setIndex( long index )
+		{
+			final long steps = index - this.index;
+			this.index = index;
+			if ( steps != 0 )
+				delegate.jumpFwd( steps );
+		}
+
+		@Override
+		public C getCell()
+		{
+			return delegate.get();
+		}
+
+		public void fwd()
+		{
+			++index;
+			delegate.fwd();
+		}
+
+		public CursorOnCells< C > copy()
+		{
+			return new CursorOnCells<>( this );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/img/cell/CellSpliterator.java
+++ b/src/main/java/net/imglib2/img/cell/CellSpliterator.java
@@ -119,27 +119,16 @@ class CellSpliterator< T extends NativeType< T >, C extends Cell< ? > > implemen
 		type.updateContainer( currentCell );
 	}
 
-
 	@Override
 	public boolean tryAdvance( final Consumer< ? super T > action )
 	{
 		if ( action == null )
 			throw new NullPointerException();
 
-		if ( tryAdvance() )
-		{
-			action.accept( type );
-			return true;
-		}
-		return false;
-	}
-
-	@Override
-	public boolean tryAdvance()
-	{
 		if ( index.get() < lastIndexInCurrentCell )
 		{
 			index.inc();
+			action.accept( type );
 			return true;
 		}
 		else if ( currentCell.index() < lastCell )
@@ -147,6 +136,7 @@ class CellSpliterator< T extends NativeType< T >, C extends Cell< ? > > implemen
 			currentCell.fwd();
 			cellUpdated();
 			index.set( 0 );
+			action.accept( type );
 			return true;
 		}
 		else

--- a/src/main/java/net/imglib2/img/cell/CellSpliterator.java
+++ b/src/main/java/net/imglib2/img/cell/CellSpliterator.java
@@ -43,7 +43,10 @@ import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
 /**
- * Spliterator for {@link CellImg}.
+ * LocalizableSpliterator for {@link CellImg}.
+ * Localizes on demand.
+ *
+ * @param <T> pixel type
  */
 class CellSpliterator< T extends NativeType< T >, C extends Cell< ? > > implements LocalizableSpliterator< T >
 {

--- a/src/main/java/net/imglib2/img/planar/PlanarImg.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImg.java
@@ -44,6 +44,7 @@ import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Fraction;
 import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
 import net.imglib2.view.iteration.SubIntervalIterable;
 
 import java.util.ArrayList;
@@ -79,7 +80,7 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 	public PlanarImg( final List< A > slices, final long[] dim, final Fraction entitiesPerPixel )
 	{
 		super( dim, entitiesPerPixel );
-		this.dimensions = longToIntArray( dim );
+		this.dimensions = Util.long2int( dim );
 		this.sliceSteps = computeSliceSteps( dim );
 		this.numSlices = numberOfSlices( dim );
 		if(slices.size() != numSlices)
@@ -351,14 +352,6 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 	}
 
 	// -- Helper methods --
-
-	private static int[] longToIntArray( final long[] dim )
-	{
-		final int[] dimensions = new int[ dim.length ];
-		for ( int d = 0; d < dim.length; ++d )
-			dimensions[ d ] = ( int ) dim[ d ];
-		return dimensions;
-	}
 
 	private static int[] computeSliceSteps( final long[] dimensions )
 	{

--- a/src/main/java/net/imglib2/img/planar/PlanarImg.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarImg.java
@@ -318,6 +318,13 @@ public class PlanarImg< T extends NativeType< T >, A extends ArrayDataAccess< A 
 		return new PlanarSpliterator<>( this, 0, size() );
 	}
 
+	@Override
+	public LocalizableSpliterator< T > localizingSpliterator()
+	{
+		// TODO: Implement PlanarLocalizingSpliterator
+		return spliterator();
+	}
+
 	private boolean correspondsToPlane( final Interval interval )
 	{
 		// check if interval describes one plane

--- a/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarLocalizingCursor.java
@@ -151,16 +151,24 @@ public class PlanarLocalizingCursor< T extends NativeType< T > > extends Abstrac
 			index = 0;
 			++sliceIndex;
 			type.updateContainer( this );
+			position[ 0 ] = 0;
+			position[ 1 ] = 0;
+			for ( int d = 2; d < n; ++d )
+			{
+				if ( ++position[ d ] > max[ d ] )
+					position[ d ] = 0;
+				else
+					break;
+			}
+		} else {
+			if ( ++position[ 0 ] > max[ 0 ] )
+			{
+				position[ 0 ] = 0;
+				++position[ 1 ];
+			}
 		}
 		typeIndex.set( index );
 
-		for ( int d = 0; d < n; ++d )
-		{
-			if ( ++position[ d ] > max[ d ] )
-				position[ d ] = 0;
-			else
-				break;
-		}
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/planar/PlanarSpliterator.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarSpliterator.java
@@ -182,7 +182,7 @@ class PlanarSpliterator< T extends NativeType< T > > implements LocalizableSplit
 		else
 		{
 			final PlanarSpliterator< T > prefix = new PlanarSpliterator<>( img, lo, mid );
-			slice = ( int ) ( ( mid - 1 ) / elementsPerSlice );
+			slice = ( int ) ( mid / elementsPerSlice );
 			index.set( ( int ) ( mid - 1 - slice * elementsPerSlice ) );
 			type.updateContainer( this );
 			return prefix;

--- a/src/main/java/net/imglib2/img/planar/PlanarSpliterator.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarSpliterator.java
@@ -41,6 +41,12 @@ import net.imglib2.stream.LocalizableSpliterator;
 import net.imglib2.type.Index;
 import net.imglib2.type.NativeType;
 
+/**
+ * LocalizableSpliterator for {@link PlanarImg}.
+ * Localizes on demand.
+ *
+ * @param <T> pixel type
+ */
 class PlanarSpliterator< T extends NativeType< T > > implements LocalizableSpliterator< T >, PlanarImg.PlanarContainerSampler
 {
 	private final PlanarImg< T, ? > img;

--- a/src/main/java/net/imglib2/img/planar/PlanarSpliterator.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarSpliterator.java
@@ -1,0 +1,294 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2023 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.planar;
+
+import java.util.function.Consumer;
+import net.imglib2.Positionable;
+import net.imglib2.RealPositionable;
+import net.imglib2.stream.LocalizableSpliterator;
+import net.imglib2.type.Index;
+import net.imglib2.type.NativeType;
+
+class PlanarSpliterator< T extends NativeType< T > > implements LocalizableSpliterator< T >, PlanarImg.PlanarContainerSampler
+{
+	private final PlanarImg< T, ? > img;
+
+	private final T type;
+
+	private final long elementsPerSlice;
+
+	private final int lastSlice;
+
+	private final int lastIndexInSlice;
+
+	private final int lastIndexInLastSlice;
+
+	private int slice;
+
+	private final Index index;
+
+	PlanarSpliterator( PlanarImg< T, ? > img, long origin, long fence )
+	{
+		this.img = img;
+		this.type = img.createLinkedType();
+		this.elementsPerSlice = img.elementsPerSlice;
+
+		final long last = fence - 1;
+		lastSlice = ( int ) ( last / elementsPerSlice );
+		lastIndexInSlice = img.elementsPerSlice - 1;
+		lastIndexInLastSlice = ( int ) ( last - lastSlice * elementsPerSlice );
+
+		index = type.index();
+		slice = ( int ) ( origin / elementsPerSlice );
+		index.set( ( int ) ( origin - slice * elementsPerSlice ) );
+		index.dec();
+
+		type.updateContainer( this );
+
+		tmp = new int[ img.numDimensions() ];
+	}
+
+	private PlanarSpliterator( PlanarSpliterator< T > o )
+	{
+		img = o.img;
+		type = img.createLinkedType();
+		elementsPerSlice = o.elementsPerSlice;
+		lastSlice = o.lastSlice;
+		lastIndexInSlice = o.lastIndexInSlice;
+		lastIndexInLastSlice = o.lastIndexInLastSlice;
+		slice = o.slice;
+		index = type.index();
+		index.set( o.index.get() );
+		type.updateContainer( this );
+		tmp = new int[ img.numDimensions() ];
+	}
+
+	@Override
+	public int getCurrentSliceIndex()
+	{
+		return slice;
+	}
+
+	@Override
+	public int numDimensions()
+	{
+		return img.numDimensions();
+	}
+
+	@Override
+	public boolean tryAdvance( final Consumer< ? super T > action )
+	{
+		if ( action == null )
+			throw new NullPointerException();
+
+		if ( tryAdvance() )
+		{
+			action.accept( type );
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean tryAdvance()
+	{
+		if ( slice >= lastSlice && index.get() >= lastIndexInLastSlice )
+			return false;
+
+		if ( index.get() < lastIndexInSlice )
+		{
+			index.inc();
+		}
+		else
+		{
+			index.set( 0 );
+			++slice;
+			type.updateContainer( this );
+		}
+
+		return true;
+	}
+
+	@Override
+	public void forEachRemaining( final Consumer< ? super T > action )
+	{
+		if ( action == null )
+			throw new NullPointerException();
+
+		while ( slice < lastSlice )
+		{
+			forEachRemainingInSlice( action );
+			index.set( -1 );
+			++slice;
+			type.updateContainer( this );
+		}
+		forEachRemainingInSlice( action );
+	}
+
+	private void forEachRemainingInSlice(final Consumer< ? super T > action)
+	{
+		final int len = ( slice == lastSlice ? lastIndexInLastSlice : lastIndexInSlice ) - index.get();
+		for ( int i = 0; i < len; i++ )
+		{
+			index.inc();
+			action.accept( type );
+		}
+	}
+
+	private long globalIndex( int slice, int index )
+	{
+		return slice * elementsPerSlice + index;
+	}
+
+	@Override
+	public PlanarSpliterator< T > trySplit()
+	{
+		long lo = globalIndex( slice, index.get() ) + 1;
+		long mid = ( lo + globalIndex( lastSlice, lastIndexInLastSlice ) + 1 ) >>> 1;
+		if ( lo >= mid )
+			return null;
+		else
+		{
+			final PlanarSpliterator< T > prefix = new PlanarSpliterator<>( img, lo, mid );
+			slice = ( int ) ( ( mid - 1 ) / elementsPerSlice );
+			index.set( ( int ) ( mid - 1 - slice * elementsPerSlice ) );
+			type.updateContainer( this );
+			return prefix;
+		}
+	}
+
+	@Override
+	public long estimateSize()
+	{
+		return ( lastSlice - slice ) * elementsPerSlice + lastIndexInLastSlice - index.get();
+	}
+
+	@Override
+	public int characteristics()
+	{
+		return IMMUTABLE | NONNULL | ORDERED | SIZED | SUBSIZED;
+	}
+
+	@Override
+	public PlanarSpliterator< T > copy()
+	{
+		return new PlanarSpliterator<>( this );
+	}
+
+	@Override
+	public T get()
+	{
+		return type;
+	}
+
+
+
+
+	// -- Localizable --
+
+	@Override
+	public void localize( final int[] pos )
+	{
+		img.indexToGlobalPosition( slice, index.get(), pos );
+	}
+
+	@Override
+	public int getIntPosition( final int d )
+	{
+		return img.indexToGlobalPosition( slice, index.get(), d );
+	}
+
+	/**
+	 * used internally to forward all localize() versions to the (abstract)
+	 * int[] version.
+	 */
+	final private int[] tmp;
+
+	@Override
+	public void localize( final float[] pos )
+	{
+		localize( tmp );
+		for ( int d = 0; d < tmp.length; d++ )
+			pos[ d ] = tmp[ d ];
+	}
+
+	@Override
+	public void localize( final double[] pos )
+	{
+		localize( tmp );
+		for ( int d = 0; d < tmp.length; d++ )
+			pos[ d ] = tmp[ d ];
+	}
+
+	@Override
+	public void localize( final Positionable position )
+	{
+		localize( tmp );
+		position.setPosition( tmp );
+	}
+
+	@Override
+	public void localize( final RealPositionable position )
+	{
+		localize( tmp );
+		position.setPosition( tmp );
+	}
+
+	@Override
+	public void localize( final long[] pos )
+	{
+		localize( tmp );
+		for ( int d = 0; d < tmp.length; d++ )
+			pos[ d ] = tmp[ d ];
+	}
+
+	@Override
+	public float getFloatPosition( final int d )
+	{
+		return getIntPosition( d );
+	}
+
+	@Override
+	public double getDoublePosition( final int d )
+	{
+		return getIntPosition( d );
+	}
+
+	@Override
+	public long getLongPosition( final int d )
+	{
+		return getIntPosition( d );
+	}
+}

--- a/src/main/java/net/imglib2/img/planar/PlanarSpliterator.java
+++ b/src/main/java/net/imglib2/img/planar/PlanarSpliterator.java
@@ -113,17 +113,6 @@ class PlanarSpliterator< T extends NativeType< T > > implements LocalizableSplit
 		if ( action == null )
 			throw new NullPointerException();
 
-		if ( tryAdvance() )
-		{
-			action.accept( type );
-			return true;
-		}
-		return false;
-	}
-
-	@Override
-	public boolean tryAdvance()
-	{
 		if ( slice >= lastSlice && index.get() >= lastIndexInLastSlice )
 			return false;
 
@@ -138,6 +127,7 @@ class PlanarSpliterator< T extends NativeType< T > > implements LocalizableSplit
 			type.updateContainer( this );
 		}
 
+		action.accept( type );
 		return true;
 	}
 

--- a/src/main/java/net/imglib2/stream/CursorSpliterator.java
+++ b/src/main/java/net/imglib2/stream/CursorSpliterator.java
@@ -70,18 +70,6 @@ public class CursorSpliterator< T > implements LocalizableSpliterator< T >
 	}
 
 	@Override
-	public boolean tryAdvance()
-	{
-		if ( index >= 0 && index < fence )
-		{
-			++index;
-			cursor.fwd();
-			return true;
-		}
-		return false;
-	}
-
-	@Override
 	public CursorSpliterator< T > trySplit()
 	{
 		long lo = index, mid = ( lo + fence ) >>> 1;

--- a/src/main/java/net/imglib2/stream/CursorSpliterator.java
+++ b/src/main/java/net/imglib2/stream/CursorSpliterator.java
@@ -2,7 +2,9 @@ package net.imglib2.stream;
 
 import java.util.Spliterator;
 import java.util.function.Consumer;
-import net.imglib2.RealCursor;
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.Positionable;
 import net.imglib2.RealPoint;
 import net.imglib2.RealPositionable;
 
@@ -11,12 +13,12 @@ import net.imglib2.RealPositionable;
  *
  * @param <T> the type of elements returned by this Spliterator, and the pixel type of the underlying cursor.
  */
-public class RealCursorSpliterator< T > implements RealLocalizableSpliterator< T >
+public class CursorSpliterator< T > implements LocalizableSpliterator< T >
 {
 	/**
 	 * The underlying cursor, positioned such that {@code cursor.next()} yields the element at {@code index}.
 	 */
-	private final RealCursor< T > cursor;
+	private final Cursor< T > cursor;
 
 	/**
 	 * The current index, modified on advance/split.
@@ -45,7 +47,7 @@ public class RealCursorSpliterator< T > implements RealLocalizableSpliterator< T
 	 * @param additionalCharacteristics
 	 * 		additional characteristics besides {@code SIZED | SUBSIZED}
 	 */
-	public RealCursorSpliterator( RealCursor< T > cursor, long origin, long fence, int additionalCharacteristics )
+	public CursorSpliterator( Cursor< T > cursor, long origin, long fence, int additionalCharacteristics )
 	{
 		this.cursor = cursor;
 		this.index = origin;
@@ -80,14 +82,14 @@ public class RealCursorSpliterator< T > implements RealLocalizableSpliterator< T
 	}
 
 	@Override
-	public RealCursorSpliterator< T > trySplit()
+	public CursorSpliterator< T > trySplit()
 	{
 		long lo = index, mid = ( lo + fence ) >>> 1;
 		if ( lo >= mid )
 			return null;
 		else
 		{
-			final RealCursorSpliterator< T > prefix = new RealCursorSpliterator<>( cursor.copy(), lo, mid, characteristics );
+			final CursorSpliterator< T > prefix = new CursorSpliterator<>( cursor.copy(), lo, mid, characteristics );
 			cursor.jumpFwd( mid - lo );
 			index = mid;
 			return prefix;
@@ -117,9 +119,9 @@ public class RealCursorSpliterator< T > implements RealLocalizableSpliterator< T
 	}
 
 	@Override
-	public RealCursorSpliterator< T > copy()
+	public CursorSpliterator< T > copy()
 	{
-		return new RealCursorSpliterator<>( cursor.copy(), index, fence, characteristics );
+		return new CursorSpliterator<>( cursor.copy(), index, fence, characteristics );
 	}
 
 
@@ -172,5 +174,51 @@ public class RealCursorSpliterator< T > implements RealLocalizableSpliterator< T
 	public double getDoublePosition( final int d )
 	{
 		return cursor.getDoublePosition( d );
+	}
+
+
+	// -----------------------------------------------------------
+	//   Localizable
+
+	@Override
+	public void localize( final int[] position )
+	{
+		cursor.localize( position );
+	}
+
+	@Override
+	public void localize( final long[] position )
+	{
+		cursor.localize( position );
+	}
+
+	@Override
+	public void localize( final Positionable position )
+	{
+		cursor.localize( position );
+	}
+
+	@Override
+	public int getIntPosition( final int d )
+	{
+		return cursor.getIntPosition( d );
+	}
+
+	@Override
+	public long[] positionAsLongArray()
+	{
+		return cursor.positionAsLongArray();
+	}
+
+	@Override
+	public Point positionAsPoint()
+	{
+		return cursor.positionAsPoint();
+	}
+
+	@Override
+	public long getLongPosition( final int d )
+	{
+		return cursor.getLongPosition( d );
 	}
 }

--- a/src/main/java/net/imglib2/stream/LocalizableSamplerWrapper.java
+++ b/src/main/java/net/imglib2/stream/LocalizableSamplerWrapper.java
@@ -30,19 +30,13 @@ class LocalizableSamplerWrapper< T > implements Spliterator< LocalizableSampler<
 	@Override
 	public void forEachRemaining( final Consumer< ? super LocalizableSampler< T > > action )
 	{
-		delegate.forEachRemaining( () -> action.accept( this ) );
+		delegate.forEachRemaining( t -> action.accept( this ) );
 	}
 
 	@Override
 	public boolean tryAdvance( final Consumer< ? super LocalizableSampler< T > > action )
 	{
-		if ( delegate.tryAdvance() )
-		{
-			action.accept( this );
-			return true;
-		}
-		else
-			return false;
+		return delegate.tryAdvance( t -> action.accept( this ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/stream/LocalizableSamplerWrapper.java
+++ b/src/main/java/net/imglib2/stream/LocalizableSamplerWrapper.java
@@ -6,10 +6,25 @@ import net.imglib2.LocalizableSampler;
 import net.imglib2.Positionable;
 import net.imglib2.RealPositionable;
 
+/**
+ * Wraps {@link LocalizableSpliterator} as {@code Spliterator<LocalizableSampler<T>>}.
+ * <p>
+ * Concretely, it implements {@code LocalizableSampler}, forwarding all methods
+ * to the wrapped {@code LocalizableSpliterator}. And passes itself as a proxy
+ * to the {@code Consumer} in {@link #tryAdvance} and {@link #forEachRemaining}.
+ *
+ * @param <T> pixel type
+ */
 class LocalizableSamplerWrapper< T > implements Spliterator< LocalizableSampler< T > >, LocalizableSampler< T >
 {
 	private final LocalizableSpliterator< T > delegate;
 
+	/**
+	 * Wrap the given {@code delegate} as {@code Spliterator<LocalizableSampler<T>>}.
+	 *
+	 * @param delegate
+	 * 		spliterator to wrap
+	 */
 	LocalizableSamplerWrapper( final LocalizableSpliterator< T > delegate )
 	{
 		this.delegate = delegate;

--- a/src/main/java/net/imglib2/stream/LocalizableSamplerWrapper.java
+++ b/src/main/java/net/imglib2/stream/LocalizableSamplerWrapper.java
@@ -1,0 +1,136 @@
+package net.imglib2.stream;
+
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import net.imglib2.LocalizableSampler;
+import net.imglib2.Positionable;
+import net.imglib2.RealPositionable;
+
+class LocalizableSamplerWrapper< T > implements Spliterator< LocalizableSampler< T > >, LocalizableSampler< T >
+{
+	private final LocalizableSpliterator< T > delegate;
+
+	LocalizableSamplerWrapper( final LocalizableSpliterator< T > delegate )
+	{
+		this.delegate = delegate;
+	}
+
+	@Override
+	public T get()
+	{
+		return delegate.get();
+	}
+
+	@Override
+	public LocalizableSamplerWrapper< T > copy()
+	{
+		return new LocalizableSamplerWrapper<>( delegate.copy() );
+	}
+
+	@Override
+	public void forEachRemaining( final Consumer< ? super LocalizableSampler< T > > action )
+	{
+		delegate.forEachRemaining( () -> action.accept( this ) );
+	}
+
+	@Override
+	public boolean tryAdvance( final Consumer< ? super LocalizableSampler< T > > action )
+	{
+		if ( delegate.tryAdvance() )
+		{
+			action.accept( this );
+			return true;
+		}
+		else
+			return false;
+	}
+
+	@Override
+	public Spliterator< LocalizableSampler< T > > trySplit()
+	{
+		final LocalizableSpliterator< T > prefix = delegate.trySplit();
+		return prefix == null ? null : new LocalizableSamplerWrapper<>( prefix );
+	}
+
+	@Override
+	public long estimateSize()
+	{
+		return delegate.estimateSize();
+	}
+
+	@Override
+	public int characteristics()
+	{
+		return delegate.characteristics();
+	}
+
+
+	// -----------------------------------------------------------
+	//   Localizable
+
+	@Override
+	public int numDimensions()
+	{
+		return delegate.numDimensions();
+	}
+
+	@Override
+	public void localize( final int[] position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public void localize( final float[] position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public void localize( final double[] position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public void localize( final long[] position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public void localize( final Positionable position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public void localize( final RealPositionable position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public int getIntPosition( final int d )
+	{
+		return delegate.getIntPosition( d );
+	}
+
+	@Override
+	public long getLongPosition( final int d )
+	{
+		return delegate.getLongPosition( d );
+	}
+
+	@Override
+	public float getFloatPosition( final int d )
+	{
+		return delegate.getFloatPosition( d );
+	}
+
+	@Override
+	public double getDoublePosition( final int d )
+	{
+		return delegate.getDoublePosition( d );
+	}
+}

--- a/src/main/java/net/imglib2/stream/LocalizableSpliterator.java
+++ b/src/main/java/net/imglib2/stream/LocalizableSpliterator.java
@@ -1,0 +1,12 @@
+package net.imglib2.stream;
+
+import net.imglib2.Localizable;
+
+public interface LocalizableSpliterator< T > extends RealLocalizableSpliterator< T >, Localizable
+{
+	@Override
+	LocalizableSpliterator< T > trySplit();
+
+	@Override
+	LocalizableSpliterator< T > copy();
+}

--- a/src/main/java/net/imglib2/stream/LocalizableSpliterator.java
+++ b/src/main/java/net/imglib2/stream/LocalizableSpliterator.java
@@ -1,7 +1,36 @@
 package net.imglib2.stream;
 
+import net.imglib2.IterableInterval;
 import net.imglib2.Localizable;
 
+/**
+ * A {@code Spliterator<T>} which is Localizable similar to a Cursor.
+ * <p>
+ * The location of the Spliterator reflects the location of the element passed
+ * to the {@code Consumer} in {@link #tryAdvance} or {@link #forEachRemaining}
+ * (at the time the element is passed, and until the next element is passed).
+ * <p>
+ * Similar to {@code Cursor}, {@code LocalizableSpliterator} usually
+ * comes in two flavors:
+ * <ul>
+ *     <li>{@link IterableInterval#spliterator()} computes location only on demand, and</li>
+ *     <li>{@link IterableInterval#localizingSpliterator()} preemptively tracks location on every step.</li>
+ * </ul>
+ * (Which one is more efficient depends on how often location is actually needed.)
+ * <p>
+ * To make the {@code Localizable} property available in a {@code Stream}, use
+ * the {@link Streams} utility class to create {@code
+ * Stream<LocalizableSampler<T>>} (which internally wraps {@code
+ * LocalizableSpliterator}).
+ * <p>
+ * Corresponding to the {@code LocalizableSpliterator} flavors,
+ * <ul>
+ *     <li>{@link Streams#localizable(IterableInterval)} computes element location only on demand, and
+ *     <li>{@link Streams#localizing(IterableInterval)} tracks location on every step.</li>
+ * </ul>
+ *
+ * @param <T> pixel type
+ */
 public interface LocalizableSpliterator< T > extends RealLocalizableSpliterator< T >, Localizable
 {
 	@Override

--- a/src/main/java/net/imglib2/stream/RealCursorSpliterator.java
+++ b/src/main/java/net/imglib2/stream/RealCursorSpliterator.java
@@ -1,0 +1,94 @@
+package net.imglib2.stream;
+
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import net.imglib2.RealCursor;
+
+/**
+ * Spliterator implementation on top of {@code RealCursor}.
+ *
+ * @param <T> the type of elements returned by this Spliterator, and the pixel type of the underlying cursor.
+ */
+public class RealCursorSpliterator< T > implements Spliterator< T >
+{
+	/**
+	 * The underlying cursor, positioned such that {@code cursor.next()} yields the element at {@code index}.
+	 */
+	private final RealCursor< T > cursor;
+
+	/**
+	 * The current index, modified on advance/split.
+	 */
+	private long index;
+
+	/**
+	 * One past last index
+	 */
+	private final long fence;
+
+	/**
+	 * Characteristics always include {@code SIZED | SUBSIZED}.
+	 */
+	private final int characteristics;
+
+	/**
+	 * Creates a spliterator covering the given range.
+	 *
+	 * @param cursor
+	 * 		provides elements, starting with the element at origin, on cursor.next()
+	 * @param origin
+	 * 		the least index (inclusive) to cover
+	 * @param fence
+	 * 		one past the greatest index to cover
+	 * @param additionalCharacteristics
+	 * 		additional characteristics besides {@code SIZED | SUBSIZED}
+	 */
+	public RealCursorSpliterator( RealCursor< T > cursor, long origin, long fence, int additionalCharacteristics )
+	{
+		this.cursor = cursor;
+		this.index = origin;
+		this.fence = fence;
+		this.characteristics = additionalCharacteristics | Spliterator.SIZED | Spliterator.SUBSIZED;
+	}
+
+	@Override
+	public boolean tryAdvance( final Consumer< ? super T > action )
+	{
+		if ( action == null )
+			throw new NullPointerException();
+		if ( index >= 0 && index < fence )
+		{
+			++index;
+			action.accept( cursor.next() );
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public RealCursorSpliterator< T > trySplit()
+	{
+		long lo = index, mid = ( lo + fence ) >>> 1;
+		if ( lo >= mid )
+			return null;
+		else
+		{
+			final RealCursorSpliterator< T > prefix = new RealCursorSpliterator<>( cursor.copy(), lo, mid, characteristics );
+			cursor.jumpFwd( mid - lo );
+			index = mid;
+			return prefix;
+		}
+	}
+
+	@Override
+	public long estimateSize()
+	{
+		return fence - index;
+	}
+
+	@Override
+	public int characteristics()
+	{
+		return characteristics;
+	}
+}

--- a/src/main/java/net/imglib2/stream/RealCursorSpliterator.java
+++ b/src/main/java/net/imglib2/stream/RealCursorSpliterator.java
@@ -68,18 +68,6 @@ public class RealCursorSpliterator< T > implements RealLocalizableSpliterator< T
 	}
 
 	@Override
-	public boolean tryAdvance()
-	{
-		if ( index >= 0 && index < fence )
-		{
-			++index;
-			cursor.fwd();
-			return true;
-		}
-		return false;
-	}
-
-	@Override
 	public RealCursorSpliterator< T > trySplit()
 	{
 		long lo = index, mid = ( lo + fence ) >>> 1;

--- a/src/main/java/net/imglib2/stream/RealLocalizableSamplerWrapper.java
+++ b/src/main/java/net/imglib2/stream/RealLocalizableSamplerWrapper.java
@@ -29,19 +29,13 @@ class RealLocalizableSamplerWrapper< T > implements Spliterator< RealLocalizable
 	@Override
 	public void forEachRemaining( final Consumer< ? super RealLocalizableSampler< T > > action )
 	{
-		delegate.forEachRemaining( () -> action.accept( this ) );
+		delegate.forEachRemaining( t -> action.accept( this ) );
 	}
 
 	@Override
 	public boolean tryAdvance( final Consumer< ? super RealLocalizableSampler< T > > action )
 	{
-		if ( delegate.tryAdvance() )
-		{
-			action.accept( this );
-			return true;
-		}
-		else
-			return false;
+		return delegate.tryAdvance( t -> action.accept( this ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/stream/RealLocalizableSamplerWrapper.java
+++ b/src/main/java/net/imglib2/stream/RealLocalizableSamplerWrapper.java
@@ -1,0 +1,105 @@
+package net.imglib2.stream;
+
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import net.imglib2.RealLocalizableSampler;
+import net.imglib2.RealPositionable;
+
+class RealLocalizableSamplerWrapper< T > implements Spliterator< RealLocalizableSampler< T > >, RealLocalizableSampler< T >
+{
+	private final RealLocalizableSpliterator< T > delegate;
+
+	RealLocalizableSamplerWrapper( final RealLocalizableSpliterator< T > delegate )
+	{
+		this.delegate = delegate;
+	}
+
+	@Override
+	public T get()
+	{
+		return delegate.get();
+	}
+
+	@Override
+	public RealLocalizableSamplerWrapper< T > copy()
+	{
+		return new RealLocalizableSamplerWrapper<>( delegate.copy() );
+	}
+
+	@Override
+	public void forEachRemaining( final Consumer< ? super RealLocalizableSampler< T > > action )
+	{
+		delegate.forEachRemaining( () -> action.accept( this ) );
+	}
+
+	@Override
+	public boolean tryAdvance( final Consumer< ? super RealLocalizableSampler< T > > action )
+	{
+		if ( delegate.tryAdvance() )
+		{
+			action.accept( this );
+			return true;
+		}
+		else
+			return false;
+	}
+
+	@Override
+	public Spliterator< RealLocalizableSampler< T > > trySplit()
+	{
+		final RealLocalizableSpliterator< T > prefix = delegate.trySplit();
+		return prefix == null ? null : new RealLocalizableSamplerWrapper<>( prefix );
+	}
+
+	@Override
+	public long estimateSize()
+	{
+		return delegate.estimateSize();
+	}
+
+	@Override
+	public int characteristics()
+	{
+		return delegate.characteristics();
+	}
+
+
+	// -----------------------------------------------------------
+	//   RealLocalizable
+
+	@Override
+	public int numDimensions()
+	{
+		return delegate.numDimensions();
+	}
+
+	@Override
+	public void localize( final float[] position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public void localize( final double[] position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public void localize( final RealPositionable position )
+	{
+		delegate.localize( position );
+	}
+
+	@Override
+	public float getFloatPosition( final int d )
+	{
+		return delegate.getFloatPosition( d );
+	}
+
+	@Override
+	public double getDoublePosition( final int d )
+	{
+		return delegate.getDoublePosition( d );
+	}
+}

--- a/src/main/java/net/imglib2/stream/RealLocalizableSamplerWrapper.java
+++ b/src/main/java/net/imglib2/stream/RealLocalizableSamplerWrapper.java
@@ -5,10 +5,25 @@ import java.util.function.Consumer;
 import net.imglib2.RealLocalizableSampler;
 import net.imglib2.RealPositionable;
 
+/**
+ * Wraps {@link RealLocalizableSpliterator} as {@code Spliterator<RealLocalizableSampler<T>>}.
+ * <p>
+ * Concretely, it implements {@code RealLocalizableSampler}, forwarding all methods
+ * to the wrapped {@code RealLocalizableSpliterator}. And passes itself as a proxy
+ * to the {@code Consumer} in {@link #tryAdvance} and {@link #forEachRemaining}.
+ *
+ * @param <T> pixel type
+ */
 class RealLocalizableSamplerWrapper< T > implements Spliterator< RealLocalizableSampler< T > >, RealLocalizableSampler< T >
 {
 	private final RealLocalizableSpliterator< T > delegate;
 
+	/**
+	 * Wrap the given {@code delegate} as {@code Spliterator<RealLocalizableSampler<T>>}.
+	 *
+	 * @param delegate
+	 * 		spliterator to wrap
+	 */
 	RealLocalizableSamplerWrapper( final RealLocalizableSpliterator< T > delegate )
 	{
 		this.delegate = delegate;

--- a/src/main/java/net/imglib2/stream/RealLocalizableSpliterator.java
+++ b/src/main/java/net/imglib2/stream/RealLocalizableSpliterator.java
@@ -1,0 +1,21 @@
+package net.imglib2.stream;
+
+import java.util.Spliterator;
+import net.imglib2.RealLocalizable;
+import net.imglib2.Sampler;
+
+public interface RealLocalizableSpliterator< T > extends Spliterator< T >, RealLocalizable, Sampler< T >
+{
+	boolean tryAdvance();
+
+	default void forEachRemaining( final Runnable action )
+	{
+		forEachRemaining( t -> action.run() );
+	}
+
+	@Override
+	RealLocalizableSpliterator< T > trySplit();
+
+	@Override
+	RealLocalizableSpliterator< T > copy();
+}

--- a/src/main/java/net/imglib2/stream/RealLocalizableSpliterator.java
+++ b/src/main/java/net/imglib2/stream/RealLocalizableSpliterator.java
@@ -1,9 +1,38 @@
 package net.imglib2.stream;
 
 import java.util.Spliterator;
+import net.imglib2.IterableRealInterval;
 import net.imglib2.RealLocalizable;
 import net.imglib2.Sampler;
 
+/**
+ * A {@code Spliterator<T>} which is Localizable similar to a Cursor.
+ * <p>
+ * The location of the Spliterator reflects the location of the element passed
+ * to the {@code Consumer} in {@link #tryAdvance} or {@link #forEachRemaining}
+ * (at the time the element is passed, and until the next element is passed).
+ * <p>
+ * Similar to {@code RealCursor}, {@code RealLocalizableSpliterator} usually
+ * comes in two flavors:
+ * <ul>
+ *     <li>{@link IterableRealInterval#spliterator()} computes location only on demand, and</li>
+ *     <li>{@link IterableRealInterval#localizingSpliterator()} preemptively tracks location on every step.</li>
+ * </ul>
+ * (Which one is more efficient depends on how often location is actually needed.)
+ * <p>
+ * To make the {@code RealLocalizable} property available in a {@code Stream},
+ * use the {@link Streams} utility class to create {@code
+ * Stream<RealLocalizableSampler<T>>} (which internally wraps {@code
+ * RealLocalizableSpliterator}).
+ * <p>
+ * Corresponding to the {@code RealLocalizableSpliterator} flavors,
+ * <ul>
+ *     <li>{@link Streams#localizable(IterableRealInterval)} computes element location only on demand, and
+ *     <li>{@link Streams#localizing(IterableRealInterval)} tracks location on every step.</li>
+ * </ul>
+ *
+ * @param <T> pixel type
+ */
 public interface RealLocalizableSpliterator< T > extends Spliterator< T >, RealLocalizable, Sampler< T >
 {
 	@Override

--- a/src/main/java/net/imglib2/stream/RealLocalizableSpliterator.java
+++ b/src/main/java/net/imglib2/stream/RealLocalizableSpliterator.java
@@ -6,13 +6,6 @@ import net.imglib2.Sampler;
 
 public interface RealLocalizableSpliterator< T > extends Spliterator< T >, RealLocalizable, Sampler< T >
 {
-	boolean tryAdvance();
-
-	default void forEachRemaining( final Runnable action )
-	{
-		forEachRemaining( t -> action.run() );
-	}
-
 	@Override
 	RealLocalizableSpliterator< T > trySplit();
 

--- a/src/main/java/net/imglib2/stream/Streams.java
+++ b/src/main/java/net/imglib2/stream/Streams.java
@@ -1,0 +1,31 @@
+package net.imglib2.stream;
+
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import net.imglib2.IterableInterval;
+import net.imglib2.IterableRealInterval;
+import net.imglib2.LocalizableSampler;
+import net.imglib2.RealLocalizableSampler;
+
+public class Streams
+{
+	public static < T > Stream< RealLocalizableSampler< T > > localizable( IterableRealInterval< T > interval )
+	{
+		return StreamSupport.stream( new RealLocalizableSamplerWrapper<>( interval.spliterator() ), false );
+	}
+
+	public static < T > Stream< LocalizableSampler< T > > localizable( IterableInterval< T > interval )
+	{
+		return StreamSupport.stream( new LocalizableSamplerWrapper<>( interval.spliterator() ), false );
+	}
+
+	public static < T > Stream< RealLocalizableSampler< T > > localizing( IterableRealInterval< T > interval )
+	{
+		return StreamSupport.stream( new RealLocalizableSamplerWrapper<>( interval.localizingSpliterator() ), false );
+	}
+
+	public static < T > Stream< LocalizableSampler< T > > localizing( IterableInterval< T > interval )
+	{
+		return StreamSupport.stream( new LocalizableSamplerWrapper<>( interval.localizingSpliterator() ), false );
+	}
+}

--- a/src/main/java/net/imglib2/stream/Streams.java
+++ b/src/main/java/net/imglib2/stream/Streams.java
@@ -7,23 +7,86 @@ import net.imglib2.IterableRealInterval;
 import net.imglib2.LocalizableSampler;
 import net.imglib2.RealLocalizableSampler;
 
+/**
+ * Utilities for creating "localizable Streams".
+ */
 public class Streams
 {
+	/**
+	 * Create a sequential {@code Stream} of the elements (value and location)
+	 * of the given {@code interval}.
+	 * <p>
+	 * Element locations are computed on demand only, which is suited for usages
+	 * where location is only needed for a few elements.
+	 * (Also see {@link #localizing(IterableRealInterval)}).
+	 *
+	 * @param interval
+	 * 		interval over which to provide a {@code Stream}.
+	 * @param <T> pixel type
+	 *
+	 * @return a {@code Stream<RealLocalizableSampler<T>>} over the elements of
+	 *  	the given interval.
+	 */
 	public static < T > Stream< RealLocalizableSampler< T > > localizable( IterableRealInterval< T > interval )
 	{
 		return StreamSupport.stream( new RealLocalizableSamplerWrapper<>( interval.spliterator() ), false );
 	}
 
-	public static < T > Stream< LocalizableSampler< T > > localizable( IterableInterval< T > interval )
-	{
-		return StreamSupport.stream( new LocalizableSamplerWrapper<>( interval.spliterator() ), false );
-	}
-
+	/**
+	 * Create a sequential {@code Stream} of the elements (value and location)
+	 * of the given {@code interval}.
+	 * <p>
+	 * Element location is tracked preemptively on every step, which is suited for usages
+	 * where location is needed for all elements.
+	 * (Also see {@link #localizable(IterableRealInterval)}).
+	 *
+	 * @param interval
+	 * 		interval over which to provide a {@code Stream}.
+	 * @param <T> pixel type
+	 *
+	 * @return a {@code Stream<RealLocalizableSampler<T>>} over the elements of
+	 *  	the given interval.
+	 */
 	public static < T > Stream< RealLocalizableSampler< T > > localizing( IterableRealInterval< T > interval )
 	{
 		return StreamSupport.stream( new RealLocalizableSamplerWrapper<>( interval.localizingSpliterator() ), false );
 	}
 
+	/**
+	 * Create a sequential {@code Stream} of the elements (value and location)
+	 * of the given {@code interval}.
+	 * <p>
+	 * Element locations are computed on demand only, which is suited for usages
+	 * where location is only needed for a few elements.
+	 * (Also see {@link #localizing(IterableInterval)}).
+	 *
+	 * @param interval
+	 * 		interval over which to provide a {@code Stream}.
+	 * @return a {@code Stream<LocalizableSampler<T>>} over the elements of the
+	 *  	given interval.
+	 *
+	 * @param <T> pixel type
+	 */
+	public static < T > Stream< LocalizableSampler< T > > localizable( IterableInterval< T > interval )
+	{
+		return StreamSupport.stream( new LocalizableSamplerWrapper<>( interval.spliterator() ), false );
+	}
+
+	/**
+	 * Create a sequential {@code Stream} of the elements (value and location)
+	 * of the given {@code interval}.
+	 * <p>
+	 * Element location is tracked preemptively on every step, which is suited for usages
+	 * where location is needed for all elements.
+	 * (Also see {@link #localizable(IterableInterval)}).
+	 *
+	 * @param interval
+	 * 		interval over which to provide a {@code Stream}.
+	 * @return a {@code Stream<LocalizableSampler<T>>} over the elements of the
+	 *  	given interval.
+	 *
+	 * @param <T> pixel type
+	 */
 	public static < T > Stream< LocalizableSampler< T > > localizing( IterableInterval< T > interval )
 	{
 		return StreamSupport.stream( new LocalizableSamplerWrapper<>( interval.localizingSpliterator() ), false );

--- a/src/main/java/net/imglib2/util/IntervalIndexer.java
+++ b/src/main/java/net/imglib2/util/IntervalIndexer.java
@@ -149,6 +149,18 @@ public class IntervalIndexer
 		position[ maxDim ] = index;
 	}
 
+	final static public void indexToPosition( int index, final int[] dimensions, final Positionable position )
+	{
+		final int maxDim = dimensions.length - 1;
+		for ( int d = 0; d < maxDim; ++d )
+		{
+			final int j = index / dimensions[ d ];
+			position.setPosition( index - j * dimensions[ d ], d );
+			index = j;
+		}
+		position.setPosition( index, maxDim );
+	}
+
 	final static public void indexToPosition( long index, final long[] dimensions, final long[] position )
 	{
 		final int maxDim = dimensions.length - 1;

--- a/src/test/java/net/imglib2/img/cell/CellCursorTest.java
+++ b/src/test/java/net/imglib2/img/cell/CellCursorTest.java
@@ -127,7 +127,7 @@ public class CellCursorTest
 	@Test
 	public void testJmpWithCursor()
 	{
-		final int steps = 43;
+		final int steps = 279;
 		final Cursor< IntType > cursor1 = intImg.cursor();
 		for ( int i = 0; i < steps; ++i )
 			cursor1.fwd();

--- a/src/test/java/net/imglib2/stream/CellStreamBenchmark.java
+++ b/src/test/java/net/imglib2/stream/CellStreamBenchmark.java
@@ -1,0 +1,145 @@
+package net.imglib2.stream;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Spliterator;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import net.imglib2.img.Img;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.IntType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 20, time = 300, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class CellStreamBenchmark
+{
+	private final Img< IntType > img;
+
+	public CellStreamBenchmark()
+	{
+		final long[] dimensions = { 200, 200, 100 };
+		img = new CellImgFactory<>( new IntType(), 64 ).create( dimensions );
+		Random random = new Random( 1L );
+		img.forEach( t -> t.set( random.nextInt( 256 ) ) );
+	}
+
+	@Benchmark
+	public long benchmarkForLoop()
+	{
+		long count = 0;
+		for ( IntType t : img )
+		{
+			if ( t.get() > 127 )
+				++count;
+		}
+		return count;
+	}
+
+	@Benchmark
+	public long benchmarkStream()
+	{
+//		return img.stream().mapToInt( IntType::get ).filter( value -> value > 127 ).count();
+		return img.stream().filter( t -> t.get() > 127 ).count();
+	}
+
+	@Benchmark
+	public long benchmarkParallelStream()
+	{
+//		return img.parallelStream().mapToInt( IntType::get ).filter( value -> value > 127 ).count();
+		return img.parallelStream().filter( t -> t.get() > 127 ).count();
+	}
+
+	static class Count implements Consumer< IntType >
+	{
+		private long count;
+
+		@Override
+		public void accept( final IntType t )
+		{
+			if ( t.get() > 127 )
+				++count;
+		}
+
+		public long get()
+		{
+			return count;
+		}
+	}
+
+	@Benchmark
+	public long benchmarkSpliterator()
+	{
+		final Count count = new Count();
+		final Spliterator< IntType > spl = img.spliterator();
+		spl.forEachRemaining( count );
+		return count.get();
+	}
+
+	@Benchmark
+	public long benchmarkIterator()
+	{
+		final Count count = new Count();
+		final Iterator< IntType > it = img.iterator();
+		while( it.hasNext() )
+		{
+			count.accept( it.next() );
+		}
+		return count.get();
+	}
+
+	@Benchmark
+	public long benchmarkIterator2()
+	{
+		final Count count = new Count();
+		final Iterator< IntType > it = img.iterator();
+		countIt( it, count );
+		return count.get();
+	}
+
+	static void countIt( Iterator< IntType > it, Count count )
+	{
+		while( it.hasNext() )
+		{
+			count.accept( it.next() );
+		}
+	}
+
+	@Benchmark
+	public long benchmarkLoopBuilder()
+	{
+		final List< Long > longs = LoopBuilder.setImages( img ).multiThreaded().forEachChunk( consumerChunk -> {
+			final long[] count = { 0 };
+			consumerChunk.forEachPixel( t -> {
+				if ( t.get() > 127 )
+					++count[ 0 ];
+			} );
+			return count[ 0 ];
+		} );
+		return longs.stream().mapToLong( Long::longValue ).sum();
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( CellStreamBenchmark.class.getSimpleName() ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/stream/ImgStreamTest.java
+++ b/src/test/java/net/imglib2/stream/ImgStreamTest.java
@@ -108,4 +108,13 @@ public class ImgStreamTest
 		final long actualCount = img.parallelStream().filter( BooleanType::get ).count();
 		Assert.assertEquals( expectedCount, actualCount );
 	}
+
+	@Test
+	public void testEstimateSize()
+	{
+		final LocalizableSpliterator< BitType > spliterator = img.spliterator();
+		final long actualSize = spliterator.estimateSize();
+		final long expectedSize = img.size();
+		Assert.assertEquals( expectedSize, actualSize );
+	}
 }

--- a/src/test/java/net/imglib2/stream/ImgStreamTest.java
+++ b/src/test/java/net/imglib2/stream/ImgStreamTest.java
@@ -1,0 +1,111 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.stream;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.img.planar.PlanarImgFactory;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.logic.BitType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+@RunWith( Parameterized.class )
+public class ImgStreamTest
+{
+	private Img< BitType > img;
+
+	private int expectedCount;
+
+	@Parameterized.Parameters( name = "{0}" )
+	public static Collection< ImgFactory< BitType > > data()
+	{
+		final List< ImgFactory< BitType > > list = new ArrayList<>();
+		list.add( new ArrayImgFactory<>( new BitType() ) );
+		list.add( new CellImgFactory<>( new BitType() ) );
+		list.add( new PlanarImgFactory<>( new BitType() ) );
+		return list;
+	}
+
+	public ImgStreamTest( ImgFactory< BitType > factory )
+	{
+		img = factory.create( 100, 100, 100 );
+
+		final Random rand = new Random( 12 );
+		expectedCount = 0;
+		for ( BitType t : img )
+		{
+			final boolean b = rand.nextBoolean();
+			t.set( b );
+			if ( b )
+				++expectedCount;
+		}
+	}
+
+//	@Test
+	public void testForLoop()
+	{
+		long actualCount = 0;
+		for ( BitType t : img )
+		{
+			if ( t.get() )
+				++actualCount;
+		}
+		Assert.assertEquals( expectedCount, actualCount );
+	}
+
+	@Test
+	public void testStream()
+	{
+		final long actualCount = img.stream().filter( BooleanType::get ).count();
+		Assert.assertEquals( expectedCount, actualCount );
+	}
+
+	@Test
+	public void testParallelStream()
+	{
+		final long actualCount = img.parallelStream().filter( BooleanType::get ).count();
+		Assert.assertEquals( expectedCount, actualCount );
+	}
+}

--- a/src/test/java/net/imglib2/stream/LocalizableSamplerStreamBenchmark.java
+++ b/src/test/java/net/imglib2/stream/LocalizableSamplerStreamBenchmark.java
@@ -1,0 +1,159 @@
+package net.imglib2.stream;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.img.planar.PlanarImgs;
+import net.imglib2.type.numeric.integer.IntType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 15, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class LocalizableSamplerStreamBenchmark
+{
+	private Img< IntType > img;
+
+	@Param( value = { "ArrayImg", "PlanarImg", "CellImg" } )
+	private String imgType;
+
+	@Setup
+	public void setup()
+	{
+		final long[] dimensions = { 2000, 200, 10 };
+
+		if ( imgType.equals( "ArrayImg" ) )
+			img = ArrayImgs.ints( dimensions );
+		else if ( imgType.equals( "PlanarImg" ) )
+			img = PlanarImgs.ints( dimensions );
+		else if ( imgType.equals( "CellImg" ) )
+			img = new CellImgFactory<>( new IntType(), 64 ).create( dimensions );
+		else
+			throw new IllegalArgumentException();
+
+		Random random = new Random( 1L );
+		img.forEach( t -> t.set( random.nextInt( 1000 ) ) );
+	}
+
+	@Benchmark
+	public long benchmarkStream()
+	{
+		long sum = Streams.localizable( img )
+				.mapToLong( s -> s.get().get()
+						+ s.getIntPosition( 0 )
+						+ s.getIntPosition( 1 )
+						+ s.getIntPosition( 2 )
+				).sum();
+		return sum;
+	}
+
+	@Benchmark
+	public long benchmarkLocalizingStream()
+	{
+		long sum = Streams.localizing( img )
+				.mapToLong( s -> s.get().get()
+						+ s.getIntPosition( 0 )
+						+ s.getIntPosition( 1 )
+						+ s.getIntPosition( 2 )
+				).sum();
+		return sum;
+	}
+
+	@Benchmark
+	public long benchmarkParallelStream()
+	{
+		long sum = Streams.localizable( img )
+				.parallel()
+				.mapToLong( s -> s.get().get()
+						+ s.getIntPosition( 0 )
+						+ s.getIntPosition( 1 )
+						+ s.getIntPosition( 2 )
+				).sum();
+		return sum;
+	}
+
+	@Benchmark
+	public long benchmarkLocalizingParallelStream()
+	{
+		long sum = Streams.localizing( img )
+				.parallel()
+				.mapToLong( s -> s.get().get()
+						+ s.getIntPosition( 0 )
+						+ s.getIntPosition( 1 )
+						+ s.getIntPosition( 2 )
+				).sum();
+		return sum;
+	}
+
+	static class Sum implements Consumer< Cursor< IntType > >
+	{
+		private long sum;
+
+		@Override
+		public void accept( final Cursor< IntType > s )
+		{
+			sum += s.get().get()
+					+ s.getIntPosition( 0 )
+					+ s.getIntPosition( 1 )
+					+ s.getIntPosition( 2 );
+		}
+
+		public long get()
+		{
+			return sum;
+		}
+	}
+
+	@Benchmark
+	public long benchmarkCursor()
+	{
+		final Sum sum = new Sum();
+		final Cursor< IntType > it = img.cursor();
+		while ( it.hasNext() )
+		{
+			it.fwd();
+			sum.accept( it );
+		}
+		return sum.get();
+	}
+
+	@Benchmark
+	public long benchmarkLocalizingCursor()
+	{
+		final Sum sum = new Sum();
+		final Cursor< IntType > it = img.localizingCursor();
+		while ( it.hasNext() )
+		{
+			it.fwd();
+			sum.accept( it );
+		}
+		return sum.get();
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( LocalizableSamplerStreamBenchmark.class.getSimpleName() ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/stream/LocalizingStreamTest.java
+++ b/src/test/java/net/imglib2/stream/LocalizingStreamTest.java
@@ -1,0 +1,136 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.stream;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.img.planar.PlanarImgFactory;
+import net.imglib2.type.numeric.integer.IntType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+@RunWith( Parameterized.class )
+public class LocalizingStreamTest
+{
+	private Img< IntType > img;
+
+	private long expectedSum;
+
+	@Parameterized.Parameters( name = "{0}" )
+	public static Collection< ImgFactory< IntType > > data()
+	{
+		final List< ImgFactory< IntType > > list = new ArrayList<>();
+		list.add( new ArrayImgFactory<>( new IntType() ) );
+		list.add( new CellImgFactory<>( new IntType() ) );
+		list.add( new PlanarImgFactory<>( new IntType() ) );
+		return list;
+	}
+
+	public LocalizingStreamTest( ImgFactory< IntType > factory )
+	{
+		img = factory.create( 10, 10, 10 );
+
+		final Random rand = new Random( 12 );
+		final Cursor< IntType > c = img.localizingCursor();
+		while( c.hasNext())
+		{
+			final int value = rand.nextInt(1000 );
+			c.next().set( value );
+			expectedSum += value * c.getIntPosition( 0 );
+			expectedSum += c.getIntPosition( 1 );
+			expectedSum += c.getIntPosition( 2 );
+		}
+	}
+
+	@Test
+	public void testStream()
+	{
+		final long actualSum = Streams.localizable( img )
+				.mapToLong( s -> s.get().get()
+						* s.getIntPosition( 0 )
+						+ s.getIntPosition( 1 )
+						+ s.getIntPosition( 2 )
+				).sum();
+		Assert.assertEquals( expectedSum, actualSum );
+	}
+
+	@Test
+	public void testLocalizingStream()
+	{
+		final long actualSum = Streams.localizing( img )
+				.mapToLong( s -> s.get().get()
+						* s.getIntPosition( 0 )
+						+ s.getIntPosition( 1 )
+						+ s.getIntPosition( 2 )
+				).sum();
+		Assert.assertEquals( expectedSum, actualSum );
+	}
+
+	@Test
+	public void testParallelStream()
+	{
+		final long actualSum = Streams.localizable( img )
+				.parallel()
+				.mapToLong( s -> s.get().get()
+						* s.getIntPosition( 0 )
+						+ s.getIntPosition( 1 )
+						+ s.getIntPosition( 2 )
+				).sum();
+		Assert.assertEquals( expectedSum, actualSum );
+	}
+
+	@Test
+	public void testLocalizingParallelStream()
+	{
+		final long actualSum = Streams.localizing( img )
+				.parallel()
+				.mapToLong( s -> s.get().get()
+						* s.getIntPosition( 0 )
+						+ s.getIntPosition( 1 )
+						+ s.getIntPosition( 2 )
+				).sum();
+		Assert.assertEquals( expectedSum, actualSum );
+	}
+}

--- a/src/test/java/net/imglib2/stream/PlanarStreamBenchmark.java
+++ b/src/test/java/net/imglib2/stream/PlanarStreamBenchmark.java
@@ -1,0 +1,148 @@
+package net.imglib2.stream;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Spliterator;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.planar.PlanarImgs;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.util.Intervals;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 20, time = 300, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class PlanarStreamBenchmark
+{
+	private final Img< IntType > img;
+
+	public PlanarStreamBenchmark()
+	{
+		final long[] dimensions = { 200, 200, 100 };
+		img = PlanarImgs.ints( dimensions );
+		Random random = new Random( 1L );
+		img.forEach( t -> t.set( random.nextInt( 256 ) ) );
+	}
+
+	@Benchmark
+	public long benchmarkForLoop()
+	{
+		long count = 0;
+		for ( IntType t : img )
+		{
+			if ( t.get() > 127 )
+				++count;
+		}
+		return count;
+	}
+
+	@Benchmark
+	public long benchmarkStream()
+	{
+//		return img.stream().mapToInt( IntType::get ).filter( value -> value > 127 ).count();
+		return img.stream().filter( t -> t.get() > 127 ).count();
+	}
+
+	@Benchmark
+	public long benchmarkParallelStream()
+	{
+//		return img.parallelStream().mapToInt( IntType::get ).filter( value -> value > 127 ).count();
+		return img.parallelStream().filter( t -> t.get() > 127 ).count();
+	}
+
+	static class Count implements Consumer< IntType >
+	{
+		private long count;
+
+		@Override
+		public void accept( final IntType t )
+		{
+			if ( t.get() > 127 )
+				++count;
+		}
+
+		public long get()
+		{
+			return count;
+		}
+	}
+
+	@Benchmark
+	public long benchmarkSpliterator()
+	{
+		final Count count = new Count();
+		final Spliterator< IntType > spl = img.spliterator();
+		spl.forEachRemaining( count );
+		return count.get();
+	}
+
+	@Benchmark
+	public long benchmarkIterator()
+	{
+		final Count count = new Count();
+		final Iterator< IntType > it = img.iterator();
+		while( it.hasNext() )
+		{
+			count.accept( it.next() );
+		}
+		return count.get();
+	}
+
+	@Benchmark
+	public long benchmarkIterator2()
+	{
+		final Count count = new Count();
+		final Iterator< IntType > it = img.iterator();
+		countIt( it, count );
+		return count.get();
+	}
+
+	static void countIt( Iterator< IntType > it, Count count )
+	{
+		while( it.hasNext() )
+		{
+			count.accept( it.next() );
+		}
+	}
+
+	@Benchmark
+	public long benchmarkLoopBuilder()
+	{
+		final List< Long > longs = LoopBuilder.setImages( img ).multiThreaded().forEachChunk( consumerChunk -> {
+			final long[] count = { 0 };
+			consumerChunk.forEachPixel( t -> {
+				if ( t.get() > 127 )
+					++count[ 0 ];
+			} );
+			return count[ 0 ];
+		} );
+		return longs.stream().mapToLong( Long::longValue ).sum();
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( PlanarStreamBenchmark.class.getSimpleName() ).build();
+		new Runner( options ).run();
+	}
+}

--- a/src/test/java/net/imglib2/stream/StreamBenchmark.java
+++ b/src/test/java/net/imglib2/stream/StreamBenchmark.java
@@ -1,0 +1,116 @@
+package net.imglib2.stream;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.util.Intervals;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State( Scope.Benchmark )
+@Warmup( iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 20, time = 300, timeUnit = TimeUnit.MILLISECONDS )
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+public class StreamBenchmark
+{
+	private final int[] values;
+
+	private final Img< IntType > img;
+
+	public StreamBenchmark()
+	{
+		final long[] dimensions = { 2000, 2000 };
+		values = new int[ ( int ) Intervals.numElements( dimensions ) ];
+		img = ArrayImgs.ints( values, dimensions );
+		Random random = new Random( 1L );
+		img.forEach( t -> t.set( random.nextInt(256 ) ) );
+	}
+
+	@Benchmark
+	public long benchmarkForLoop()
+	{
+		long count = 0;
+		for ( IntType t : img )
+		{
+			if ( t.get() > 127 )
+				++count;
+		}
+		return count;
+	}
+
+	@Benchmark
+	public long benchmarkStream()
+	{
+//		return img.stream().mapToInt( IntType::get ).filter( value -> value > 127 ).count();
+		return img.stream().filter( t -> t.get() > 127 ).count();
+	}
+
+	@Benchmark
+	public long benchmarkParallelStream()
+	{
+//		return img.parallelStream().mapToInt( IntType::get ).filter( value -> value > 127 ).count();
+		return img.parallelStream().unordered().filter( t -> t.get() > 127 ).count();
+	}
+
+	@Benchmark
+	public long benchmarkForLoopArray()
+	{
+		long count = 0;
+		for ( int value : values )
+		{
+			if ( value > 127 )
+				++count;
+		}
+		return count;
+	}
+
+	@Benchmark
+	public long benchmarkStreamArray()
+	{
+		return IntStream.of( values ).filter( value -> value > 127 ).count();
+	}
+
+	@Benchmark
+	public long benchmarkParallelStreamArray()
+	{
+		return IntStream.of( values ).parallel().filter( value -> value > 127 ).count();
+	}
+
+	@Benchmark
+	public long benchmarkLoopBuilder()
+	{
+		final List< Long > longs = LoopBuilder.setImages( img ).multiThreaded().forEachChunk( consumerChunk -> {
+			final long[] count = { 0 };
+			consumerChunk.forEachPixel( t -> {
+				if ( t.get() > 127 )
+					++count[ 0 ];
+			} );
+			return count[ 0 ];
+		} );
+		return longs.stream().mapToLong( Long::longValue ).sum();
+	}
+
+	public static void main( String... args ) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( StreamBenchmark.class.getSimpleName() ).build();
+		new Runner( options ).run();
+	}
+}


### PR DESCRIPTION
This PR adds `IterableRealInterval.stream()` and `.parallelStream()` default methods to access the pixel values in an image as a `Stream<T>`.

The stream methods rely on a default implementation of `IterableRealInterval.spliterator()` backed by `RealCursor`.

Encounter order of the streams matches that of cursors, i.e. `Views.flatIterable(img).stream()` yields elements in flat iteration order.

Usage examples:
* count the number of `true` pixels in a binary image
  ```java
  Img<BitType> img = ...;
  long numberOfOnes = img.stream().filter(BitType::get).count();
  ```
* find the maximum pixel value in a DoubleType image
  ```java
  Img<DoubleType > img = ...;
  OptionalDouble maxValue = img.parallelStream().mapToDouble( DoubleType::get ).max();
  ```

### Pitfalls
**Note that the `T` elements of the stream are proxies and reused** (as usual).
The `RealCursorSpliterator` implementation takes care that a new proxy is used for each split-off prefix, so `parallelStream()` works as expected.
However, explicit copying operations must be added, if stream elements are supposed to be retained (by stateful intermediate or terminal operations).

For example, to collect all `DoubleType` values between `0` and `1` into a list:
```java
List< DoubleType > values = img.stream()
    .filter( t -> t.get() >= 0.0 && t.get() <= 1.0 )
    .map( DoubleType::copy ) // <-- this is important!
    .collect( Collectors.toList() );
```
The `.map(DoubleType::copy)` operation is necessary, otherwise the `values` list will contain many duplicates of the same `DoubleType` object (which may not even have to a value between `0` and `1`). The copy could also be done before the `.filter(...)` operation, but it's better to do it as late as possible to avoid unnecessary creation of objects.

### Performance
Initial benchmarks show that using streams (even without copying) is a lot slower than explicit `for` loops, for example.

Running the following [benchmark](https://github.com/imglib/imglib2/blob/67d59dfd796ddacbee8bf20ccce86e7a01489768/src/test/java/net/imglib2/stream/StreamBenchmark.java)
```java
// Img<IntType> img = ArrayImgs.ints(2000, 2000);

@Benchmark
public long benchmarkForLoop() {
    long count = 0;
    for (IntType t : img) {
        if (t.get() > 127)
            ++count;
    }
    return count;
}

@Benchmark
public long benchmarkStream() {
    return img.stream().filter(t -> t.get() > 127).count();
}
```
results in
```
Benchmark                                     Mode  Cnt   Score   Error  Units
StreamBenchmark.benchmarkForLoop              avgt   20   4,537 ± 0,095  ms/op
StreamBenchmark.benchmarkStream               avgt   20  33,331 ± 0,193  ms/op
```

Not ideal... It may be possible to improve performance, but so far I didn't find anything that works.

However, I think this is anyway more a quality-of-life feature. (Like the `RandomAccessible.getAt(...)` convenience methods (https://github.com/imglib/imglib2/pull/246) which I find myself using more often then I expected, despite the performance overhead.)

### Ideas
There is more to explore in this direction.

* Most importantly, it is of limiting to have only access to pixel *values*. It is more useful to also know pixel *positions*. For this, we should explore (additionally) providing `Stream<LocalizableSampler<T>>` instead of `Stream<T>`.
  The implementation would be simple, basically just use `Cursor<T>` instead of `Cursor<T>.get()` for the stream elements. However, the generics are a bit hairy.
* Does it make sense to add `ImgLibStream` wrapper around `java.util.stream.Stream`?
  With this we could add additional operations, for example the previously mentioned `.map(DoubleType::copy)` could be `.materialize()`. We could decorate operations like `.distinct()` and `.sort()` to make sure that copies have been made before, etc.
* Can specialized `Spliterator`s improve performance over iterators, for example for `CellImg`?
* Could there be any interesting interaction with the `Views` / `Converters` framework?


