### PR TITLE
Remove duplicate data field in IntArray and ShortArray

### DIFF
--- a/src/main/java/net/imglib2/img/basictypeaccess/array/IntArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/IntArray.java
@@ -41,8 +41,6 @@ package net.imglib2.img.basictypeaccess.array;
  */
 public class IntArray extends AbstractIntArray< IntArray >
 {
-	protected int data[];
-
 	public IntArray( final int numEntities )
 	{
 		super( numEntities );

--- a/src/main/java/net/imglib2/img/basictypeaccess/array/ShortArray.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/array/ShortArray.java
@@ -41,8 +41,6 @@ package net.imglib2.img.basictypeaccess.array;
  */
 public class ShortArray extends AbstractShortArray< ShortArray >
 {
-	protected short data[];
-
 	public ShortArray( final int numEntities )
 	{
 		super( numEntities );


### PR DESCRIPTION
The `IntArray`/ `ShortArray` classes define a protected `data` array. However, this array is not used (there's already a protected `data` array defined in `AbstractIntArray` / `AbstractShortArray`).

This causes some issues when creating a class that extends `IntArray` / `ShortArray`, because then `data` refers to the one defined in `IntArray`/ `ShortArray` (which is not used), not the one defined in `AbstractIntArray` / `AbstractShortArray` (which is used).