### PR TITLE
Improve implementation of RealSum

### DIFF
--- a/src/main/java/net/imglib2/util/RealSum.java
+++ b/src/main/java/net/imglib2/util/RealSum.java
@@ -39,99 +39,53 @@ package net.imglib2.util;
  * summing up a very large number of double precision numbers. Numerical
  * problems occur when a small number is added to an already very large sum. In
  * such case, the reduced accuracy of the very large number may lead to the
- * small number being entirely ignored. The method here stores and updates
- * intermediate sums for all power of two elements such that the final sum can
- * be generated from intermediate sums that result from equal number of
- * summands.
- * 
- * @author Stephan Saalfeld
+ * small number being entirely ignored. The method here is Neumaier's
+ * improvement of the Kahan summation algorithm.
+ * See <a href="https://en.wikipedia.org/wiki/Kahan_summation_algorithm">this
+ * Wikipedia article</a> for details.
+ *
+ * @author Michael Innerberger, Stephan Saalfeld
  */
-public class RealSum
-{
-	protected boolean[] flags;
-
-	protected double[] sums;
+public class RealSum {
+	private double sum = 0.0;
+	private double compensation = 0.0;
 
 	/**
-	 * Create a new {@link RealSum}. The fields for intermediate sums is
-	 * initialized with a single element and expanded on demand as new elements
-	 * are added.
+	 * Create a new {@link RealSum} initialized to zero.
 	 */
-	public RealSum()
-	{
-		flags = new boolean[ 1 ];
-		sums = new double[ 1 ];
+	public RealSum() {}
+
+	/**
+	 * Create a new {@link RealSum} initialized to zero. This constructor
+	 * was used in a previous version of {@link RealSum} and is kept for
+	 * backwards compatibility.
+	 *
+	 * @param capacity unused
+	 */
+	@Deprecated
+	public RealSum(final int capacity) {
+		this();
 	}
 
 	/**
-	 * Create a new {@link RealSum}. The fields for intermediate sums is
-	 * initialized with a given number of elements and will only be expanded on
-	 * demand as new elements are added and the number of existing elements is
-	 * not sufficient. This may be faster in cases where the required number of
-	 * elements is known in prior.
-	 * 
-	 * @param capacity
+	 * Get the current sum.
 	 */
-	public RealSum( final int capacity )
-	{
-		final int ldu = Util.ldu( capacity ) + 1;
-		flags = new boolean[ ldu ];
-		sums = new double[ ldu ];
+	public double getSum() {
+		return sum + compensation;
 	}
 
 	/**
-	 * Get the current sum by summing up all intermediate sums. Do not call this
-	 * method repeatedly when the sum has not changed.
+	 * Add an element to the sum.
+	 *
+	 * @param value the summand to be added
 	 */
-	final public double getSum()
-	{
-		double sum = 0;
-		for ( final double s : sums )
-			sum += s;
-
-		return sum;
-	}
-
-	final protected void expand( final double s )
-	{
-		final double[] oldSums = sums;
-		sums = new double[ oldSums.length + 1 ];
-		System.arraycopy( oldSums, 0, sums, 0, oldSums.length );
-		sums[ oldSums.length ] = s;
-
-		final boolean[] oldFlags = flags;
-		flags = new boolean[ sums.length ];
-		System.arraycopy( oldFlags, 0, flags, 0, oldFlags.length );
-		flags[ oldSums.length ] = true;
-	}
-
-	/**
-	 * Add an element to the sum. All intermediate sums are updated and the
-	 * capacity is increased on demand.
-	 * 
-	 * @param a
-	 *            the summand to be added
-	 */
-	final public void add( final double a )
-	{
-		int i = 0;
-		double s = a;
-		try
-		{
-			while ( flags[ i ] )
-			{
-				flags[ i ] = false;
-				s += sums[ i ];
-				sums[ i ] = 0.0;
-				++i;
-			}
-			flags[ i ] = true;
-			sums[ i ] = s;
-			return;
+	public void add(double value) {
+		double t = sum + value;
+		if (Math.abs(sum) >= Math.abs(value)) {
+			compensation += (sum - t) + value;
+		} else {
+			compensation += (value - t) + sum;
 		}
-		catch ( final IndexOutOfBoundsException e )
-		{
-			expand( s );
-		}
+		sum = t;
 	}
 }

--- a/src/test/java/net/imglib2/util/RealSumBenchmark.java
+++ b/src/test/java/net/imglib2/util/RealSumBenchmark.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2023 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.stream.DoubleStream;
+
+/**
+ * Benchmark for {@link RealSum}, comparing it with naive double summation.
+ * 
+ * @author Michael Innerberger
+ */
+public class RealSumBenchmark {
+	@Benchmark
+	public static void sumNaive(Blackhole blackhole, RandomValues values) {
+		double sum = 0.0;
+		for (double d : values.get()) {
+			sum += d;
+		}
+		blackhole.consume(sum);
+	}
+
+	@Benchmark
+	public static void sumRealSum(Blackhole blackhole, RandomValues values) {
+		RealSum sum = new RealSum();
+		for (double d : values.get()) {
+			sum.add(d);
+		}
+		blackhole.consume(sum.getSum());
+	}
+
+	@State(Scope.Benchmark)
+	public static class RandomValues {
+		final int N = 10_000_000;
+		final double[] values = DoubleStream.generate(Math::random).limit(N).toArray();
+
+		public double[] get() {
+			return values;
+		}
+	}
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include(RealSumBenchmark.class.getSimpleName())
+				.forks(0)
+				.warmupIterations(4)
+				.measurementIterations(8)
+				.warmupTime(TimeValue.milliseconds(100))
+				.measurementTime(TimeValue.milliseconds(100))
+				.build();
+		new Runner(opt).run();
+	}
+}

--- a/src/test/java/net/imglib2/util/RealSumTest.java
+++ b/src/test/java/net/imglib2/util/RealSumTest.java
@@ -92,13 +92,10 @@ public class RealSumTest
 	@Test
 	public void testAdd()
 	{
-		for ( int t = 0; t < 20; ++t )
-		{
-			final RealSum sum = new RealSum();
-			for ( int i = 0; i < stream.length; ++i )
-				sum.add( 1 );
-			Assert.assertEquals( sum.getSum(), stream.length, 0.0001 );
-		}
+		final RealSum sum = new RealSum();
+		for ( int i = 0; i < stream.length; ++i )
+			sum.add( 1 );
+		Assert.assertEquals( sum.getSum(), stream.length, 0.0001 );
 	}
 
 	/**

--- a/src/test/java/net/imglib2/util/RealSumTest.java
+++ b/src/test/java/net/imglib2/util/RealSumTest.java
@@ -87,18 +87,6 @@ public class RealSumTest
 	}
 
 	/**
-	 * Test method for {@link net.imglib2.util.RealSum#getSum()}.
-	 */
-	@Test
-	public void testDoubleSum()
-	{
-		double sum = 0;
-		for ( int i = 0; i < stream.length; ++i )
-			sum += stream[ i ];
-		Assert.assertEquals( sum, referenceSum.doubleValue(), 0.01 );
-	}
-
-	/**
 	 * Test method for {@link net.imglib2.util.RealSum#add(double)}.
 	 */
 	@Test
@@ -110,21 +98,6 @@ public class RealSumTest
 			for ( int i = 0; i < stream.length; ++i )
 				sum.add( 1 );
 			Assert.assertEquals( sum.getSum(), stream.length, 0.0001 );
-		}
-	}
-
-	/**
-	 * Test method for {@link net.imglib2.util.RealSum#add(double)}.
-	 */
-	@Test
-	public void testDoubleAdd()
-	{
-		for ( int t = 0; t < 20; ++t )
-		{
-			double sum = 0;
-			for ( int i = 0; i < stream.length; ++i )
-				sum += 1;
-			Assert.assertEquals( sum, stream.length, 0.0001 );
 		}
 	}
 

--- a/src/test/java/net/imglib2/util/RealSumTest.java
+++ b/src/test/java/net/imglib2/util/RealSumTest.java
@@ -75,16 +75,6 @@ public class RealSumTest
 	}
 
 	/**
-	 * Test method for {@link net.imglib2.util.RealSum#RealSum(int)}.
-	 */
-	@Test
-	public void testRealSumInt()
-	{
-		final RealSum sum = new RealSum( 10 );
-		Assert.assertEquals( sum.getSum(), 0.0, 0.001 );
-	}
-
-	/**
 	 * Test method for {@link net.imglib2.util.RealSum#getSum()}.
 	 */
 	@Test

--- a/src/test/java/net/imglib2/util/RealSumTest.java
+++ b/src/test/java/net/imglib2/util/RealSumTest.java
@@ -99,10 +99,11 @@ public class RealSumTest
 	}
 
 	/**
-	 * Test method for {@link net.imglib2.util.RealSum#add(double)}.
+	 * Test method for {@link net.imglib2.util.RealSum#add(double)} on a hard
+	 * example that fails for naive double summation.
 	 */
 	@Test
-	public void testDoubleHard() {
+	public void testHardExample() {
 		final double[] values = new double[]{1.0, 1.0e100, 1.0, -1.0e100};
 		final RealSum sum = new RealSum();
 		for (double value : values) {

--- a/src/test/java/net/imglib2/util/RealSumTest.java
+++ b/src/test/java/net/imglib2/util/RealSumTest.java
@@ -137,4 +137,17 @@ public class RealSumTest
 			Assert.assertEquals( sum, stream.length, 0.0001 );
 		}
 	}
+
+	/**
+	 * Test method for {@link net.imglib2.util.RealSum#add(double)}.
+	 */
+	@Test
+	public void testDoubleHard() {
+		final double[] values = new double[]{1.0, 1.0e100, 1.0, -1.0e100};
+		final RealSum sum = new RealSum();
+		for (double value : values) {
+			sum.add(value);
+		}
+		Assert.assertEquals(2.0, sum.getSum(), 0.0001);
+	}
 }


### PR DESCRIPTION
### Problem
While profiling an application that uses ImgLib2, I learned that multiple threads concurrently summing up large arrays using [`net.imglib2.util.RealSum`](https://github.com/imglib/imglib2/blob/master/src/main/java/net/imglib2/util/RealSum.java) are responsible for a big chunk of CPU-time.

### Proposed changes
Subsequently, I researched numerically stable ways of summing up floating point numbers, and learned that the current implementation could be improved by using a variant of the [Kahan summation algorithm](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements).

I implemented this algorithm in `RealSum`, keeping the API stable. Since there is no capacity anymore, I also deprecated the constructor that takes an `int` and deleted the corresponding test.

### Improvements
I added a simple test that fails for the current implementation, but passes for the proposed implementation using the improved Kahan algorithm. Furthermore, the new implementation is substantially faster than the old one. These are the results from a benchmark adding 10M random numbers (lower is better):
```
Benchmark                               Mode  Cnt   Score   Error  Units
CompensatedSummation.newImplementation  avgt    5  12.175 ± 0.413  ms/op
CompensatedSummation.oldImplementation  avgt    5  27.491 ± 2.794  ms/op
```

### Further suggestions
Looking at [`RealSumTest`](https://github.com/imglib/imglib2/blob/master/src/test/java/net/imglib2/util/RealSumTest.java), I'm not entirely sure what the point of the `testDoubleSum()` and `testDoubleAdd()` methods is. It looks to me as if they are only trying to assert that the reference result obtained from summing `BigDecimal`s "does the correct thing". Am I missing something here? If my interpretation is correct, I suggest to delete those tests since they are not related to `RealSum` at all.