### PR TITLE
Let CellImgSamplers hold a reference to the Cell returned by getCell()

### DIFF
--- a/src/main/java/net/imglib2/img/cell/CellCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellCursor.java
@@ -99,10 +99,19 @@ public class CellCursor< T extends NativeType< T >, C extends Cell< ? > >
 		reset();
 	}
 
+	/**
+	 * {@code CellImgSampler} Hold a strong reference to the {@code Cell}
+	 * that was returned by the previous {@link #getCell()} invocation. For
+	 * cached {@code CellImgs}, this ensures that a strongly referenced
+	 * {@code CellImgSampler} keeps its current {@code Cell} from being
+	 * evicted.
+	 */
+	private C cell;
+
 	@Override
 	public C getCell()
 	{
-		return cursorOnCells.get();
+		return cell = cursorOnCells.get();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/cell/CellLocalizingCursor.java
@@ -104,10 +104,19 @@ public class CellLocalizingCursor< T extends NativeType< T >, C extends Cell< ? 
 		reset();
 	}
 
+	/**
+	 * {@code CellImgSampler} Hold a strong reference to the {@code Cell}
+	 * that was returned by the previous {@link #getCell()} invocation. For
+	 * cached {@code CellImgs}, this ensures that a strongly referenced
+	 * {@code CellImgSampler} keeps its current {@code Cell} from being
+	 * evicted.
+	 */
+	private C cell;
+
 	@Override
 	public C getCell()
 	{
-		return cursorOnCells.get();
+		return cell = cursorOnCells.get();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/CellRandomAccess.java
+++ b/src/main/java/net/imglib2/img/cell/CellRandomAccess.java
@@ -122,10 +122,19 @@ public class CellRandomAccess< T extends NativeType< T >, C extends Cell< ? > >
 		updatePosition( false );
 	}
 
+	/**
+	 * {@code CellImgSampler} Hold a strong reference to the {@code Cell}
+	 * that was returned by the previous {@link #getCell()} invocation. For
+	 * cached {@code CellImgs}, this ensures that a strongly referenced
+	 * {@code CellImgSampler} keeps its current {@code Cell} from being
+	 * evicted.
+	 */
+	private C cell;
+
 	@Override
 	public C getCell()
 	{
-		return randomAccessOnCells.get();
+		return cell = randomAccessOnCells.get();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/cell/CellSpliterator.java
+++ b/src/main/java/net/imglib2/img/cell/CellSpliterator.java
@@ -352,10 +352,19 @@ class CellSpliterator< T extends NativeType< T >, C extends Cell< ? > > implemen
 				delegate.jumpFwd( steps );
 		}
 
+		/**
+		 * {@code CellImgSampler} Hold a strong reference to the {@code Cell}
+		 * that was returned by the previous {@link #getCell()} invocation. For
+		 * cached {@code CellImgs}, this ensures that a strongly referenced
+		 * {@code CellImgSampler} keeps its current {@code Cell} from being
+		 * evicted.
+		 */
+		private C cell;
+
 		@Override
 		public C getCell()
 		{
-			return delegate.get();
+			return cell = delegate.get();
 		}
 
 		public void fwd()


### PR DESCRIPTION
Let `CellImgSampler` implementations (e.g. `CellRandomAccess`) hold a reference to the Cell returned by the last `getCell()` call. For cached `CellImg`s, this ensures that a strongly referenced `CellImgSampler` keeps its current `Cell` from being evicted.

Resolves https://github.com/imglib/imglib2-cache/issues/23