### PR TITLE
Let WrappedImg extend Img

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.imglib2</groupId>
 	<artifactId>imglib2</artifactId>
-	<version>7.1.5-SNAPSHOT</version>
+	<version>7.2.0-SNAPSHOT</version>
 
 	<name>ImgLib2 Core Library</name>
 	<description>A multidimensional, type-agnostic image processing library.</description>

--- a/src/main/java/net/imglib2/img/WrappedImg.java
+++ b/src/main/java/net/imglib2/img/WrappedImg.java
@@ -34,12 +34,96 @@
 
 package net.imglib2.img;
 
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccess;
+import net.imglib2.stream.LocalizableSpliterator;
+
 /**
  * An object that wraps an {@link Img} somehow.
  * 
  * @author Christian Dietz
  */
-public interface WrappedImg< T >
+public interface WrappedImg< T > extends Img< T >
 {
 	Img< T > getImg();
+
+	@Override
+	default T getType()
+	{
+		return getImg().getType();
+	}
+
+	@Override
+	default int numDimensions()
+	{
+		return getImg().numDimensions();
+	}
+
+	@Override
+	default long min( final int d )
+	{
+		return getImg().min( d );
+	}
+
+	@Override
+	default long max( final int d )
+	{
+		return getImg().max( d );
+	}
+
+	@Override
+	default long dimension( final int d )
+	{
+		return getImg().dimension( d );
+	}
+
+	@Override
+	default RandomAccess< T > randomAccess()
+	{
+		return getImg().randomAccess();
+	}
+
+	@Override
+	default RandomAccess< T > randomAccess( final Interval interval )
+	{
+		return getImg().randomAccess( interval );
+	}
+
+	@Override
+	default Cursor< T > cursor()
+	{
+		return getImg().cursor();
+	}
+
+	@Override
+	default Cursor< T > localizingCursor()
+	{
+		return getImg().localizingCursor();
+	}
+
+	@Override
+	default LocalizableSpliterator< T > spliterator()
+	{
+		return getImg().spliterator();
+	}
+
+	@Override
+	default LocalizableSpliterator< T > localizingSpliterator()
+	{
+		return getImg().localizingSpliterator();
+	}
+
+	@Override
+	default long size()
+	{
+		return getImg().size();
+	}
+
+	@Override
+	default Object iterationOrder()
+	{
+		return getImg().iterationOrder();
+	}
+
 }


### PR DESCRIPTION
And add default method implementations delegating to the wrapped Img.

I lifted the methods to implement from an [existing class implementing WrappedImg and Img](https://github.com/imglib/imglib2-appose/blob/d1f5ce29ba6e8ac2a0fb172120f9af61a0413248/src/main/java/net/imglib2/appose/SharedMemoryImg.java#L120-L198) with the delegation pattern.

I'm not sure this is actually a good idea. It would slightly reduce the flexibility of the `WrappedImg` interface, such that you could no longer implement the two interfaces with different type parameters e.g. `WrappedImg< FloatType >` and `Img< DoubleType >`. One scenario where you might want to do that, I guess, could be if you are creating adapter classes from one type to another? E.g. if we consider the `Converters` utility method:

```java
< A, B extends Type< B > > WriteConvertedRandomAccessibleInterval< A, B > convert(
			final RandomAccessibleInterval< A > source,
			final SamplerConverter< ? super A, B > converter )
```

And one can imagine a similar function accepting an `Img< A > source` instead and returns a `WriteConvertedImg< A, B >` that implements `WrappedImg< A >` and `Img< B >`.

A way around that could be to instead introduce a new `interface WrappedImgImg< T > extends WrappedImg< T >, Img< T >` and have the default delegation methods at this layer. Then folks who want the convenience of these delegators could implement `WrappedImgImg` instead of the two lower-level interfaces.

Thoughts?
