### PR TITLE
Class hierarchy and interpolation of Masked types (v2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.imglib2</groupId>
 	<artifactId>imglib2</artifactId>
-	<version>7.1.6-SNAPSHOT</version>
+	<version>8.0.0-SNAPSHOT</version>
 
 	<name>ImgLib2 Core Library</name>
 	<description>A multidimensional, type-agnostic image processing library.</description>

--- a/src/main/java/net/imglib2/display/MaskedToARGBConverter.java
+++ b/src/main/java/net/imglib2/display/MaskedToARGBConverter.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2025 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.display;
+
+import net.imglib2.converter.Converter;
+import net.imglib2.type.mask.Masked;
+import net.imglib2.type.numeric.ARGBType;
+
+/**
+ * A {@code Converter<Masked<T>, ARGBType>} that wraps a {@code Converter<T, ARGBType>}.
+ * <p>
+ * To convert a {@code Masked<T> input}, its {@link Masked#value()} is passed
+ * through the wrapped converter to obtain the RGB components of the output. The
+ * {@link Masked#mask()} of the input is used to obtain the A component of the
+ * output (mapping mask [0..1] to [0..255]).
+ *
+ * @param <T>
+ * 		the (un-masked) source type of the wrapped converter
+ */
+public interface MaskedToARGBConverter< T > extends Converter< Masked< T >, ARGBType >
+{
+	/**
+	 * @return the wrapped converter
+	 */
+	Converter< T, ARGBType > delegate();
+
+	/**
+	 * Given a {@code Converter<T, ARGBType>}, creates a {@code
+	 * Converter<Masked<T>, ARGBType>} that works as follows. To convert a
+	 * {@code Masked<T> input}, its {@link Masked#value()} is passed through the
+	 * wrapped converter to obtain the RGB components of the output. The {@link
+	 * Masked#mask()} of the input is used to obtain the A component of the
+	 * output (mapping mask [0..1] to [0..255]).
+	 *
+	 * @param converter
+	 * 		converter to wrap
+	 * @param <T>
+	 * 		the (un-masked) source type of the wrapped converter
+	 *
+	 * @return converter from masked type
+	 */
+	static < T > Converter< Masked< T >, ARGBType > wrap( final Converter< T, ARGBType > converter )
+	{
+		return MaskedToARGBConverterFactory.create( converter );
+	}
+}

--- a/src/main/java/net/imglib2/display/MaskedToARGBConverterFactory.java
+++ b/src/main/java/net/imglib2/display/MaskedToARGBConverterFactory.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2025 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.display;
+
+import java.util.Collections;
+
+import net.imglib2.converter.Converter;
+import net.imglib2.loops.ClassCopyProvider;
+import net.imglib2.type.mask.Masked;
+import net.imglib2.type.numeric.ARGBType;
+
+class MaskedToARGBConverterFactory
+{
+	private static final class ProviderHolder
+	{
+		@SuppressWarnings( "rawtypes" )
+		static final ClassCopyProvider< MaskedToARGBConverter > provider = new ClassCopyProvider<>( Imp.class, MaskedToARGBConverter.class, Converter.class );
+	}
+
+	@SuppressWarnings( "unchecked" )
+	static < T > MaskedToARGBConverter< T > create( final Converter< T, ARGBType > converter )
+	{
+		final Object key = Collections.singletonList( converter.getClass() );
+		return ProviderHolder.provider.newInstanceForKey( key, converter );
+	}
+
+	public static class Imp< T > implements MaskedToARGBConverter< T >
+	{
+		private final Converter< T, ARGBType > converter;
+
+		public Imp( final Converter< T, ARGBType > converter )
+		{
+			this.converter = converter;
+		}
+
+		@Override
+		public void convert( final Masked< T > input, final ARGBType output )
+		{
+			converter.convert( input.value(), output );
+			final double alpha = input.mask();
+			final int a0 = ( int ) ( alpha * 255 + 0.5 );
+			final int a = Math.min( 255, a0 );
+			output.set( ( output.get() & 0x00ffffff ) | ( a << 24 ) );
+		}
+
+		@Override
+		public Converter< T, ARGBType > delegate()
+		{
+			return converter;
+		}
+	}
+}

--- a/src/main/java/net/imglib2/interpolation/randomaccess/AbstractNLinearInterpolator.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/AbstractNLinearInterpolator.java
@@ -1,0 +1,190 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2025 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.interpolation.randomaccess;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.position.transform.Floor;
+import net.imglib2.type.Type;
+import net.imglib2.util.IntervalIndexer;
+
+/**
+ * Performs multi-linear interpolation.
+ *
+ * @param <T>
+ *
+ * @author Stephan Preibisch
+ * @author Stephan Saalfeld
+ * @author Tobias Pietzsch
+ */
+public abstract class AbstractNLinearInterpolator< T extends Type< T > > extends Floor< RandomAccess< T > > implements RealRandomAccess< T >
+{
+	/**
+	 * Weights for each pixel of the <em>2x2x...x2</em> hypercube of pixels
+	 * participating in the interpolation.
+	 *
+	 * <p>
+	 * Indices into this array are arranged in the standard iteration order (as
+	 * provided by {@link IntervalIndexer#positionToIndex}). Element 0 refers to
+	 * position <em>(0,0,...,0)</em>, element 1 refers to position
+	 * <em>(1,0,...,0)</em>, element 2 refers to position <em>(0,1,...,0)</em>,
+	 * etc.
+	 * </p>
+	 * <p>
+	 * To visit the pixels that contribute to an interpolated value, we move in
+	 * a (binary-reflected) Gray code pattern, such that only one dimension of
+	 * the target position is modified per move.
+	 * </p>
+	 * <p>
+	 * This index is the corresponding gray code bit pattern which will select
+	 * the correct corresponding weight.
+	 * </p>
+	 * <p>
+	 * See
+	 * <a href="http://en.wikipedia.org/wiki/Gray_code">http://en.wikipedia.org/
+	 * wiki/Gray_code</a>
+	 * </p>
+	 */
+	protected final double[] weights;
+
+	protected final T type;
+
+	protected final T accumulator;
+
+	protected AbstractNLinearInterpolator( final AbstractNLinearInterpolator< T > interpolator )
+	{
+		super( interpolator.target.copy() );
+
+		weights = interpolator.weights.clone();
+		type = interpolator.type;
+		accumulator = type.createVariable();
+
+		for ( int d = 0; d < n; ++d )
+		{
+			position[ d ] = interpolator.position[ d ];
+			discrete[ d ] = interpolator.discrete[ d ];
+		}
+	}
+
+	protected AbstractNLinearInterpolator( final RandomAccessible< T > randomAccessible, final T type )
+	{
+		super( randomAccessible.randomAccess() );
+
+		weights = new double[ 1 << n ];
+		this.type = type;
+		accumulator = type.createVariable();
+	}
+
+	/**
+	 * Fill the {@link #weights} array.
+	 *
+	 * <p>
+	 * Let <em>w_d</em> denote the fraction of a pixel at which the sample
+	 * position <em>p_d</em> lies from the floored position <em>pf_d</em> in
+	 * dimension <em>d</em>. That is, the value at <em>pf_d</em> contributes
+	 * with <em>(1 - w_d)</em> to the sampled value; the value at
+	 * <em>( pf_d + 1 )</em> contributes with <em>w_d</em>.
+	 * </p>
+	 * <p>
+	 * At every pixel, the total weight results from multiplying the weights of
+	 * all dimensions for that pixel. That is, the "top-left" contributing pixel
+	 * (position floored in all dimensions) gets assigned weight
+	 * <em>(1-w_0)(1-w_1)...(1-w_n)</em>.
+	 * </p>
+	 * <p>
+	 * We work through the weights array starting from the highest dimension.
+	 * For the highest dimension, the first half of the weights contain the
+	 * factor <em>(1 - w_n)</em> because this first half corresponds to floored
+	 * pixel positions in the highest dimension. The second half contain the
+	 * factor <em>w_n</em>. In this first step, the first weight of the first
+	 * half gets assigned <em>(1 - w_n)</em>. The first element of the second
+	 * half gets assigned <em>w_n</em>
+	 * </p>
+	 * <p>
+	 * From their, we work recursively down to dimension 0. That is, each half
+	 * of weights is again split recursively into two partitions. The first
+	 * element of the second partitions is the first element of the half
+	 * multiplied with <em>(w_d)</em>. The first element of the first partitions
+	 * is multiplied with <em>(1 - w_d)</em>.
+	 * </p>
+	 * <p>
+	 * When we have reached dimension 0, all weights will have a value assigned.
+	 * </p>
+	 */
+	protected void fillWeights()
+	{
+		weights[ 0 ] = 1.0d;
+
+		for ( int d = n - 1; d >= 0; --d )
+		{
+			final double w = position[ d ] - target.getLongPosition( d );
+			final double wInv = 1.0d - w;
+			final int wInvIndexIncrement = 1 << d;
+			final int loopCount = 1 << ( n - 1 - d );
+			final int baseIndexIncrement = wInvIndexIncrement * 2;
+			int baseIndex = 0;
+			for ( int i = 0; i < loopCount; ++i )
+			{
+				weights[ baseIndex + wInvIndexIncrement ] = weights[ baseIndex ] * w;
+				weights[ baseIndex ] *= wInv;
+				baseIndex += baseIndexIncrement;
+			}
+		}
+	}
+
+	/**
+	 * Get the interpolated value at the current position.
+	 *
+	 * <p>
+	 * To visit the pixels that contribute to an interpolated value, we move in
+	 * a (binary-reflected) Gray code pattern, such that only one dimension of
+	 * the target position is modified per move.
+	 * </p>
+	 * <p>
+	 * See
+	 * <a href="http://en.wikipedia.org/wiki/Gray_code">http://en.wikipedia.org/
+	 * wiki/Gray_code</a>
+	 * </p>
+	 */
+	@Override
+	public abstract T get();
+
+	@Override
+	public T getType()
+	{
+		return type;
+	}
+}

--- a/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorRealType.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorRealType.java
@@ -39,7 +39,7 @@ import net.imglib2.type.numeric.RealType;
 
 /**
  * N-linear interpolator for {@link RealType} values with overflow check.
- * Interpoalted values are clamped to the range {@link RealType#getMinValue()},{@link RealType#getMaxValue()}.
+ * Interpolated values are clamped to the range {@link RealType#getMinValue()},{@link RealType#getMaxValue()}.
  *
  * @param <T>
  *
@@ -47,9 +47,10 @@ import net.imglib2.type.numeric.RealType;
  */
 public class ClampingNLinearInterpolatorRealType< T extends RealType< T > > extends NLinearInterpolator< T >
 {
-	protected double acc;
-	protected final double clampMin;
-	protected final double clampMax;
+	private int code;
+	private double acc;
+	private final double clampMin;
+	private final double clampMax;
 
 	protected ClampingNLinearInterpolatorRealType( final ClampingNLinearInterpolatorRealType< T > interpolator )
 	{
@@ -67,7 +68,7 @@ public class ClampingNLinearInterpolatorRealType< T extends RealType< T > > exte
 
 	protected ClampingNLinearInterpolatorRealType( final RandomAccessible< T > randomAccessible )
 	{
-		this( randomAccessible, randomAccessible.randomAccess().get() );
+		this( randomAccessible, randomAccessible.getType() );
 	}
 
 	/**
@@ -99,7 +100,7 @@ public class ClampingNLinearInterpolatorRealType< T extends RealType< T > > exte
 		return new ClampingNLinearInterpolatorRealType<>( this );
 	}
 
-	final private void graycodeFwdRecursive( final int dimension )
+	private void graycodeFwdRecursive( final int dimension )
 	{
 		if ( dimension == 0 )
 		{
@@ -117,7 +118,7 @@ public class ClampingNLinearInterpolatorRealType< T extends RealType< T > > exte
 		}
 	}
 
-	final private void graycodeBckRecursive( final int dimension )
+	private void graycodeBckRecursive( final int dimension )
 	{
 		if ( dimension == 0 )
 		{
@@ -138,7 +139,7 @@ public class ClampingNLinearInterpolatorRealType< T extends RealType< T > > exte
 	/**
 	 * multiply current target value with current weight and add to accumulator.
 	 */
-	final private void accumulate()
+	private void accumulate()
 	{
 		acc += target.get().getRealDouble() * weights[ code ];
 	}

--- a/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorVolatileARGB.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorVolatileARGB.java
@@ -49,8 +49,9 @@ import net.imglib2.util.Util;
  */
 public class ClampingNLinearInterpolatorVolatileARGB< T extends AbstractVolatileNumericType< ARGBType, T > > extends NLinearInterpolator< T >
 {
-	protected double accA, accR, accG, accB;
-	protected boolean valid;
+	private int code;
+	private double accA, accR, accG, accB;
+	private boolean valid;
 
 	protected ClampingNLinearInterpolatorVolatileARGB( final ClampingNLinearInterpolatorVolatileARGB< T > interpolator )
 	{
@@ -64,7 +65,7 @@ public class ClampingNLinearInterpolatorVolatileARGB< T extends AbstractVolatile
 
 	protected ClampingNLinearInterpolatorVolatileARGB( final RandomAccessible< T > randomAccessible )
 	{
-		this( randomAccessible, randomAccessible.randomAccess().get() );
+		this( randomAccessible, randomAccessible.getType() );
 	}
 
 	/**
@@ -112,7 +113,7 @@ public class ClampingNLinearInterpolatorVolatileARGB< T extends AbstractVolatile
 		return new ClampingNLinearInterpolatorVolatileARGB<>( this );
 	}
 
-	final private void graycodeFwdRecursive( final int dimension )
+	private void graycodeFwdRecursive( final int dimension )
 	{
 		if ( dimension == 0 )
 		{
@@ -130,7 +131,7 @@ public class ClampingNLinearInterpolatorVolatileARGB< T extends AbstractVolatile
 		}
 	}
 
-	final private void graycodeBckRecursive( final int dimension )
+	private void graycodeBckRecursive( final int dimension )
 	{
 		if ( dimension == 0 )
 		{
@@ -151,7 +152,7 @@ public class ClampingNLinearInterpolatorVolatileARGB< T extends AbstractVolatile
 	/**
 	 * multiply current target value with current weight and add to accumulator.
 	 */
-	final private void accumulate()
+	private void accumulate()
 	{
 		final T t = target.get();
 		final int argb = t.get().get();

--- a/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorVolatileRealType.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/ClampingNLinearInterpolatorVolatileRealType.java
@@ -40,7 +40,7 @@ import net.imglib2.type.volatiles.AbstractVolatileRealType;
 
 /**
  * N-linear interpolator for {@link RealType} values with overflow check.
- * Interpoalted values are clamped to the range {@link RealType#getMinValue()},{@link RealType#getMaxValue()}.
+ * Interpolated values are clamped to the range {@link RealType#getMinValue()},{@link RealType#getMaxValue()}.
  *
  * @param <T>
  *
@@ -48,10 +48,11 @@ import net.imglib2.type.volatiles.AbstractVolatileRealType;
  */
 public class ClampingNLinearInterpolatorVolatileRealType< R extends RealType< R >, T extends AbstractVolatileRealType< R, T > > extends NLinearInterpolator< T >
 {
-	protected double acc;
-	protected boolean valid;
-	protected final double clampMin;
-	protected final double clampMax;
+	private int code;
+	private double acc;
+	private boolean valid;
+	private final double clampMin;
+	private final double clampMax;
 
 	protected ClampingNLinearInterpolatorVolatileRealType( final ClampingNLinearInterpolatorVolatileRealType< R, T > interpolator )
 	{
@@ -69,7 +70,7 @@ public class ClampingNLinearInterpolatorVolatileRealType< R extends RealType< R 
 
 	protected ClampingNLinearInterpolatorVolatileRealType( final RandomAccessible< T > randomAccessible )
 	{
-		this( randomAccessible, randomAccessible.randomAccess().get() );
+		this( randomAccessible, randomAccessible.getType() );
 	}
 
 	/**
@@ -104,7 +105,7 @@ public class ClampingNLinearInterpolatorVolatileRealType< R extends RealType< R 
 		return new ClampingNLinearInterpolatorVolatileRealType<>( this );
 	}
 
-	final private void graycodeFwdRecursive( final int dimension )
+	private void graycodeFwdRecursive( final int dimension )
 	{
 		if ( dimension == 0 )
 		{
@@ -122,7 +123,7 @@ public class ClampingNLinearInterpolatorVolatileRealType< R extends RealType< R 
 		}
 	}
 
-	final private void graycodeBckRecursive( final int dimension )
+	private void graycodeBckRecursive( final int dimension )
 	{
 		if ( dimension == 0 )
 		{
@@ -143,7 +144,7 @@ public class ClampingNLinearInterpolatorVolatileRealType< R extends RealType< R 
 	/**
 	 * multiply current target value with current weight and add to accumulator.
 	 */
-	final private void accumulate()
+	private void accumulate()
 	{
 		final T t = target.get();
 		acc += t.getRealDouble() * weights[ code ];

--- a/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator.java
@@ -34,12 +34,8 @@
 
 package net.imglib2.interpolation.randomaccess;
 
-import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
-import net.imglib2.RealRandomAccess;
-import net.imglib2.position.transform.Floor;
 import net.imglib2.type.numeric.NumericType;
-import net.imglib2.util.IntervalIndexer;
 
 /**
  * Performs multi-linear interpolation.
@@ -50,7 +46,7 @@ import net.imglib2.util.IntervalIndexer;
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch
  */
-public class NLinearInterpolator< T extends NumericType< T > > extends Floor< RandomAccess< T > > implements RealRandomAccess< T >
+public class NLinearInterpolator< T extends NumericType< T > > extends AbstractNLinearInterpolator< T >
 {
 	/**
 	 * Index into {@link #weights} array.
@@ -70,129 +66,29 @@ public class NLinearInterpolator< T extends NumericType< T > > extends Floor< Ra
 	 * wiki/Gray_code</a>
 	 * </p>
 	 */
-	protected int code;
+	private int code;
 
-	/**
-	 * Weights for each pixel of the <em>2x2x...x2</em> hypercube of pixels
-	 * participating in the interpolation.
-	 *
-	 * <p>
-	 * Indices into this array are arranged in the standard iteration order (as
-	 * provided by {@link IntervalIndexer#positionToIndex}). Element 0 refers to
-	 * position <em>(0,0,...,0)</em>, element 1 refers to position
-	 * <em>(1,0,...,0)</em>, element 2 refers to position <em>(0,1,...,0)</em>,
-	 * etc.
-	 * </p>
-	 */
-	final protected double[] weights;
-
-	final protected T accumulator;
-
-	final protected T tmp;
+	protected final T tmp;
 
 	protected NLinearInterpolator( final NLinearInterpolator< T > interpolator )
 	{
-		super( interpolator.target.copy() );
+		super( interpolator );
 
-		weights = interpolator.weights.clone();
-		code = interpolator.code;
-		accumulator = interpolator.accumulator.createVariable();
-		tmp = interpolator.tmp.createVariable();
-
-		for ( int d = 0; d < n; ++d )
-		{
-			position[ d ] = interpolator.position[ d ];
-			discrete[ d ] = interpolator.discrete[ d ];
-		}
+		tmp = type.createVariable();
 	}
 
 	protected NLinearInterpolator( final RandomAccessible< T > randomAccessible, final T type )
 	{
-		super( randomAccessible.randomAccess() );
-		weights = new double[ 1 << n ];
-		code = 0;
-		accumulator = type.createVariable();
+		super( randomAccessible, type );
+
 		tmp = type.createVariable();
 	}
 
 	protected NLinearInterpolator( final RandomAccessible< T > randomAccessible )
 	{
-		this( randomAccessible, randomAccessible.randomAccess().get() );
+		this( randomAccessible, randomAccessible.getType() );
 	}
 
-	/**
-	 * Fill the {@link #weights} array.
-	 *
-	 * <p>
-	 * Let <em>w_d</em> denote the fraction of a pixel at which the sample
-	 * position <em>p_d</em> lies from the floored position <em>pf_d</em> in
-	 * dimension <em>d</em>. That is, the value at <em>pf_d</em> contributes
-	 * with <em>(1 - w_d)</em> to the sampled value; the value at
-	 * <em>( pf_d + 1 )</em> contributes with <em>w_d</em>.
-	 * </p>
-	 * <p>
-	 * At every pixel, the total weight results from multiplying the weights of
-	 * all dimensions for that pixel. That is, the "top-left" contributing pixel
-	 * (position floored in all dimensions) gets assigned weight
-	 * <em>(1-w_0)(1-w_1)...(1-w_n)</em>.
-	 * </p>
-	 * <p>
-	 * We work through the weights array starting from the highest dimension.
-	 * For the highest dimension, the first half of the weights contain the
-	 * factor <em>(1 - w_n)</em> because this first half corresponds to floored
-	 * pixel positions in the highest dimension. The second half contain the
-	 * factor <em>w_n</em>. In this first step, the first weight of the first
-	 * half gets assigned <em>(1 - w_n)</em>. The first element of the second
-	 * half gets assigned <em>w_n</em>
-	 * </p>
-	 * <p>
-	 * From their, we work recursively down to dimension 0. That is, each half
-	 * of weights is again split recursively into two partitions. The first
-	 * element of the second partitions is the first element of the half
-	 * multiplied with <em>(w_d)</em>. The first element of the first partitions
-	 * is multiplied with <em>(1 - w_d)</em>.
-	 * </p>
-	 * <p>
-	 * When we have reached dimension 0, all weights will have a value assigned.
-	 * </p>
-	 */
-	protected void fillWeights()
-	{
-		weights[ 0 ] = 1.0d;
-
-		for ( int d = n - 1; d >= 0; --d )
-		{
-			final double w = position[ d ] - target.getLongPosition( d );
-			final double wInv = 1.0d - w;
-			final int wInvIndexIncrement = 1 << d;
-			final int loopCount = 1 << ( n - 1 - d );
-			final int baseIndexIncrement = wInvIndexIncrement * 2;
-			int baseIndex = 0;
-			for ( int i = 0; i < loopCount; ++i )
-			{
-				weights[ baseIndex + wInvIndexIncrement ] = weights[ baseIndex ] * w;
-				weights[ baseIndex ] *= wInv;
-				baseIndex += baseIndexIncrement;
-			}
-		}
-//		printWeights();
-//		System.out.println();
-	}
-
-	/**
-	 * Get the interpolated value at the current position.
-	 *
-	 * <p>
-	 * To visit the pixels that contribute to an interpolated value, we move in
-	 * a (binary-reflected) Gray code pattern, such that only one dimension of
-	 * the target position is modified per move.
-	 * </p>
-	 * <p>
-	 * See
-	 * <a href="http://en.wikipedia.org/wiki/Gray_code">http://en.wikipedia.org/
-	 * wiki/Gray_code</a>
-	 * </p>
-	 */
 	@Override
 	public T get()
 	{
@@ -209,15 +105,9 @@ public class NLinearInterpolator< T extends NumericType< T > > extends Floor< Ra
 	}
 
 	@Override
-	public T getType()
-	{
-		return accumulator;
-	}
-
-	@Override
 	public NLinearInterpolator< T > copy()
 	{
-		return new NLinearInterpolator< T >( this );
+		return new NLinearInterpolator<>( this );
 	}
 
 	private void graycodeFwdRecursive( final int dimension )
@@ -264,26 +154,5 @@ public class NLinearInterpolator< T extends NumericType< T > > extends Floor< Ra
 		tmp.set( target.get() );
 		tmp.mul( weights[ code ] );
 		accumulator.add( tmp );
-//		System.out.print( "accumulating value at " + target );
-//		System.out.print( "with weights [" );
-//		printCode();
-//		System.out.printf( "] = %f" + "\n", weights[ code ] );
-	}
-
-	@SuppressWarnings( "unused" )
-	private void printWeights()
-	{
-		for ( int i = 0; i < weights.length; ++i )
-			System.out.printf( "weights [ %2d ] = %f\n", i, weights[ i ] );
-	}
-
-	@SuppressWarnings( "unused" )
-	private void printCode()
-	{
-		final int maxbits = 4;
-		final String binary = Integer.toBinaryString( code );
-		for ( int i = binary.length(); i < maxbits; ++i )
-			System.out.print( "0" );
-		System.out.print( binary );
 	}
 }

--- a/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator1D.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator1D.java
@@ -59,7 +59,7 @@ public class NLinearInterpolator1D< T extends NumericType< T > > extends NLinear
 
 	protected NLinearInterpolator1D( final RandomAccessible< T > randomAccessible )
 	{
-		super( randomAccessible );
+		this( randomAccessible, randomAccessible.getType() );
 	}
 
 	@Override
@@ -69,17 +69,8 @@ public class NLinearInterpolator1D< T extends NumericType< T > > extends NLinear
 	}
 
 	@Override
-	protected void fillWeights()
-	{
-		final double w0 = position[ 0 ] - target.getLongPosition( 0 );
-		weights[ 0 ] = 1.0d - w0;
-		weights[ 1 ] = w0;
-	}
-
-	@Override
 	public T get()
 	{
-		// fillWeights();
 		final double w0 = position[ 0 ] - target.getLongPosition( 0 );
 
 		accumulator.set( target.get() );
@@ -96,6 +87,6 @@ public class NLinearInterpolator1D< T extends NumericType< T > > extends NLinear
 	@Override
 	public NLinearInterpolator1D< T > copy()
 	{
-		return new NLinearInterpolator1D< T >( this );
+		return new NLinearInterpolator1D<>( this );
 	}
 }

--- a/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator2D.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator2D.java
@@ -59,7 +59,7 @@ public class NLinearInterpolator2D< T extends NumericType< T > > extends NLinear
 
 	protected NLinearInterpolator2D( final RandomAccessible< T > randomAccessible )
 	{
-		super( randomAccessible );
+		this( randomAccessible, randomAccessible.getType() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator3D.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolator3D.java
@@ -59,7 +59,7 @@ public class NLinearInterpolator3D< T extends NumericType< T > > extends NLinear
 
 	protected NLinearInterpolator3D( final RandomAccessible< T > randomAccessible )
 	{
-		super( randomAccessible );
+		this( randomAccessible, randomAccessible.getType() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolatorARGB.java
+++ b/src/main/java/net/imglib2/interpolation/randomaccess/NLinearInterpolatorARGB.java
@@ -45,21 +45,17 @@ import net.imglib2.util.Util;
  */
 public class NLinearInterpolatorARGB extends NLinearInterpolator< ARGBType >
 {
-	protected double accA, accR, accG, accB;
+	private int code;
+	private double accA, accR, accG, accB;
 
 	protected NLinearInterpolatorARGB( final NLinearInterpolatorARGB interpolator )
 	{
 		super( interpolator );
 	}
 
-	protected NLinearInterpolatorARGB( final RandomAccessible< ARGBType > randomAccessible, final ARGBType type )
-	{
-		super( randomAccessible, type );
-	}
-
 	protected NLinearInterpolatorARGB( final RandomAccessible< ARGBType > randomAccessible )
 	{
-		this( randomAccessible, randomAccessible.randomAccess().get() );
+		super( randomAccessible, randomAccessible.getType() );
 	}
 
 	/**
@@ -105,7 +101,7 @@ public class NLinearInterpolatorARGB extends NLinearInterpolator< ARGBType >
 		return new NLinearInterpolatorARGB( this );
 	}
 
-	final private void graycodeFwdRecursive( final int dimension )
+	private void graycodeFwdRecursive( final int dimension )
 	{
 		if ( dimension == 0 )
 		{
@@ -123,7 +119,7 @@ public class NLinearInterpolatorARGB extends NLinearInterpolator< ARGBType >
 		}
 	}
 
-	final private void graycodeBckRecursive( final int dimension )
+	private void graycodeBckRecursive( final int dimension )
 	{
 		if ( dimension == 0 )
 		{
@@ -144,34 +140,12 @@ public class NLinearInterpolatorARGB extends NLinearInterpolator< ARGBType >
 	/**
 	 * multiply current target value with current weight and add to accumulator.
 	 */
-	final private void accumulate()
+	private void accumulate()
 	{
 		final int argb = target.get().get();
 		accA += ( ( argb >> 24 ) & 0xff ) * weights[ code ];
 		accR += ( ( argb >> 16 ) & 0xff ) * weights[ code ];
 		accG += ( ( argb >> 8 ) & 0xff ) * weights[ code ];
 		accB += ( argb & 0xff ) * weights[ code ];
-
-//		System.out.print( "accumulating value at " + target );
-//		System.out.print( "with weights [" );
-//		printCode();
-//		System.out.printf( "] = %f" + "\n", weights[ code ] );
-	}
-
-	@SuppressWarnings( "unused" )
-	final private void printWeights()
-	{
-		for ( int i = 0; i < weights.length; ++i )
-			System.out.printf( "weights [ %2d ] = %f\n", i, weights[ i ] );
-	}
-
-	@SuppressWarnings( "unused" )
-	final private void printCode()
-	{
-		final int maxbits = 4;
-		final String binary = Integer.toBinaryString( code );
-		for ( int i = binary.length(); i < maxbits; ++i )
-			System.out.print( "0" );
-		System.out.print( binary );
 	}
 }

--- a/src/main/java/net/imglib2/type/mask/AbstractMasked.java
+++ b/src/main/java/net/imglib2/type/mask/AbstractMasked.java
@@ -1,0 +1,57 @@
+package net.imglib2.type.mask;
+
+import java.util.Objects;
+
+import net.imglib2.util.Cast;
+import net.imglib2.util.Util;
+
+/**
+ * Abstract base class for {@code Masked} implementations. Holds a {@code double
+ * mask} and implements {@code equals()} and {@code hashCode()} based on {@code
+ * mask()} and {@code value()}.
+ *
+ * @param <T>
+ * 		the value type.
+ * @param <M>
+ * 		recursive type of derived concrete class.
+ */
+abstract class AbstractMasked< T, M extends AbstractMasked< T, M > >
+		implements Masked< T >
+{
+	private double mask;
+
+	protected AbstractMasked( double mask )
+	{
+		this.mask = mask;
+	}
+
+	// --- Masked< T > ---
+
+	@Override
+	public double mask()
+	{
+		return mask;
+	}
+
+	public void setMask( final double mask )
+	{
+		this.mask = mask;
+	}
+
+	// --- Object ---
+
+	@Override
+	public int hashCode()
+	{
+		return Util.combineHash( Objects.hashCode( value() ), Double.hashCode( mask() ) );
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if ( !getClass().isInstance( obj ) )
+			return false;
+		final M other = Cast.unchecked( obj );
+		return other.mask() == mask() && Objects.equals( other.value(), value() );
+	}
+}

--- a/src/main/java/net/imglib2/type/mask/Masked.java
+++ b/src/main/java/net/imglib2/type/mask/Masked.java
@@ -1,0 +1,79 @@
+package net.imglib2.type.mask;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealRandomAccessible;
+import net.imglib2.type.Type;
+
+/**
+ * A {@code T} value with an associated {@code double} mask.
+ * <p>
+ * The mask is intended to be used as an alpha value in the range {@code [0, 1]},
+ * but values are <em>not</em> clamped to that range.
+ *
+ * @param <T>
+ * 		the value type.
+ */
+public interface Masked< T >
+{
+	T value();
+
+	/**
+	 * If {@code T extends Type<T>} uses the {@link Type#set(Type)} method to
+	 * update the internal value instance. Otherwise, updates {@link #value()}
+	 * to reference the given {@code value}.
+	 */
+	void setValue( T value );
+
+	double mask();
+
+	void setMask( double mask );
+
+	/**
+	 * Augments a {@code RandomAccessibleInterval} with the given constant {@code mask}.
+	 * <p>
+	 * If {@code T} implements {@code Type}, the masked type also implements
+	 * {@code Type}.
+	 */
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	static < T > RandomAccessibleInterval< ? extends Masked< T > > withConstant( final RandomAccessibleInterval< T > rai, final double mask )
+	{
+		T type = rai.getType();
+		if ( type instanceof Type )
+			return MaskedType.withConstant( ( RandomAccessibleInterval ) rai, mask );
+		else
+			return MaskedObject.withConstant( rai, mask );
+	}
+
+	/**
+	 * Augments a {@code RandomAccessible} with the given constant {@code mask}.
+	 * <p>
+	 * If {@code T} implements {@code Type}, the masked type also implements
+	 * {@code Type}.
+	 */
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	static < T > RandomAccessible< ? extends Masked< T > > withConstant( final RandomAccessible< T > ra, final double mask )
+	{
+		T type = ra.getType();
+		if ( type instanceof Type )
+			return MaskedType.withConstant( ( RandomAccessible ) ra, mask );
+		else
+			return MaskedObject.withConstant( ra, mask );
+	}
+
+	/**
+	 * Augments a {@code RealRandomAccessible} with the given constant {@code mask}.
+	 * <p>
+	 * If {@code T} implements {@code Type}, the masked type also implements
+	 * {@code Type}.
+	 */
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	static < T > RealRandomAccessible< ? extends Masked< T > > withConstant( final RealRandomAccessible< T > rra, final double mask )
+	{
+		T type = rra.getType();
+		if ( type instanceof Type )
+			return MaskedType.withConstant( ( RealRandomAccessible ) rra, mask );
+		else
+			return MaskedObject.withConstant( rra, mask );
+	}
+}

--- a/src/main/java/net/imglib2/type/mask/MaskedObject.java
+++ b/src/main/java/net/imglib2/type/mask/MaskedObject.java
@@ -1,0 +1,57 @@
+package net.imglib2.type.mask;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealRandomAccessible;
+
+public class MaskedObject< T > extends AbstractMasked< T, MaskedObject< T > >
+{
+	private T value;
+
+	public MaskedObject( final T value )
+	{
+		this( value, 0 );
+	}
+
+	public MaskedObject( final T value, double mask )
+	{
+		super( mask );
+		this.value = value;
+	}
+
+	@Override
+	public T value()
+	{
+		return value;
+	}
+
+	@Override
+	public void setValue( final T value )
+	{
+		this.value = value;
+	}
+
+	static < T > RandomAccessibleInterval< MaskedObject< T > > withConstant( final RandomAccessibleInterval< T > rai, final double mask )
+	{
+		final T type = rai.getType();
+		return rai.view().convert(
+				() -> new MaskedObject<>( type, mask ),
+				new ToMaskedConverter<>() );
+	}
+
+	static < T > RandomAccessible< MaskedObject< T > > withConstant( final RandomAccessible< T > ra, final double mask )
+	{
+		final T type = ra.getType();
+		return ra.view().convert(
+				() -> new MaskedObject<>( type, mask ),
+				new ToMaskedConverter<>() );
+	}
+
+	static < T > RealRandomAccessible< MaskedObject< T > > withConstant( final RealRandomAccessible< T > rra, final double mask )
+	{
+		final T type = rra.getType();
+		return rra.realView().convert(
+				() -> new MaskedObject<>( type, mask ),
+				new ToMaskedConverter<>() );
+	}
+}

--- a/src/main/java/net/imglib2/type/mask/MaskedType.java
+++ b/src/main/java/net/imglib2/type/mask/MaskedType.java
@@ -1,0 +1,103 @@
+package net.imglib2.type.mask;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealRandomAccessible;
+import net.imglib2.type.Type;
+
+/**
+ * A {@code Masked} {@code Type} wrapping a {@code Type<T>}.
+ * <p>
+ * Provides implementations of {@code Masked} and {@code Type} interfaces.
+ *
+ * @param <T>
+ * 		the value type.
+ */
+public class MaskedType< T extends Type< T > >
+		extends AbstractMasked< T, MaskedType< T > >
+		implements Type< MaskedType< T > >
+{
+	private final T value;
+
+	public MaskedType( T value )
+	{
+		this( value, 0 );
+	}
+
+	public MaskedType( T value, double mask )
+	{
+		super( mask );
+		this.value = value;
+	}
+
+	// --- Masked< T > ---
+
+	@Override
+	public T value()
+	{
+		return value;
+	}
+
+	@Override
+	public void setValue( final T value )
+	{
+		this.value.set( value );
+	}
+
+	// --- Type< M > ---
+
+	@Override
+	public void set( final MaskedType< T > c )
+	{
+		setValue( c.value() );
+		setMask( c.mask() );
+	}
+
+	@Override
+	public MaskedType< T > copy()
+	{
+		final MaskedType< T > copy = createVariable();
+		copy.set( this );
+		return copy;
+	}
+
+	@Override
+	public MaskedType< T > createVariable()
+	{
+		return new MaskedType<>( value().createVariable() );
+	}
+
+	// --- ValueEquals< M > ---
+
+	@Override
+	public boolean valueEquals( final MaskedType< T > other )
+	{
+		return mask() == other.mask() && value().valueEquals( other.value() );
+	}
+
+	// ------------------------
+
+	static < T extends Type< T > > RandomAccessibleInterval< MaskedType< T > > withConstant( final RandomAccessibleInterval< T > rai, final double mask )
+	{
+		final T type = rai.getType();
+		return rai.view().convert(
+				() -> new MaskedType<>( type.createVariable(), mask ),
+				new ToMaskedConverter<>() );
+	}
+
+	static < T extends Type< T > > RandomAccessible< MaskedType< T > > withConstant( final RandomAccessible< T > ra, final double mask )
+	{
+		final T type = ra.getType();
+		return ra.view().convert(
+				() -> new MaskedType<>( type.createVariable(), mask ),
+				new ToMaskedConverter<>() );
+	}
+
+	static < T extends Type< T > > RealRandomAccessible< MaskedType< T > > withConstant( final RealRandomAccessible< T > rra, final double mask )
+	{
+		final T type = rra.getType();
+		return rra.realView().convert(
+				() -> new MaskedType<>( type.createVariable(), mask ),
+				new ToMaskedConverter<>() );
+	}
+}

--- a/src/main/java/net/imglib2/type/mask/ToMaskedConverter.java
+++ b/src/main/java/net/imglib2/type/mask/ToMaskedConverter.java
@@ -1,0 +1,22 @@
+package net.imglib2.type.mask;
+
+import net.imglib2.converter.Converter;
+
+/**
+ * Converts a {@code T} to a {@code Masked<T>}. It just sets the {@code value()}
+ * of the {@code Masked} to the input value, leaving the mask of the {@code
+ * output} type untouched.
+ * <p>
+ * For example, this is useful to mask a {@code RandomAccessibleInterval} with
+ * constant 1. The result can then be extended with a constant value mask 0. The
+ * result is a {@code RandomAccessible} that is fully opaque inside the original
+ * interval and fully transparent outside.
+ */
+public class ToMaskedConverter< A, B extends Masked< A > > implements Converter< A, B >
+{
+	@Override
+	public void convert( final A input, final B output )
+	{
+		output.setValue( input );
+	}
+}

--- a/src/main/java/net/imglib2/type/mask/interpolation/MaskedClampingNLinearInterpolatorFactory.java
+++ b/src/main/java/net/imglib2/type/mask/interpolation/MaskedClampingNLinearInterpolatorFactory.java
@@ -1,0 +1,81 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2025 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.type.mask.interpolation;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.RealInterval;
+import net.imglib2.RealRandomAccess;
+import net.imglib2.Volatile;
+import net.imglib2.interpolation.InterpolatorFactory;
+import net.imglib2.type.Type;
+import net.imglib2.type.mask.Masked;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * Provides clamping n-linear interpolators for masked volatile and non-volatile types.
+ *
+ * @param <T> the masked type
+ *
+ * @author Tobias Pietzsch
+ */
+public class MaskedClampingNLinearInterpolatorFactory< T extends Type< T > & Masked< ? extends NumericType< ? > > > implements InterpolatorFactory< T, RandomAccessible< T > >
+{
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	@Override
+	public RealRandomAccess< T > create( final RandomAccessible< T > randomAccessible )
+	{
+		final T type = randomAccessible.getType();
+		if ( type.value() instanceof RealType )
+		{
+			if ( type.value() instanceof Volatile )
+				return new MaskedClampingNLinearInterpolatorVolatileRealType( randomAccessible );
+			else
+				return new MaskedClampingNLinearInterpolatorRealType( randomAccessible );
+		}
+		else
+			// fall back to (non-clamping) NLinearInterpolator
+			return new MaskedNLinearInterpolator( randomAccessible );
+	}
+
+	/**
+	 * For now, ignore the {@link RealInterval} and return
+	 * {@link #create(RandomAccessible)}.
+	 */
+	@Override
+	public RealRandomAccess< T > create( final RandomAccessible< T > randomAccessible, final RealInterval interval )
+	{
+		return create( randomAccessible );
+	}
+}

--- a/src/main/java/net/imglib2/type/mask/interpolation/MaskedClampingNLinearInterpolatorRealType.java
+++ b/src/main/java/net/imglib2/type/mask/interpolation/MaskedClampingNLinearInterpolatorRealType.java
@@ -1,0 +1,167 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2022 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.type.mask.interpolation;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.interpolation.randomaccess.AbstractNLinearInterpolator;
+import net.imglib2.type.Type;
+import net.imglib2.type.mask.Masked;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * N-linear interpolator for masked {@link RealType} values with overflow check.
+ * Interpolated values are clamped to the range {@link RealType#getMinValue()},{@link RealType#getMaxValue()}.
+ * <p>
+ * Multiplication and addition operations in the interpolator are implemented
+ * for pre-multiplied alpha, i.e. {@code (v, a)*s := (v, a*s)} and
+ * {@code (v, a) + (w, b) := ((v*a+w*b)/(a+b), a+b)}.
+ *
+ * @param <R>
+ * 		the {@code RealType} that is wrapped by the masked type {@code T}
+ * @param <T>
+ * 		the masked type
+ *
+ * @author Tobias Pietzsch
+ */
+public class MaskedClampingNLinearInterpolatorRealType< R extends RealType< R >, T extends Masked< R > & Type< T > > extends AbstractNLinearInterpolator< T >
+{
+	private int code;
+	private double accValue;
+	private double accAlpha;
+	private final double clampMin;
+	private final double clampMax;
+
+	protected MaskedClampingNLinearInterpolatorRealType( final MaskedClampingNLinearInterpolatorRealType< R, T > interpolator )
+	{
+		super( interpolator );
+		clampMin = interpolator.clampMin;
+		clampMax = interpolator.clampMax;
+	}
+
+	protected MaskedClampingNLinearInterpolatorRealType( final RandomAccessible< T > randomAccessible, final T type )
+	{
+		super( randomAccessible, type );
+		clampMin = type.value().getMinValue();
+		clampMax = type.value().getMaxValue();
+	}
+
+	protected MaskedClampingNLinearInterpolatorRealType( final RandomAccessible< T > randomAccessible )
+	{
+		this( randomAccessible, randomAccessible.getType() );
+	}
+
+	/**
+	 * Get the interpolated value at the current position.
+	 *
+	 * <p>
+	 * To visit the pixels that contribute to an interpolated value, we move in
+	 * a (binary-reflected) Gray code pattern, such that only one dimension of
+	 * the target position is modified per move.
+	 *
+	 * <p>
+	 * @see <a href="http://en.wikipedia.org/wiki/Gray_code">Gray code</a>.
+	 */
+	@Override
+	public T get()
+	{
+		fillWeights();
+		final T t = target.get();
+		final double walpha = weights[ 0 ] * t.mask();
+		accAlpha = walpha;
+		accValue = t.value().getRealDouble() * walpha;
+		code = 0;
+		graycodeFwdRecursive( n - 1 );
+		target.bck( n - 1 );
+		accValue = accAlpha < EPSILON ? 0 : Math.max( clampMin, Math.min( clampMax, accValue / accAlpha ) );
+		accumulator.value().setReal( accValue );
+		accumulator.setMask( accAlpha );
+		return accumulator;
+	}
+
+	private static final double EPSILON = 1e-10;
+
+	@Override
+	public MaskedClampingNLinearInterpolatorRealType< R, T > copy()
+	{
+		return new MaskedClampingNLinearInterpolatorRealType<>( this );
+	}
+
+	private void graycodeFwdRecursive( final int dimension )
+	{
+		if ( dimension == 0 )
+		{
+			target.fwd( 0 );
+			code += 1;
+			accumulate();
+		}
+		else
+		{
+			graycodeFwdRecursive( dimension - 1 );
+			target.fwd( dimension );
+			code += 1 << dimension;
+			accumulate();
+			graycodeBckRecursive( dimension - 1 );
+		}
+	}
+
+	private void graycodeBckRecursive( final int dimension )
+	{
+		if ( dimension == 0 )
+		{
+			target.bck( 0 );
+			code -= 1;
+			accumulate();
+		}
+		else
+		{
+			graycodeFwdRecursive( dimension - 1 );
+			target.bck( dimension );
+			code -= 1 << dimension;
+			accumulate();
+			graycodeBckRecursive( dimension - 1 );
+		}
+	}
+
+	/**
+	 * multiply current target value with current weight and add to accumulator.
+	 */
+	private void accumulate()
+	{
+		final T t = target.get();
+		final double walpha = weights[ code ] * t.mask();
+		accAlpha += walpha;
+		accValue += t.value().getRealDouble() * walpha;
+	}
+}

--- a/src/main/java/net/imglib2/type/mask/interpolation/MaskedClampingNLinearInterpolatorVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/mask/interpolation/MaskedClampingNLinearInterpolatorVolatileRealType.java
@@ -1,0 +1,173 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2022 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.type.mask.interpolation;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.Volatile;
+import net.imglib2.interpolation.randomaccess.AbstractNLinearInterpolator;
+import net.imglib2.type.Type;
+import net.imglib2.type.mask.Masked;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * N-linear interpolator for masked volatile {@link RealType} values with overflow check.
+ * Interpolated values are clamped to the range {@link RealType#getMinValue()},{@link RealType#getMaxValue()}.
+ * <p>
+ * Multiplication and addition operations in the interpolator are implemented
+ * for pre-multiplied alpha, i.e. {@code (v, a)*s := (v, a*s)} and
+ * {@code (v, a) + (w, b) := ((v*a+w*b)/(a+b), a+b)}.
+ *
+ * @param <R>
+ * 		the {@code RealType} that is wrapped by the masked type {@code T}
+ * @param <T>
+ * 		the masked type
+ *
+ * @author Tobias Pietzsch
+ */
+public class MaskedClampingNLinearInterpolatorVolatileRealType< R extends Volatile< ? > & RealType< R >, T extends Masked< R > & Type< T > > extends AbstractNLinearInterpolator< T >
+{
+	private int code;
+	private double accValue;
+	private double accAlpha;
+	private boolean valid;
+	private final double clampMin;
+	private final double clampMax;
+
+	protected MaskedClampingNLinearInterpolatorVolatileRealType( final MaskedClampingNLinearInterpolatorVolatileRealType< R, T > interpolator )
+	{
+		super( interpolator );
+		clampMin = interpolator.clampMin;
+		clampMax = interpolator.clampMax;
+	}
+
+	protected MaskedClampingNLinearInterpolatorVolatileRealType( final RandomAccessible< T > randomAccessible, final T type )
+	{
+		super( randomAccessible, type );
+		clampMin = type.value().getMinValue();
+		clampMax = type.value().getMaxValue();
+	}
+
+	protected MaskedClampingNLinearInterpolatorVolatileRealType( final RandomAccessible<  T > randomAccessible )
+	{
+		this( randomAccessible, randomAccessible.getType() );
+	}
+
+	/**
+	 * Get the interpolated value at the current position.
+	 *
+	 * <p>
+	 * To visit the pixels that contribute to an interpolated value, we move in
+	 * a (binary-reflected) Gray code pattern, such that only one dimension of
+	 * the target position is modified per move.
+	 *
+	 * <p>
+	 *
+	 * @see <a href="http://en.wikipedia.org/wiki/Gray_code">Gray code</a>.
+	 */
+	@Override
+	public T get()
+	{
+		fillWeights();
+		final T t = target.get();
+		final double walpha = weights[ 0 ] * t.mask();
+		accAlpha = walpha;
+		accValue = t.value().getRealDouble() * walpha;
+		valid = t.value().isValid();
+		code = 0;
+		graycodeFwdRecursive( n - 1 );
+		target.bck( n - 1 );
+		accValue = accAlpha < EPSILON ? 0 : Math.max( clampMin, Math.min( clampMax, accValue / accAlpha ) );
+		accumulator.value().setReal( accValue );
+		accumulator.value().setValid( valid );
+		accumulator.setMask( accAlpha );
+		return accumulator;
+	}
+
+	private static final double EPSILON = 1e-10;
+
+	@Override
+	public MaskedClampingNLinearInterpolatorVolatileRealType< R, T > copy()
+	{
+		return new MaskedClampingNLinearInterpolatorVolatileRealType<>( this );
+	}
+
+	private void graycodeFwdRecursive( final int dimension )
+	{
+		if ( dimension == 0 )
+		{
+			target.fwd( 0 );
+			code += 1;
+			accumulate();
+		}
+		else
+		{
+			graycodeFwdRecursive( dimension - 1 );
+			target.fwd( dimension );
+			code += 1 << dimension;
+			accumulate();
+			graycodeBckRecursive( dimension - 1 );
+		}
+	}
+
+	private void graycodeBckRecursive( final int dimension )
+	{
+		if ( dimension == 0 )
+		{
+			target.bck( 0 );
+			code -= 1;
+			accumulate();
+		}
+		else
+		{
+			graycodeFwdRecursive( dimension - 1 );
+			target.bck( dimension );
+			code -= 1 << dimension;
+			accumulate();
+			graycodeBckRecursive( dimension - 1 );
+		}
+	}
+
+	/**
+	 * multiply current target value with current weight and add to accumulator.
+	 */
+	private void accumulate()
+	{
+		final T t = target.get();
+		final double walpha = weights[ code ] * t.mask();
+		accAlpha += walpha;
+		accValue += t.value().getRealDouble() * walpha;
+		valid &= t.value().isValid();
+	}
+}

--- a/src/main/java/net/imglib2/type/mask/interpolation/MaskedNLinearInterpolator.java
+++ b/src/main/java/net/imglib2/type/mask/interpolation/MaskedNLinearInterpolator.java
@@ -1,0 +1,153 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2025 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.type.mask.interpolation;
+
+import net.imglib2.RandomAccessible;
+import net.imglib2.interpolation.randomaccess.AbstractNLinearInterpolator;
+import net.imglib2.type.Type;
+import net.imglib2.type.mask.Masked;
+import net.imglib2.type.numeric.NumericType;
+
+/**
+ * N-linear interpolator for masked {@link NumericType} values.
+ * <p>
+ * Multiplication and addition operations in the interpolator are implemented
+ * for pre-multiplied alpha, i.e. {@code (v, a)*s := (v, a*s)} and
+ * {@code (v, a) + (w, b) := ((v*a+w*b)/(a+b), a+b)}.
+ *
+ * @param <N>
+ * 		the {@code RealType} that is wrapped by the masked type {@code T}
+ * @param <T>
+ * 		the masked type
+ *
+ * @author Tobias Pietzsch
+ */
+public class MaskedNLinearInterpolator< N extends NumericType< N >, T extends Masked< N > & Type< T > > extends AbstractNLinearInterpolator< T >
+{
+	private int code;
+	private double accAlpha;
+	private final N tmp;
+
+	protected MaskedNLinearInterpolator( final MaskedNLinearInterpolator< N, T > interpolator )
+	{
+		super( interpolator );
+		tmp = type.value().createVariable();
+	}
+
+	protected MaskedNLinearInterpolator( final RandomAccessible< T > randomAccessible, final T type )
+	{
+		super( randomAccessible, type );
+		tmp = type.value().createVariable();
+	}
+
+	protected MaskedNLinearInterpolator( final RandomAccessible< T > randomAccessible )
+	{
+		this( randomAccessible, randomAccessible.getType() );
+	}
+
+	@Override
+	public T get()
+	{
+		fillWeights();
+		final T t = target.get();
+		final double walpha = weights[ 0 ] * t.mask();
+		accAlpha = walpha;
+		accumulator.value().set( t.value() );
+		accumulator.value().mul( walpha );
+		code = 0;
+		graycodeFwdRecursive( n - 1 );
+		target.bck( n - 1 );
+		accumulator.value().mul( accAlpha < EPSILON ? 0 : ( 1.0 / accAlpha ) );
+		accumulator.setMask(accAlpha);
+		return accumulator;
+	}
+
+	private static final double EPSILON = 1e-10;
+
+	@Override
+	public MaskedNLinearInterpolator< N, T > copy()
+	{
+		return new MaskedNLinearInterpolator<>( this );
+	}
+
+	private void graycodeFwdRecursive( final int dimension )
+	{
+		if ( dimension == 0 )
+		{
+			target.fwd( 0 );
+			code += 1;
+			accumulate();
+		}
+		else
+		{
+			graycodeFwdRecursive( dimension - 1 );
+			target.fwd( dimension );
+			code += 1 << dimension;
+			accumulate();
+			graycodeBckRecursive( dimension - 1 );
+		}
+	}
+
+	private void graycodeBckRecursive( final int dimension )
+	{
+		if ( dimension == 0 )
+		{
+			target.bck( 0 );
+			code -= 1;
+			accumulate();
+		}
+		else
+		{
+			graycodeFwdRecursive( dimension - 1 );
+			target.bck( dimension );
+			code -= 1 << dimension;
+			accumulate();
+			graycodeBckRecursive( dimension - 1 );
+		}
+	}
+
+	/**
+	 * multiply current target value with current weight and add to accumulator.
+	 */
+	private void accumulate()
+	{
+		final T t = target.get();
+		final double walpha = weights[ code ] * t.mask();
+		accAlpha += walpha;
+		tmp.set( t.value() );
+		tmp.mul( walpha );
+		accumulator.value().add( tmp );
+	}
+}

--- a/src/main/java/net/imglib2/view/Views.java
+++ b/src/main/java/net/imglib2/view/Views.java
@@ -68,6 +68,7 @@ import net.imglib2.type.Type;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.operators.SetZero;
 import net.imglib2.util.Grid;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Pair;
@@ -313,7 +314,7 @@ public class Views
 	 *         infinity with a constant value of zero.
 	 * @see net.imglib2.outofbounds.OutOfBoundsConstantValue
 	 */
-	public static < T extends NumericType< T >, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendZero( final F source )
+	public static < T extends Type< T > & SetZero, F extends RandomAccessibleInterval< T > > ExtendedRandomAccessibleInterval< T, F > extendZero( final F source )
 	{
 		final T zero = source.getType().createVariable();
 		zero.setZero();
@@ -1547,7 +1548,7 @@ public class Views
 	 * @return Expansion of the {@link RandomAccessibleInterval} source as
 	 *         specified by border.
 	 */
-	public static < T extends NumericType< T > > IntervalView< T > expandZero( final RandomAccessibleInterval< T > source, final long... border )
+	public static < T extends Type< T > & SetZero > IntervalView< T > expandZero( final RandomAccessibleInterval< T > source, final long... border )
 	{
 		return interval( extendZero( source ), Intervals.expand( source, border ) );
 	}

--- a/src/main/java/net/imglib2/view/fluent/RealRandomAccessibleView.java
+++ b/src/main/java/net/imglib2/view/fluent/RealRandomAccessibleView.java
@@ -104,18 +104,18 @@ public interface RealRandomAccessibleView< T > extends RealRandomAccessible< T >
 	 * U>} that reads a value from its first argument and writes a converted
 	 * value to its second argument.
 	 *
-	 * @param converter
-	 * 		converts pixel values from {@code T} to {@code U}
 	 * @param targetSupplier
 	 * 		creates instances of {@code U} for storing converted values
+	 * @param converter
+	 * 		converts pixel values from {@code T} to {@code U}
 	 * @param <U>
 	 * 		target pixel type
 	 *
 	 * @return a converted view
 	 */
 	default < U > RealRandomAccessibleView< U > convert(
-			final Converter< ? super T, ? super U > converter,
-			final Supplier< U > targetSupplier )
+			final Supplier< U > targetSupplier,
+			final Converter< ? super T, ? super U > converter )
 	{
 		return wrap( Converters.convert2( delegate(), converter, targetSupplier ) );
 	}
@@ -130,18 +130,18 @@ public interface RealRandomAccessibleView< T > extends RealRandomAccessible< T >
 	 * from its first argument and writes a converted value to its second
 	 * argument.
 	 *
-	 * @param converterSupplier
-	 * 		converts pixel values from {@code T} to {@code U}
 	 * @param targetSupplier
 	 * 		creates instances of {@code U} for storing converted values
+	 * @param converterSupplier
+	 * 		converts pixel values from {@code T} to {@code U}
 	 * @param <U>
 	 * 		target pixel type
 	 *
 	 * @return a converted view
 	 */
 	default < U > RealRandomAccessibleView< U > convert(
-			final Supplier< Converter< ? super T, ? super U > > converterSupplier,
-			final Supplier< U > targetSupplier )
+			final Supplier< U > targetSupplier,
+			final Supplier< Converter< ? super T, ? super U > > converterSupplier )
 	{
 		return wrap( Converters.convert2( delegate(), converterSupplier, targetSupplier ) );
 	}


### PR DESCRIPTION
This PR introduces the `Masked` types.

A `Masked<T>` combines a `T` value and a `double` mask.

The static methods `Masked.withConstant(...)` can be used to add constant mask to `RandomAccessible`, `RandomAccessibleInterval`, and `RealRandomAccessible`. The resulting Accessibles can be interpolated using standard nearest-neighbor interpolation, or `MaskedClampingNLinearInterpolatorFactory` which provide linear interpolation using pre-multiplied alpha masks.

Both will be used by BigDataViewer to add constant 1-masks to source `RandomAccessibleIntervals`, extend those with 0-masked values, interpolate the resulting `RandomAccessibles`, and blend them using alpha-weighted averaging.

The PR also includes an unrelated (breaking) fix is to harmonize `realView().convert(...)` and `view().convert(...)` signatures. The same argument order is used for all of these now.

(revision of https://github.com/imglib/imglib2/pull/380)