### PR TITLE
fix bug in KDTreeUtils unflatten()

### DIFF
--- a/src/main/java/net/imglib2/kdtree/KDTreeUtils.java
+++ b/src/main/java/net/imglib2/kdtree/KDTreeUtils.java
@@ -226,7 +226,7 @@ final class KDTreeUtils
 		for (int i = 0; i < positions.length; ++i )
 		{
 			final int d = i % n;
-			unflattened[ d ][ i / n + d ] = positions[ i ];
+			unflattened[ d ][ i / n ] = positions[ i ];
 		}
 		return unflattened;
 


### PR DESCRIPTION
threw an ArrayIndexOutOfBoundsException for the following use-case:

// input: [1.0, 1.0, 1.0, 0.0, 1.0, 0.5, 0.0, 0.0, 0.0, 1.0], dim=2

// the should-be result with the fix
deep: [[1.0, 1.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.5, 0.0, 1.0]]

// without the fix
java.lang.ArrayIndexOutOfBoundsException: 5
	at net.imglib2.kdtree.KDTreeUtils.unflatten(KDTreeUtils.java:229)