### PR TITLE
Make Volatile an interface

### DIFF
--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatile.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatile.java
@@ -1,0 +1,67 @@
+package net.imglib2.type.volatiles;
+
+import java.util.Objects;
+
+import net.imglib2.Volatile;
+import net.imglib2.util.Cast;
+import net.imglib2.util.Util;
+
+/**
+ * Something volatile that has a value and is either VALID or INVALID.
+ *
+ * @author Stephan Saalfeld
+ */
+public class AbstractVolatile< T > implements Volatile< T >
+{
+	final T t;
+
+	boolean valid;
+
+	public AbstractVolatile( final T t, final boolean valid )
+	{
+		this.t = t;
+		this.valid = valid;
+	}
+
+	public AbstractVolatile( final T t )
+	{
+		this( t, false );
+	}
+
+	// --- Volatile<T> ---
+
+	@Override
+	public T get()
+	{
+		return t;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return valid;
+	}
+
+	@Override
+	public void setValid( final boolean valid )
+	{
+		this.valid = valid;
+	}
+
+	// --- Object ---
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if ( ! getClass().isInstance( obj ) )
+			return false;
+		final Volatile< T > other = Cast.unchecked( obj );
+		return other.isValid() == isValid() && Objects.equals( other.get(), get() );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Util.combineHash( Boolean.hashCode( isValid() ), Objects.hashCode( get() ) );
+	}
+}

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
@@ -47,27 +47,16 @@ import net.imglib2.util.Util;
  * @param <T>
  *            type of derived concrete class.
  * 
+ * @author Tobias Pietzsch
  * @author Stephan Saalfeld
  */
-abstract public class AbstractVolatileNumericType< N extends NumericType< N >, T extends AbstractVolatileNumericType< N, T > >
-		extends Volatile< N >
+public abstract class AbstractVolatileNumericType< N extends NumericType< N >, T extends AbstractVolatileNumericType< N, T > >
+		extends AbstractVolatileType< N, T >
 		implements NumericType< T >
 {
-	public AbstractVolatileNumericType( final N t, final boolean valid )
+	protected AbstractVolatileNumericType( final N t, final boolean valid )
 	{
 		super( t, valid );
-	}
-
-	public AbstractVolatileNumericType( final N t )
-	{
-		this( t, false );
-	}
-
-	@Override
-	public void set( final T c )
-	{
-		t.set( c.t );
-		valid = c.valid;
 	}
 
 	@Override
@@ -133,27 +122,5 @@ abstract public class AbstractVolatileNumericType< N extends NumericType< N >, T
 	public void mul( final double c )
 	{
 		t.mul( c );
-	}
-
-	@Override
-	public boolean valueEquals( T other )
-	{
-		return isValid() == other.isValid() && t.valueEquals( other.t );
-	}
-
-	@Override
-	public boolean equals( final Object obj )
-	{
-		if ( ! getClass().isInstance( obj ) )
-			return false;
-		@SuppressWarnings( "unchecked" )
-		T t = ( T ) obj;
-		return AbstractVolatileNumericType.this.valueEquals( t );
-	}
-
-	@Override
-	public int hashCode()
-	{
-		return Util.combineHash( Boolean.hashCode( isValid() ), t.hashCode() );
 	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
@@ -49,10 +49,10 @@ import net.imglib2.util.Util;
  * @author Stephan Saalfeld
  */
 public abstract class AbstractVolatileRealType< R extends RealType< R >, T extends AbstractVolatileRealType< R, T > >
-		extends Volatile< R >
+		extends AbstractVolatileNumericType< R, T >
 		implements RealType< T >
 {
-	public AbstractVolatileRealType( final R t, final boolean valid )
+	protected AbstractVolatileRealType( final R t, final boolean valid )
 	{
 		super( t, valid );
 	}
@@ -184,102 +184,8 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	}
 
 	@Override
-	public void set( final T c )
-	{
-		t.set( c.t );
-		valid = c.valid;
-	}
-
-	@Override
-	public void add( final T c )
-	{
-		t.add( c.t );
-		valid &= c.valid;
-	}
-
-	@Override
-	public void sub( final T c )
-	{
-		t.sub( c.t );
-		valid &= c.valid;
-	}
-
-	@Override
-	public void mul( final T c )
-	{
-		t.mul( c.t );
-		valid &= c.valid;
-	}
-
-	@Override
-	public void div( final T c )
-	{
-		t.div( c.t );
-		valid &= c.valid;
-	}
-
-	@Override
-	public void pow( final T c )
-	{
-		t.pow( c.t );
-		valid &= c.valid;
-	}
-
-	@Override
-	public void pow( final double power )
-	{
-		t.pow( power );
-	}
-
-	@Override
-	public void setZero()
-	{
-		t.setZero();
-	}
-
-	@Override
-	public void setOne()
-	{
-		t.setOne();
-	}
-
-	@Override
-	public void mul( final float c )
-	{
-		t.mul( c );
-	}
-
-	@Override
-	public void mul( final double c )
-	{
-		t.mul( c );
-	}
-
-	@Override
 	public int compareTo( final T o )
 	{
 		return t.compareTo( o.t );
-	}
-
-	@Override
-	public boolean valueEquals( T other )
-	{
-		return isValid() == other.isValid() && t.valueEquals( other.t );
-	}
-
-	@Override
-	public boolean equals( final Object obj )
-	{
-		if ( ! getClass().isInstance( obj ) )
-			return false;
-		@SuppressWarnings( "unchecked" )
-		T t = ( T ) obj;
-		return AbstractVolatileRealType.this.valueEquals( t );
-	}
-
-	@Override
-	public int hashCode()
-	{
-		return Util.combineHash( Boolean.hashCode( isValid() ), t.hashCode() );
 	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileType.java
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -32,18 +32,40 @@
  * #L%
  */
 
-package net.imglib2;
+package net.imglib2.type.volatiles;
+
+import net.imglib2.Volatile;
+import net.imglib2.type.Type;
 
 /**
- * Something volatile that has a value and is either VALID or INVALID.
+ * Abstract base class for {@link Volatile}s that wrap {@link Type}.
  *
- * @author Stephan Saalfeld
+ * @param <V>
+ *            wrapped {@link Type}.
+ * @param <T>
+ *            recursive type of derived class.
+ *
+ * @author Tobias Pietzsch
  */
-public interface Volatile< T >
+public abstract class AbstractVolatileType< V extends Type< V >, T extends AbstractVolatileType< V, T > >
+		extends AbstractVolatile< V >
+		implements Type< T >
 {
-	T get();
+	protected AbstractVolatileType( final V t, final boolean valid )
+	{
+		super( t, valid );
+	}
 
-	boolean isValid();
+	@Override
+	public void set( final T c )
+	{
+		get().set( c.get() );
+		setValid( c.isValid() );
+	}
 
-	void setValid( boolean valid );
+	@Override
+	public boolean valueEquals( T other )
+	{
+		return isValid() == other.isValid() && get().valueEquals( other.get() );
+	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/VolatileType.java
+++ b/src/main/java/net/imglib2/type/volatiles/VolatileType.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2025 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.type.volatiles;
+
+import net.imglib2.type.Type;
+
+/**
+ * Something volatile that has a value and is either VALID or INVALID.
+ *
+ * @author Tobias Pietzsch
+ */
+public class VolatileType< T extends Type< T > > extends AbstractVolatileType< T, VolatileType< T > >
+{
+	public VolatileType( final T t, final boolean valid )
+	{
+		super( t, valid );
+	}
+
+	public VolatileType( final T t )
+	{
+		this( t, true );
+	}
+
+	@Override
+	public VolatileType< T > createVariable()
+	{
+		return new VolatileType< T >( t.createVariable(), true );
+	}
+
+	@Override
+	public VolatileType< T > copy()
+	{
+		return new VolatileType< T >( t.copy(), valid );
+	}
+}


### PR DESCRIPTION
Make `Volatile` an interface.

Introduce abstract class hierarchy
`Volatile` ← `AbstractVolatileType` ← `AbstractVolatileNumericType` ← `AbstractVolatileRealType`
to reduce code duplication.

This will require re-building dependent projects (although not requiring code changes). Therefore should be combined with another breaking change when convenient...

(extracted from https://github.com/imglib/imglib2/pull/380)