### PR TITLE
Updated forEachChunk example

### DIFF
--- a/src/main/java/net/imglib2/loops/LoopBuilder.java
+++ b/src/main/java/net/imglib2/loops/LoopBuilder.java
@@ -173,16 +173,16 @@ public class LoopBuilder< T >
 	 * <pre>
 	 * {@code
 	 *
-	 * List<IntType> listOfSums = LoopBuilder.setImages( image ).multithreaded().forEachChunk(
+	 * List<IntType> listOfSums = LoopBuilder.setImages( image ).multiThreaded().forEachChunk(
 	 *     chunk -> {
 	 *         IntType sum = new IntType();
-	 *         chunk.forEach( pixel -> sum.add( pixel ) ):
+	 *         chunk.forEachPixel(pixel -> sum.add( new IntType( (int) pixel.getRealDouble() ) ) );
 	 *         return sum;
 	 *     }
 	 * );
 	 *
 	 * IntType totalSum = new IntType();
-	 * listOfSums.forEach( sum -> totalSum.add( sum );
+	 * listOfSums.forEach( totalSum::add );
 	 * return totalSum;
 	 * }
 	 * </pre>


### PR DESCRIPTION
The code example was a little broken.

* `multithreaded()` had a misspelling.
* `chunk.forEach` was replaced by `chunk.forEachPixel`.
* The `chunk.forEach` line had a colon instead of a semicolon at the end.
* A more robust conversion to `IntType` was added, since converting directly from `RealType` causes a `ClassCastException`.
  * This step wasn't strictly needed, but ensuring the example works in all cases improves the dev experience.
* The lambda for `listOfSums.forEach` was missing a closing parenthesis and was replaced by a method reference, which looks nice.