### PR TITLE
Add default method NativeImg.getAccessType()

### DIFF
--- a/src/main/java/net/imglib2/blocks/ViewPrimitiveBlocks.java
+++ b/src/main/java/net/imglib2/blocks/ViewPrimitiveBlocks.java
@@ -68,7 +68,7 @@ class ViewPrimitiveBlocks< T extends NativeType< T >, R extends NativeType< R > 
 	{
 		this.props = props;
 		final PrimitiveType primitiveType = props.getRootType().getNativeTypeFactory().getPrimitiveType();
-		final MemCopy memCopy = MemCopy.forPrimitiveType( primitiveType, /*props.getRootAccessType() instanceof BufferAccess*/ false, false );
+		final MemCopy memCopy = MemCopy.forPrimitiveType( primitiveType, props.getRoot().getAccessType() instanceof BufferAccess, false );
 		final Extension extension = props.getExtension() != null ? props.getExtension() : Extension.border();
 		final Object oob = extractOobValue( props.getRootType(), extension );
 		final Ranges findRanges = Ranges.forExtension( extension );

--- a/src/main/java/net/imglib2/blocks/ViewProperties.java
+++ b/src/main/java/net/imglib2/blocks/ViewProperties.java
@@ -37,7 +37,6 @@ import java.util.function.Supplier;
 import net.imglib2.RandomAccessible;
 import net.imglib2.converter.Converter;
 import net.imglib2.img.NativeImg;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
 import net.imglib2.transform.integer.MixedTransform;
 import net.imglib2.type.NativeType;
 import net.imglib2.view.TransformBuilder;
@@ -144,22 +143,6 @@ class ViewProperties< T extends NativeType< T >, R extends NativeType< R > >
 	public R getRootType()
 	{
 		return rootType;
-	}
-
-	public ArrayDataAccess< ? > getRootAccessType()
-	{
-		return ( ArrayDataAccess< ? > ) getDataAccess( root );
-	}
-
-	/*
-	 * TODO: There should be a better way to get straight to a DataAccess instance.
-	 *       This is similar to the getType() problem.
-	 *       For now, this will work.
-	 *       Make an issue about getDataAccess() ...
-	 */
-	private static < A > A getDataAccess( NativeImg< ?, A > img )
-	{
-		return img.update( img.cursor() );
 	}
 
 	public Extension getExtension()

--- a/src/main/java/net/imglib2/img/NativeImg.java
+++ b/src/main/java/net/imglib2/img/NativeImg.java
@@ -57,4 +57,18 @@ public interface NativeImg< T extends Type< T >, A > extends Img< T >
 	void setLinkedType( T type );
 
 	T createLinkedType();
+
+	/**
+	 * This is used for checking whether a {@link NativeImg} is backed by
+	 * primitive arrays or {@code ByteBuffer}.
+	 * <p>
+	 * This may return the actual data backing this {@code NativeImg}, or just
+	 * some {@code A} of the same type. <em>Do not store a reference to the
+	 * returned object to avoid memory leaks!</em>
+	 *
+	 * @return an instance of the access type {@code A} backing this image.
+	 */
+	default A getAccessType() {
+		return update( cursor() );
+	}
 }


### PR DESCRIPTION
And re-enable BufferAccess handling in PrimitiveBlocks.

Fixes https://github.com/imglib/imglib2/issues/367