### PR TITLE
Add convenience methods for creating images from arrays

### DIFF
--- a/src/main/java/net/imglib2/img/Imgs.java
+++ b/src/main/java/net/imglib2/img/Imgs.java
@@ -1,0 +1,94 @@
+package net.imglib2.img;
+
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.complex.ComplexDoubleType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import java.util.Arrays;
+
+/**
+ * Convenience factory methods for creation of {@link Img} instances from arrays
+ * for testing and exploration purposes.
+ *
+ * @author Michael Innerberger
+ */
+public class Imgs {
+	// prevent instantiation
+	private Imgs() {}
+
+	public static Img<ByteType> fromArray(final byte[] array, final long... dimensions) {
+		return ArrayImgs.bytes(array, dimensions);
+	}
+
+	public static Img<IntType> fromArray(final int[] array, final long... dimensions) {
+		return ArrayImgs.ints(array, dimensions);
+	}
+
+	public static Img<LongType> fromArray(final long[] array, final long... dimensions) {
+		return ArrayImgs.longs(array, dimensions);
+	}
+
+	public static Img<FloatType> fromArray(final float[] array, final long... dimensions) {
+		return ArrayImgs.floats(array, dimensions);
+	}
+
+	public static Img<DoubleType> fromArray(final double[] array, final long... dimensions) {
+		return ArrayImgs.doubles(array, dimensions);
+	}
+
+	public static Img<ComplexDoubleType> fromArray(final double[] real, final double[] imag, final long... dimensions) {
+		Img<ComplexDoubleType> img = ArrayImgs.complexDoubles(dimensions);
+		int i = 0;
+		for (final ComplexDoubleType pixel : img) {
+			pixel.setReal(real[i]);
+			pixel.setImaginary(imag[i++]);
+		}
+		return img;
+	}
+
+	public static Img<ComplexFloatType> fromArray(final float[] real, final float[] imag, final long... dimensions) {
+		Img<ComplexFloatType> img = ArrayImgs.complexFloats(dimensions);
+		int i = 0;
+		for (final ComplexFloatType pixel : img) {
+			pixel.setReal(real[i]);
+			pixel.setImaginary(imag[i++]);
+		}
+		return img;
+	}
+
+	public static Img<ByteType> fromArrays(final byte[][] slices, final long... dimensions) {
+		final int nPixels = (int) Arrays.stream(dimensions).reduce(1, (a, b) -> a * b);
+		final byte[] array = new byte[nPixels];
+		for (int i = 0; i < slices.length; i++)
+			System.arraycopy(slices[i], 0, array, i * slices[i].length, slices[i].length);
+		return fromArray(array, dimensions);
+	}
+
+	public static Img<IntType> fromArrays(final int[][] slices, final long... dimensions) {
+		final int[] array = Arrays.stream(slices).flatMapToInt(Arrays::stream).toArray();
+		return fromArray(array, dimensions);
+	}
+
+	public static Img<LongType> fromArrays(final long[][] slices, final long... dimensions) {
+		final long[] array = Arrays.stream(slices).flatMapToLong(Arrays::stream).toArray();
+		return fromArray(array, dimensions);
+	}
+
+	public static Img<FloatType> fromArrays(final float[][] slices, final long... dimensions) {
+		final int nPixels = (int) Arrays.stream(dimensions).reduce(1, (a, b) -> a * b);
+		final float[] array = new float[nPixels];
+		for (int i = 0; i < slices.length; i++)
+			System.arraycopy(slices[i], 0, array, i * slices[i].length, slices[i].length);
+		return fromArray(array, dimensions);
+	}
+
+	public static Img<DoubleType> fromArrays(final double[][] slices, final long... dimensions) {
+		final double[] array = Arrays.stream(slices).flatMapToDouble(Arrays::stream).toArray();
+		return fromArray(array, dimensions);
+	}
+}

--- a/src/test/java/net/imglib2/img/ImgConvenienceFactoryMethodTest.java
+++ b/src/test/java/net/imglib2/img/ImgConvenienceFactoryMethodTest.java
@@ -1,0 +1,148 @@
+package net.imglib2.img;
+
+import net.imglib2.type.numeric.complex.ComplexDoubleType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImgConvenienceFactoryMethodTest {
+
+	private static final double delta = 0.0;
+
+	@Test
+	public void createBytes() {
+		Img<ByteType> img = Imgs.fromArray(new byte[] { 1, 2, 3, 4, 5, 6 }, 2, 3);
+		int i = 0;
+		for (final ByteType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get());
+		}
+	}
+
+	@Test
+	public void createInts() {
+		Img<IntType> img = Imgs.fromArray(new int[] { 1, 2, 3, 4, 5, 6 }, 2, 3);
+		int i = 0;
+		for (final IntType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get());
+		}
+	}
+
+	@Test
+	public void createLongs() {
+		Img<LongType> img = Imgs.fromArray(new long[] { 1, 2, 3, 4, 5, 6 }, 2, 3);
+		int i = 0;
+		for (final LongType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get());
+		}
+	}
+
+	@Test
+	public void createFloats() {
+		Img<FloatType> img = Imgs.fromArray(new float[] { 1, 2, 3, 4, 5, 6 }, 2, 3);
+		int i = 0;
+		for (final FloatType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get(), delta);
+		}
+	}
+
+	@Test
+	public void createDoubles() {
+		Img<DoubleType> img = Imgs.fromArray(new double[] { 1, 2, 3, 4, 5, 6 }, 2, 3);
+		int i = 0;
+		for (final DoubleType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get(), delta);
+		}
+	}
+
+	@Test
+	public void createComplexFloats() {
+		Img<ComplexFloatType> img = Imgs.fromArray(new float[] { 1, 2, 3, 4, 5, 6 }, new float[] { 2, 3, 4, 5, 6, 7 }, 2, 3);
+		int i = 0;
+		for (final ComplexFloatType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.getRealDouble(), delta);
+			assertEquals(indexMsg(i), i+1, pixel.getImaginaryDouble(), delta);
+		}
+	}
+
+	@Test
+	public void createComplexDoubles() {
+		Img<ComplexDoubleType> img = Imgs.fromArray(new double[] { 1, 2, 3, 4, 5, 6 }, new double[] { 2, 3, 4, 5, 6, 7 }, 2, 3);
+		int i = 0;
+		for (final ComplexDoubleType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.getRealDouble(), delta);
+			assertEquals(indexMsg(i), i+1, pixel.getImaginaryDouble(), delta);
+		}
+	}
+
+	@Test
+	public void createByteSlices() {
+		final byte[][] data = {{ 1, 2, 3, 4, 5, 6 }, { 7, 8, 9, 10, 11, 12 }};
+		Img<ByteType> img = Imgs.fromArrays(data, 2, 3, 2);
+		int i = 0;
+		for (final ByteType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get(), delta);
+		}
+	}
+
+	@Test
+	public void createIntSlices() {
+		final int[][] data = {{ 1, 2, 3, 4, 5, 6 }, { 7, 8, 9, 10, 11, 12 }};
+		Img<IntType> img = Imgs.fromArrays(data, 2, 3, 2);
+		int i = 0;
+		for (final IntType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get(), delta);
+		}
+	}
+
+	@Test
+	public void createLongSlices() {
+		final long[][] data = {{ 1, 2, 3, 4, 5, 6 }, { 7, 8, 9, 10, 11, 12 }};
+		Img<LongType> img = Imgs.fromArrays(data, 2, 3, 2);
+		int i = 0;
+		for (final LongType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get(), delta);
+		}
+	}
+
+	@Test
+	public void createFloatSlices() {
+		final float[][] data = {{ 1, 2, 3, 4, 5, 6 }, { 7, 8, 9, 10, 11, 12 }};
+		Img<FloatType> img = Imgs.fromArrays(data, 2, 3, 2);
+		int i = 0;
+		for (final FloatType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get(), delta);
+		}
+	}
+
+	@Test
+	public void createDoubleSlices() {
+		final double[][] data = {{ 1, 2, 3, 4, 5, 6 }, { 7, 8, 9, 10, 11, 12 }};
+		Img<DoubleType> img = Imgs.fromArrays(data, 2, 3, 2);
+		int i = 0;
+		for (final DoubleType pixel : img) {
+			i++;
+			assertEquals(indexMsg(i), i, pixel.get(), delta);
+		}
+	}
+
+	private static String indexMsg(final int i) {
+		return "Index: " + i;
+	}
+}


### PR DESCRIPTION
The "learnathon" part of the ImgLib2/BDV hackathon in Brno showed that there is a need for an `Img`-creation API that caters to absolute beginners. The existing API for wrapping native arrays by means of the `ArrayImgs` util-class implicitly introduces the concepts of Img-backend and data-access, which seemed to keep people from exploring more awesome features.

I do think that wrapping native arrays is the best way to introduce people that are familiar with Matlab / Python / ... to ImgLib2, so I'm proposing this little wrapper API that can serve as a first exposure point for beginners:
```Java
ArrayImg<FloatType, ?> img = ArrayImgs.floats(array, dims) // previous
Img<FloatType> img = Imgs.fromArray(array, dims)           // new
```

Just to clarify again, this is meant as an educational API, so I don't see any need for deprecating the `ArrayImgs` API. This is simply inspired by the `List`-API that does a very good job of keeping implementational details hidden.